### PR TITLE
Refcount fixes and full body scrub.

### DIFF
--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -64,18 +64,13 @@ class HttpClientConnection(object):
                 future.set_exception(Exception("Error during connect: err={}".format(error_code)))
 
         try:
-            if tls_connection_options is not None:
-                internal_conn_options_handle = tls_connection_options._internal_tls_conn_options
-            else:
-                internal_conn_options_handle = None
-
             _aws_crt_python.aws_py_http_client_connection_create(bootstrap._internal_bootstrap,
                                                                  on_connection_setup_native_cb,
                                                                  connection._on_connection_shutdown,
                                                                  host_name,
                                                                  port,
                                                                  socket_options,
-                                                                 internal_conn_options_handle)
+                                                                 tls_connection_options)
 
         except Exception as e:
             future.set_exception(e)

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -40,18 +40,17 @@ class Will(object):
         self.retain = retain
 
 class Client(object):
-    __slots__ = ('_internal_client', 'bootstrap', 'tls_ctx')
+    __slots__ = ('_binding', 'tls_ctx')
 
     def __init__(self, bootstrap, tls_ctx = None):
         assert isinstance(bootstrap, ClientBootstrap)
         assert tls_ctx is None or isinstance(tls_ctx, ClientTlsContext)
 
-        self.bootstrap = bootstrap
         self.tls_ctx = tls_ctx
-        self._internal_client = _aws_crt_python.aws_py_mqtt_client_new(self.bootstrap._internal_bootstrap)
+        self._binding = _aws_crt_python.aws_py_mqtt_client_new(bootstrap, tls_ctx)
 
 class Connection(object):
-    __slots__ = ('_internal_connection', 'client')
+    __slots__ = ('_binding', 'client')
 
     def __init__(self,
             client,
@@ -65,10 +64,13 @@ class Connection(object):
         """
 
         assert isinstance(client, Client)
+        assert callable(on_connection_interrupted) or on_connection_interrupted is None
+        assert callable(on_connection_resumed) or on_connection_resumed is None
+
         self.client = client
 
-        self._internal_connection = _aws_crt_python.aws_py_mqtt_client_connection_new(
-            client._internal_client,
+        self._binding = _aws_crt_python.aws_py_mqtt_client_connection_new(
+            client,
             on_connection_interrupted,
             on_connection_resumed,
             )
@@ -95,16 +97,12 @@ class Connection(object):
             assert will is None or isinstance(will, Will)
             assert use_websocket == False
 
-            tls_ctx_cap = None
-            if self.client.tls_ctx:
-                tls_ctx_cap = self.client.tls_ctx._internal_tls_ctx
-
             _aws_crt_python.aws_py_mqtt_client_connection_connect(
-                self._internal_connection,
+                self._binding,
                 client_id,
                 host_name,
                 port,
-                tls_ctx_cap,
+                self.client.tls_ctx,
                 keep_alive,
                 ping_timeout,
                 will,
@@ -128,7 +126,7 @@ class Connection(object):
                 future.set_exception(Exception("Error during reconnect"))
 
         try:
-            _aws_crt_python.aws_py_mqtt_client_connection_reconnect(self._internal_connection, on_connect)
+            _aws_crt_python.aws_py_mqtt_client_connection_reconnect(self._binding, on_connect)
         except Exception as e:
             future.set_exception(e)
 
@@ -142,7 +140,7 @@ class Connection(object):
             future.set_result(dict())
 
         try:
-            _aws_crt_python.aws_py_mqtt_client_connection_disconnect(self._internal_connection, on_disconnect)
+            _aws_crt_python.aws_py_mqtt_client_connection_disconnect(self._binding, on_disconnect)
         except Exception as e:
             future.set_exception(e)
 
@@ -152,6 +150,7 @@ class Connection(object):
         """
         callback: callback with signature (topic, message)
         """
+
         future = Future()
         packet_id = 0
 
@@ -163,7 +162,9 @@ class Connection(object):
             ))
 
         try:
-            packet_id = _aws_crt_python.aws_py_mqtt_client_connection_subscribe(self._internal_connection, topic, qos.value, callback, suback)
+            assert callable(callback)
+            assert isinstance(qos, QoS)
+            packet_id = _aws_crt_python.aws_py_mqtt_client_connection_subscribe(self._binding, topic, qos.value, callback, suback)
         except Exception as e:
             future.set_exception(e)
 
@@ -179,7 +180,7 @@ class Connection(object):
             ))
 
         try:
-            packet_id = _aws_crt_python.aws_py_mqtt_client_connection_unsubscribe(self._internal_connection, topic, unsuback)
+            packet_id = _aws_crt_python.aws_py_mqtt_client_connection_unsubscribe(self._binding, topic, unsuback)
 
         except Exception as e:
             future.set_exception(e)
@@ -196,11 +197,11 @@ class Connection(object):
             ))
 
         try:
-            packet_id = _aws_crt_python.aws_py_mqtt_client_connection_publish(self._internal_connection, topic, payload, qos.value, retain, puback)
+            packet_id = _aws_crt_python.aws_py_mqtt_client_connection_publish(self._binding, topic, payload, qos.value, retain, puback)
         except Exception as e:
             future.set_exception(e)
 
         return future, packet_id
 
     def ping(self):
-        _aws_crt_python.aws_py_mqtt_client_connection_ping(self._internal_connection)
+        _aws_crt_python.aws_py_mqtt_client_connection_ping(self._binding)

--- a/source/http_client_connection.c
+++ b/source/http_client_connection.c
@@ -128,14 +128,14 @@ PyObject *aws_py_http_client_connection_create(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    struct aws_client_bootstrap *bootstrap = aws_py_get_client_bootstrap(bootstrap_py);
+    struct aws_client_bootstrap *bootstrap = get_aws_client_bootstrap(bootstrap_py);
     if (!bootstrap) {
         goto error;
     }
 
     struct aws_tls_connection_options *connection_options = NULL;
     if (tls_conn_options_py != Py_None) {
-        connection_options = aws_py_get_tls_connection_options(tls_conn_options_py);
+        connection_options = get_aws_tls_connection_options(tls_conn_options_py);
         if (!connection_options) {
             goto error;
         }

--- a/source/io.c
+++ b/source/io.c
@@ -36,8 +36,6 @@ PyObject *aws_py_is_alpn_available(PyObject *self, PyObject *args) {
 }
 
 static void s_elg_destructor(PyObject *elg_capsule) {
-
-    assert(PyCapsule_CheckExact(elg_capsule));
     struct aws_event_loop_group *elg = PyCapsule_GetPointer(elg_capsule, s_capsule_name_elg);
     assert(elg);
 
@@ -52,17 +50,15 @@ PyObject *aws_py_io_event_loop_group_new(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
 
-    uint16_t num_threads = 0;
-
+    uint16_t num_threads;
     if (!PyArg_ParseTuple(args, "H", &num_threads)) {
         return NULL;
     }
 
-    struct aws_event_loop_group *elg = aws_mem_acquire(allocator, sizeof(struct aws_event_loop_group));
+    struct aws_event_loop_group *elg = aws_mem_calloc(allocator, 1, sizeof(struct aws_event_loop_group));
     if (!elg) {
         return PyErr_AwsLastError();
     }
-    AWS_ZERO_STRUCT(*elg);
 
     if (aws_event_loop_group_default_init(elg, allocator, num_threads)) {
         aws_mem_release(allocator, elg);
@@ -72,12 +68,32 @@ PyObject *aws_py_io_event_loop_group_new(PyObject *self, PyObject *args) {
     return PyCapsule_New(elg, s_capsule_name_elg, s_elg_destructor);
 }
 
-static void s_host_resolver_destructor(PyObject *host_resolver_capsule) {
-    assert(PyCapsule_CheckExact(host_resolver_capsule));
+struct aws_event_loop_group *aws_py_get_event_loop_group(PyObject *event_loop_group) {
+    struct aws_event_loop_group *native = NULL;
 
-    struct aws_host_resolver *host_resolver = PyCapsule_GetPointer(host_resolver_capsule, s_capsule_name_host_resolver);
+    PyObject *elg_capsule = PyObject_GetAttrString(event_loop_group, "_binding");
+    if (elg_capsule) {
+        native = PyCapsule_GetPointer(elg_capsule, s_capsule_name_elg);
+        assert(native);
+        Py_DECREF(elg_capsule);
+    }
+
+    return native;
+}
+
+struct host_resolver_binding {
+    struct aws_host_resolver native;
+
+    /* Dependencies that must outlive us */
+    PyObject *event_loop_group;
+};
+
+static void s_host_resolver_destructor(PyObject *host_resolver_capsule) {
+    struct host_resolver_binding *host_resolver =
+        PyCapsule_GetPointer(host_resolver_capsule, s_capsule_name_host_resolver);
     assert(host_resolver);
-    aws_host_resolver_clean_up(host_resolver);
+    aws_host_resolver_clean_up(&host_resolver->native);
+    Py_DECREF(host_resolver->event_loop_group);
     aws_mem_release(aws_crt_python_get_allocator(), host_resolver);
 }
 
@@ -86,33 +102,80 @@ PyObject *aws_py_io_host_resolver_new_default(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
 
-    int max_hosts = 16;
-    PyObject *elg_capsule = NULL;
-    if (!PyArg_ParseTuple(args, "bO", &max_hosts, &elg_capsule)) {
-        return NULL;
-    }
-    if (!elg_capsule || !PyCapsule_CheckExact(elg_capsule)) {
-        PyErr_SetNone(PyExc_ValueError);
+    int max_hosts;
+    PyObject *elg_py;
+    if (!PyArg_ParseTuple(args, "bO", &max_hosts, &elg_py)) {
         return NULL;
     }
 
-    struct aws_event_loop_group *elg = PyCapsule_GetPointer(elg_capsule, s_capsule_name_elg);
-    struct aws_host_resolver *host_resolver = aws_mem_acquire(allocator, sizeof(struct aws_host_resolver));
-    if (aws_host_resolver_init_default(host_resolver, allocator, max_hosts, elg)) {
+    struct aws_event_loop_group *elg = aws_py_get_event_loop_group(elg_py);
+    if (!elg) {
+        return NULL;
+    }
+
+    struct host_resolver_binding *host_resolver = aws_mem_calloc(allocator, 1, sizeof(struct host_resolver_binding));
+    if (!host_resolver) {
         PyErr_SetAwsLastError();
-        aws_mem_release(allocator, host_resolver);
         return NULL;
     }
 
-    return PyCapsule_New(host_resolver, s_capsule_name_host_resolver, s_host_resolver_destructor);
+    /* From hereon, we need to clean up if errors occur */
+
+    if (aws_host_resolver_init_default(&host_resolver->native, allocator, max_hosts, elg)) {
+        PyErr_SetAwsLastError();
+        goto resolver_init_failed;
+    }
+
+    PyObject *capsule = PyCapsule_New(host_resolver, s_capsule_name_host_resolver, s_host_resolver_destructor);
+    if (!capsule) {
+        goto capsule_new_failed;
+    }
+
+    /* from hereon, nothing will fail */
+
+    host_resolver->event_loop_group = elg_py;
+    Py_INCREF(elg_py);
+    return capsule;
+
+capsule_new_failed:
+    aws_host_resolver_clean_up(&host_resolver->native);
+resolver_init_failed:
+    aws_mem_release(allocator, host_resolver);
+    return NULL;
 }
 
-static void s_client_bootstrap_destructor(PyObject *bootstrap_capsule) {
+struct aws_host_resolver *aws_py_get_host_resolver(PyObject *host_resolver) {
+    struct aws_host_resolver *native = NULL;
 
-    assert(PyCapsule_CheckExact(bootstrap_capsule));
-    struct aws_client_bootstrap *bootstrap = PyCapsule_GetPointer(bootstrap_capsule, s_capsule_name_client_bootstrap);
+    PyObject *binding_capsule = PyObject_GetAttrString(host_resolver, "_binding");
+    if (binding_capsule) {
+        struct host_resolver_binding *binding = PyCapsule_GetPointer(binding_capsule, s_capsule_name_host_resolver);
+        if (binding) {
+            native = &binding->native;
+            assert(native);
+        }
+        Py_DECREF(binding_capsule);
+    }
+
+    return native;
+}
+
+struct client_bootstrap_binding {
+    struct aws_client_bootstrap *native;
+
+    /* Dependencies that must outlive us */
+    PyObject *event_loop_group;
+    PyObject *host_resolver;
+};
+
+static void s_client_bootstrap_destructor(PyObject *bootstrap_capsule) {
+    struct client_bootstrap_binding *bootstrap =
+        PyCapsule_GetPointer(bootstrap_capsule, s_capsule_name_client_bootstrap);
     assert(bootstrap);
-    aws_client_bootstrap_release(bootstrap);
+    Py_DECREF(bootstrap->host_resolver);
+    Py_DECREF(bootstrap->event_loop_group);
+    aws_client_bootstrap_release(bootstrap->native);
+    aws_mem_release(aws_crt_python_get_allocator(), bootstrap);
 }
 
 PyObject *aws_py_io_client_bootstrap_new(PyObject *self, PyObject *args) {
@@ -120,40 +183,60 @@ PyObject *aws_py_io_client_bootstrap_new(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
 
-    PyObject *elg_capsule = NULL;
-    PyObject *host_resolver_capsule = NULL;
+    PyObject *elg_py;
+    PyObject *host_resolver_py;
 
-    if (!PyArg_ParseTuple(args, "OO", &elg_capsule, &host_resolver_capsule)) {
+    if (!PyArg_ParseTuple(args, "OO", &elg_py, &host_resolver_py)) {
         return NULL;
     }
 
-    if (!elg_capsule || !PyCapsule_CheckExact(elg_capsule)) {
-        PyErr_SetNone(PyExc_ValueError);
-        return NULL;
-    }
-    struct aws_event_loop_group *elg = PyCapsule_GetPointer(elg_capsule, s_capsule_name_elg);
+    struct aws_event_loop_group *elg = aws_py_get_event_loop_group(elg_py);
     if (!elg) {
         return NULL;
     }
 
-    if (!host_resolver_capsule || !PyCapsule_CheckExact(host_resolver_capsule)) {
-        PyErr_SetNone(PyExc_ValueError);
+    struct aws_host_resolver *host_resolver = aws_py_get_host_resolver(host_resolver_py);
+    if (!host_resolver) {
         return NULL;
     }
-    struct aws_host_resolver *host_resolver = PyCapsule_GetPointer(host_resolver_capsule, s_capsule_name_host_resolver);
 
-    struct aws_client_bootstrap *bootstrap = aws_client_bootstrap_new(allocator, elg, host_resolver, NULL);
+    struct client_bootstrap_binding *bootstrap = aws_mem_calloc(allocator, 1, sizeof(struct client_bootstrap_binding));
     if (!bootstrap) {
         PyErr_SetAwsLastError();
         return NULL;
     }
 
-    return PyCapsule_New(bootstrap, s_capsule_name_client_bootstrap, s_client_bootstrap_destructor);
+    /* from hereon, we need to clean up if errors occur */
+
+    bootstrap->native = aws_client_bootstrap_new(allocator, elg, host_resolver, NULL);
+    if (!bootstrap->native) {
+        PyErr_SetAwsLastError();
+        goto bootstrap_new_failed;
+    }
+
+    PyObject *capsule = PyCapsule_New(bootstrap, s_capsule_name_client_bootstrap, s_client_bootstrap_destructor);
+    if (!capsule) {
+        goto capsule_new_failed;
+    }
+
+    /* from hereon, nothing will fail */
+
+    bootstrap->event_loop_group = elg_py;
+    Py_INCREF(elg_py);
+
+    bootstrap->host_resolver = host_resolver_py;
+    Py_INCREF(host_resolver_py);
+
+    return capsule;
+
+capsule_new_failed:
+    aws_client_bootstrap_release(bootstrap->native);
+bootstrap_new_failed:
+    aws_mem_release(allocator, bootstrap);
+    return NULL;
 }
 
 static void s_tls_ctx_destructor(PyObject *tls_ctx_capsule) {
-
-    assert(PyCapsule_CheckExact(tls_ctx_capsule));
 
     struct aws_tls_ctx *tls_ctx = PyCapsule_GetPointer(tls_ctx_capsule, s_capsule_name_tls_ctx);
     assert(tls_ctx);
@@ -166,19 +249,18 @@ PyObject *aws_py_io_client_tls_ctx_new(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
 
-    int min_tls_version = AWS_IO_TLS_VER_SYS_DEFAULTS;
-    const char *ca_path = NULL;
-    const char *ca_buffer = NULL;
-    Py_ssize_t ca_buffer_len = 0;
-    const char *alpn_list = NULL;
-    const char *certificate_buffer = NULL;
-    Py_ssize_t certificate_buffer_len = 0;
-    const char *private_key_buffer = NULL;
-    Py_ssize_t private_key_buffer_len = 0;
-    const char *pkcs12_path = NULL;
-    const char *pkcs12_password = NULL;
-    uint8_t verify_peer = false;
-
+    int min_tls_version;
+    const char *ca_path;
+    const char *ca_buffer;
+    Py_ssize_t ca_buffer_len;
+    const char *alpn_list;
+    const char *certificate_buffer;
+    Py_ssize_t certificate_buffer_len;
+    const char *private_key_buffer;
+    Py_ssize_t private_key_buffer_len;
+    const char *pkcs12_path;
+    const char *pkcs12_password;
+    uint8_t verify_peer;
     if (!PyArg_ParseTuple(
             args,
             "bzz#zz#z#zzb",
@@ -199,55 +281,105 @@ PyObject *aws_py_io_client_tls_ctx_new(PyObject *self, PyObject *args) {
 
     struct aws_tls_ctx_options ctx_options;
     AWS_ZERO_STRUCT(ctx_options);
-    if (certificate_buffer && private_key_buffer && certificate_buffer_len > 0 && private_key_buffer_len > 0) {
+    if (certificate_buffer_len > 0 && private_key_buffer_len > 0) {
         struct aws_byte_cursor cert = aws_byte_cursor_from_array(certificate_buffer, certificate_buffer_len);
         struct aws_byte_cursor key = aws_byte_cursor_from_array(private_key_buffer, private_key_buffer_len);
-        aws_tls_ctx_options_init_client_mtls(&ctx_options, allocator, &cert, &key);
+        if (aws_tls_ctx_options_init_client_mtls(&ctx_options, allocator, &cert, &key)) {
+            PyErr_SetAwsLastError();
+            return NULL;
+        }
     } else {
         aws_tls_ctx_options_init_default_client(&ctx_options, allocator);
     }
 
+    /* From hereon, we need to clean up if errors occur */
+
     ctx_options.minimum_tls_version = min_tls_version;
 
     if (ca_path) {
-        aws_tls_ctx_options_override_default_trust_store_from_path(&ctx_options, ca_path, NULL);
+        if (aws_tls_ctx_options_override_default_trust_store_from_path(&ctx_options, ca_path, NULL)) {
+            PyErr_SetAwsLastError();
+            goto ctx_options_failure;
+        }
     }
-    if (ca_buffer && ca_buffer_len > 0) {
+    if (ca_buffer_len > 0) {
         struct aws_byte_cursor ca = aws_byte_cursor_from_array(ca_buffer, ca_buffer_len);
 
-        aws_tls_ctx_options_override_default_trust_store(&ctx_options, &ca);
+        if (aws_tls_ctx_options_override_default_trust_store(&ctx_options, &ca)) {
+            PyErr_SetAwsLastError();
+            goto ctx_options_failure;
+        }
     }
 
     if (alpn_list) {
-        aws_tls_ctx_options_set_alpn_list(&ctx_options, alpn_list);
+        if (aws_tls_ctx_options_set_alpn_list(&ctx_options, alpn_list)) {
+            PyErr_SetAwsLastError();
+            goto ctx_options_failure;
+        }
     }
 
 #ifdef __APPLE__
     if (pkcs12_path && pkcs12_password) {
         struct aws_byte_cursor password = aws_byte_cursor_from_c_str(pkcs12_password);
-        aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(&ctx_options, allocator, pkcs12_path, &password);
+        if (aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(&ctx_options, allocator, pkcs12_path, &password)) {
+            PyErr_SetAwsLastError();
+            goto ctx_options_failure;
+        }
     }
 #endif
     ctx_options.verify_peer = (bool)verify_peer;
     struct aws_tls_ctx *tls_ctx = aws_tls_client_ctx_new(allocator, &ctx_options);
-
     if (!tls_ctx) {
-        return PyErr_AwsLastError();
+        PyErr_AwsLastError();
+        goto ctx_options_failure;
     }
 
-    return PyCapsule_New(tls_ctx, s_capsule_name_tls_ctx, s_tls_ctx_destructor);
+    PyObject *capsule = PyCapsule_New(tls_ctx, s_capsule_name_tls_ctx, s_tls_ctx_destructor);
+    if (!capsule) {
+        goto capsule_new_failure;
+    }
+
+    /* from hereon, nothing will fail */
+
+    aws_tls_ctx_options_clean_up(&ctx_options);
+    return capsule;
+
+capsule_new_failure:
+ctx_options_failure:
+    aws_tls_ctx_options_clean_up(&ctx_options);
+    return NULL;
 }
+
+struct aws_tls_ctx *aws_py_get_tls_ctx(PyObject *tls_ctx) {
+    struct aws_tls_ctx *native = NULL;
+
+    PyObject *capsule = PyObject_GetAttrString(tls_ctx, "_binding");
+    if (capsule) {
+        native = PyCapsule_GetPointer(capsule, s_capsule_name_tls_ctx);
+        assert(native);
+        Py_DECREF(capsule);
+    }
+
+    return native;
+}
+
+struct tls_connection_options_binding {
+    struct aws_tls_connection_options native;
+
+    /* Dependencies that must outlive us */
+    PyObject *tls_ctx;
+};
 
 static void s_tls_connection_options_destructor(PyObject *tls_connection_options_capsule) {
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
-    assert(PyCapsule_CheckExact(tls_connection_options_capsule));
 
-    struct aws_tls_connection_options *tls_connection_options =
+    struct tls_connection_options_binding *tls_connection_options =
         PyCapsule_GetPointer(tls_connection_options_capsule, s_capsule_name_tls_conn_options);
     assert(tls_connection_options);
 
-    aws_tls_connection_options_clean_up(tls_connection_options);
+    aws_tls_connection_options_clean_up(&tls_connection_options->native);
+    Py_DECREF(tls_connection_options->tls_ctx);
     aws_mem_release(allocator, tls_connection_options);
 }
 
@@ -255,54 +387,83 @@ PyObject *aws_py_io_tls_connections_options_new_from_ctx(PyObject *self, PyObjec
     (void)self;
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
-    struct aws_tls_connection_options *conn_options = NULL;
 
-    PyObject *tls_ctx_capsule = NULL;
+    PyObject *tls_ctx_py;
 
-    if (!PyArg_ParseTuple(args, "O", &tls_ctx_capsule)) {
-        goto error;
+    if (!PyArg_ParseTuple(args, "O", &tls_ctx_py)) {
+        return NULL;
     }
 
-    assert(PyCapsule_CheckExact(tls_ctx_capsule));
-    struct aws_tls_ctx *ctx = PyCapsule_GetPointer(tls_ctx_capsule, s_capsule_name_tls_ctx);
-
-    conn_options = aws_mem_acquire(allocator, sizeof(struct aws_tls_connection_options));
-
-    aws_tls_connection_options_init_from_ctx(conn_options, ctx);
-
-    return PyCapsule_New(conn_options, s_capsule_name_tls_conn_options, s_tls_connection_options_destructor);
-
-error:
-    if (conn_options) {
-        aws_mem_release(allocator, conn_options);
+    struct aws_tls_ctx *ctx = aws_py_get_tls_ctx(tls_ctx_py);
+    if (!ctx) {
+        return NULL;
     }
 
+    struct tls_connection_options_binding *conn_options =
+        aws_mem_calloc(allocator, 1, sizeof(struct tls_connection_options_binding));
+    if (!conn_options) {
+        PyErr_SetAwsLastError();
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur */
+
+    PyObject *capsule =
+        PyCapsule_New(conn_options, s_capsule_name_tls_conn_options, s_tls_connection_options_destructor);
+    if (!capsule) {
+        goto capsule_new_failed;
+    }
+
+    /* from hereon, nothing will fail */
+
+    aws_tls_connection_options_init_from_ctx(&conn_options->native, ctx);
+
+    conn_options->tls_ctx = tls_ctx_py;
+    Py_INCREF(tls_ctx_py);
+
+    return capsule;
+
+capsule_new_failed:
+    aws_mem_release(allocator, conn_options);
     return NULL;
+}
+
+struct aws_tls_connection_options *aws_py_get_tls_connection_options(PyObject *tls_connection_options) {
+    struct aws_tls_connection_options *native = NULL;
+
+    PyObject *binding_capsule = PyObject_GetAttrString(tls_connection_options, "_binding");
+    if (binding_capsule) {
+        struct tls_connection_options_binding *binding =
+            PyCapsule_GetPointer(binding_capsule, s_capsule_name_tls_conn_options);
+        if (binding) {
+            native = &binding->native;
+            assert(native);
+        }
+        Py_DECREF(binding_capsule);
+    }
+
+    return native;
 }
 
 PyObject *aws_py_io_tls_connection_options_set_alpn_list(PyObject *self, PyObject *args) {
     (void)self;
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
-    PyObject *tls_conn_options_capsule = NULL;
-    const char *alpn_list = NULL;
-    Py_ssize_t alpn_list_len = 0;
 
-    if (!PyArg_ParseTuple(args, "Os#", &tls_conn_options_capsule, &alpn_list, &alpn_list_len)) {
-        Py_RETURN_NONE;
+    PyObject *tls_conn_options_py;
+    const char *alpn_list;
+    if (!PyArg_ParseTuple(args, "Os", &tls_conn_options_py, &alpn_list)) {
+        return NULL;
     }
 
-    assert(alpn_list);
-    assert(PyCapsule_CheckExact(tls_conn_options_capsule));
-    struct aws_tls_connection_options *connection_options =
-        PyCapsule_GetPointer(tls_conn_options_capsule, s_capsule_name_tls_conn_options);
+    struct aws_tls_connection_options *connection_options = aws_py_get_tls_connection_options(tls_conn_options_py);
+    if (!connection_options) {
+        return NULL;
+    }
 
-    char alpn_list_cpy[129] = {0};
-    assert(alpn_list_len < sizeof(alpn_list_cpy));
-    memcpy(alpn_list_cpy, alpn_list, alpn_list_len);
-
-    if (aws_tls_connection_options_set_alpn_list(connection_options, allocator, alpn_list_cpy)) {
+    if (aws_tls_connection_options_set_alpn_list(connection_options, allocator, alpn_list)) {
         PyErr_SetAwsLastError();
+        return NULL;
     }
 
     Py_RETURN_NONE;
@@ -312,24 +473,24 @@ PyObject *aws_py_io_tls_connection_options_set_server_name(PyObject *self, PyObj
     (void)self;
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
-    PyObject *tls_conn_options_capsule = NULL;
-    const char *server_name = NULL;
-    Py_ssize_t server_name_len = 0;
 
-    if (!PyArg_ParseTuple(args, "Os#", &tls_conn_options_capsule, &server_name, &server_name_len)) {
-        Py_RETURN_NONE;
+    PyObject *tls_conn_options_py;
+    const char *server_name;
+    Py_ssize_t server_name_len;
+    if (!PyArg_ParseTuple(args, "Os#", &tls_conn_options_py, &server_name, &server_name_len)) {
+        return NULL;
     }
 
-    assert(server_name);
-    assert(PyCapsule_CheckExact(tls_conn_options_capsule));
-    struct aws_tls_connection_options *connection_options =
-        PyCapsule_GetPointer(tls_conn_options_capsule, s_capsule_name_tls_conn_options);
+    struct aws_tls_connection_options *connection_options = aws_py_get_tls_connection_options(tls_conn_options_py);
+    if (!connection_options) {
+        return NULL;
+    }
 
-    struct aws_byte_cursor server_name_cur =
-        aws_byte_cursor_from_array((const uint8_t *)server_name, (size_t)server_name_len);
+    struct aws_byte_cursor server_name_cur = aws_byte_cursor_from_array(server_name, (size_t)server_name_len);
 
     if (aws_tls_connection_options_set_server_name(connection_options, allocator, &server_name_cur)) {
         PyErr_SetAwsLastError();
+        return NULL;
     }
 
     Py_RETURN_NONE;

--- a/source/io.c
+++ b/source/io.c
@@ -241,7 +241,8 @@ struct aws_client_bootstrap *get_aws_client_bootstrap(PyObject *client_bootstrap
 
     PyObject *binding_capsule = PyObject_GetAttrString(client_bootstrap, "_binding");
     if (binding_capsule) {
-        struct client_bootstrap_binding *binding = PyCapsule_GetPointer(binding_capsule, s_capsule_name_client_bootstrap);
+        struct client_bootstrap_binding *binding =
+            PyCapsule_GetPointer(binding_capsule, s_capsule_name_client_bootstrap);
         if (binding) {
             native = binding->native;
             assert(native);

--- a/source/io.c
+++ b/source/io.c
@@ -131,7 +131,7 @@ PyObject *aws_py_io_host_resolver_new_default(PyObject *self, PyObject *args) {
         goto capsule_new_failed;
     }
 
-    /* from hereon, nothing will fail */
+    /* From hereon, nothing will fail */
 
     host_resolver->event_loop_group = elg_py;
     Py_INCREF(elg_py);
@@ -206,7 +206,7 @@ PyObject *aws_py_io_client_bootstrap_new(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    /* from hereon, we need to clean up if errors occur */
+    /* From hereon, we need to clean up if errors occur */
 
     bootstrap->native = aws_client_bootstrap_new(allocator, elg, host_resolver, NULL);
     if (!bootstrap->native) {
@@ -219,7 +219,7 @@ PyObject *aws_py_io_client_bootstrap_new(PyObject *self, PyObject *args) {
         goto capsule_new_failed;
     }
 
-    /* from hereon, nothing will fail */
+    /* From hereon, nothing will fail */
 
     bootstrap->event_loop_group = elg_py;
     Py_INCREF(elg_py);
@@ -330,7 +330,7 @@ PyObject *aws_py_io_client_tls_ctx_new(PyObject *self, PyObject *args) {
     ctx_options.verify_peer = (bool)verify_peer;
     struct aws_tls_ctx *tls_ctx = aws_tls_client_ctx_new(allocator, &ctx_options);
     if (!tls_ctx) {
-        PyErr_AwsLastError();
+        PyErr_SetAwsLastError();
         goto ctx_options_failure;
     }
 
@@ -339,7 +339,7 @@ PyObject *aws_py_io_client_tls_ctx_new(PyObject *self, PyObject *args) {
         goto capsule_new_failure;
     }
 
-    /* from hereon, nothing will fail */
+    /* From hereon, nothing will fail */
 
     aws_tls_ctx_options_clean_up(&ctx_options);
     return capsule;
@@ -414,7 +414,7 @@ PyObject *aws_py_io_tls_connections_options_new_from_ctx(PyObject *self, PyObjec
         goto capsule_new_failed;
     }
 
-    /* from hereon, nothing will fail */
+    /* From hereon, nothing will fail */
 
     aws_tls_connection_options_init_from_ctx(&conn_options->native, ctx);
 

--- a/source/io.c
+++ b/source/io.c
@@ -68,7 +68,7 @@ PyObject *aws_py_io_event_loop_group_new(PyObject *self, PyObject *args) {
     return PyCapsule_New(elg, s_capsule_name_elg, s_elg_destructor);
 }
 
-struct aws_event_loop_group *aws_py_get_event_loop_group(PyObject *event_loop_group) {
+struct aws_event_loop_group *get_aws_event_loop_group(PyObject *event_loop_group) {
     struct aws_event_loop_group *native = NULL;
 
     PyObject *elg_capsule = PyObject_GetAttrString(event_loop_group, "_binding");
@@ -108,7 +108,7 @@ PyObject *aws_py_io_host_resolver_new_default(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    struct aws_event_loop_group *elg = aws_py_get_event_loop_group(elg_py);
+    struct aws_event_loop_group *elg = get_aws_event_loop_group(elg_py);
     if (!elg) {
         return NULL;
     }
@@ -144,7 +144,7 @@ resolver_init_failed:
     return NULL;
 }
 
-struct aws_host_resolver *aws_py_get_host_resolver(PyObject *host_resolver) {
+struct aws_host_resolver *get_aws_host_resolver(PyObject *host_resolver) {
     struct aws_host_resolver *native = NULL;
 
     PyObject *binding_capsule = PyObject_GetAttrString(host_resolver, "_binding");
@@ -190,12 +190,12 @@ PyObject *aws_py_io_client_bootstrap_new(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    struct aws_event_loop_group *elg = aws_py_get_event_loop_group(elg_py);
+    struct aws_event_loop_group *elg = get_aws_event_loop_group(elg_py);
     if (!elg) {
         return NULL;
     }
 
-    struct aws_host_resolver *host_resolver = aws_py_get_host_resolver(host_resolver_py);
+    struct aws_host_resolver *host_resolver = get_aws_host_resolver(host_resolver_py);
     if (!host_resolver) {
         return NULL;
     }
@@ -234,6 +234,22 @@ capsule_new_failed:
 bootstrap_new_failed:
     aws_mem_release(allocator, bootstrap);
     return NULL;
+}
+
+struct aws_client_bootstrap *get_aws_client_bootstrap(PyObject *client_bootstrap) {
+    struct aws_client_bootstrap *native = NULL;
+
+    PyObject *binding_capsule = PyObject_GetAttrString(client_bootstrap, "_binding");
+    if (binding_capsule) {
+        struct client_bootstrap_binding *binding = PyCapsule_GetPointer(binding_capsule, s_capsule_name_client_bootstrap);
+        if (binding) {
+            native = binding->native;
+            assert(native);
+        }
+        Py_DECREF(binding_capsule);
+    }
+
+    return native;
 }
 
 static void s_tls_ctx_destructor(PyObject *tls_ctx_capsule) {
@@ -350,7 +366,7 @@ ctx_options_failure:
     return NULL;
 }
 
-struct aws_tls_ctx *aws_py_get_tls_ctx(PyObject *tls_ctx) {
+struct aws_tls_ctx *get_aws_tls_ctx(PyObject *tls_ctx) {
     struct aws_tls_ctx *native = NULL;
 
     PyObject *capsule = PyObject_GetAttrString(tls_ctx, "_binding");
@@ -394,7 +410,7 @@ PyObject *aws_py_io_tls_connections_options_new_from_ctx(PyObject *self, PyObjec
         return NULL;
     }
 
-    struct aws_tls_ctx *ctx = aws_py_get_tls_ctx(tls_ctx_py);
+    struct aws_tls_ctx *ctx = get_aws_tls_ctx(tls_ctx_py);
     if (!ctx) {
         return NULL;
     }
@@ -428,7 +444,7 @@ capsule_new_failed:
     return NULL;
 }
 
-struct aws_tls_connection_options *aws_py_get_tls_connection_options(PyObject *tls_connection_options) {
+struct aws_tls_connection_options *get_aws_tls_connection_options(PyObject *tls_connection_options) {
     struct aws_tls_connection_options *native = NULL;
 
     PyObject *binding_capsule = PyObject_GetAttrString(tls_connection_options, "_binding");
@@ -456,7 +472,7 @@ PyObject *aws_py_io_tls_connection_options_set_alpn_list(PyObject *self, PyObjec
         return NULL;
     }
 
-    struct aws_tls_connection_options *connection_options = aws_py_get_tls_connection_options(tls_conn_options_py);
+    struct aws_tls_connection_options *connection_options = get_aws_tls_connection_options(tls_conn_options_py);
     if (!connection_options) {
         return NULL;
     }
@@ -481,7 +497,7 @@ PyObject *aws_py_io_tls_connection_options_set_server_name(PyObject *self, PyObj
         return NULL;
     }
 
-    struct aws_tls_connection_options *connection_options = aws_py_get_tls_connection_options(tls_conn_options_py);
+    struct aws_tls_connection_options *connection_options = get_aws_tls_connection_options(tls_conn_options_py);
     if (!connection_options) {
         return NULL;
     }

--- a/source/io.h
+++ b/source/io.h
@@ -77,4 +77,14 @@ PyObject *aws_py_io_tls_connection_options_set_alpn_list(PyObject *self, PyObjec
 
 PyObject *aws_py_io_tls_connection_options_set_server_name(PyObject *self, PyObject *args);
 
+
+/* Given a python object, return a pointer to its underlying native type.
+ * If NULL is returned, a python error has been set */
+
+struct aws_event_loop_group *aws_py_get_event_loop_group(PyObject *event_loop_group);
+struct aws_host_resolver *aws_py_get_host_resolver(PyObject *host_resolver);
+struct aws_client_bootstrap *aws_py_get_client_bootstrap(PyObject *client_bootstrap);
+struct aws_tls_ctx *aws_py_get_tls_ctx(PyObject *tls_ctx);
+struct aws_tls_connection_options *aws_py_get_tls_connection_options(PyObject *tls_connection_options);
+
 #endif /* AWS_CRT_PYTHON_IO_H */

--- a/source/io.h
+++ b/source/io.h
@@ -22,21 +22,6 @@
 #include "module.h"
 
 /**
- * Name string for event_loop_group capsules.
- */
-extern const char *s_capsule_name_client_bootstrap;
-
-/**
- * Name string for tls_ctx capsules.
- */
-extern const char *s_capsule_name_tls_ctx;
-
-/**
- * Name string for tls_connection_options capsules.
- */
-extern const char *s_capsule_name_tls_conn_options;
-
-/**
  * Name String to logging capsules
  */
 extern const char *s_capsule_name_logger;

--- a/source/io.h
+++ b/source/io.h
@@ -66,10 +66,10 @@ PyObject *aws_py_io_tls_connection_options_set_server_name(PyObject *self, PyObj
 /* Given a python object, return a pointer to its underlying native type.
  * If NULL is returned, a python error has been set */
 
-struct aws_event_loop_group *aws_py_get_event_loop_group(PyObject *event_loop_group);
-struct aws_host_resolver *aws_py_get_host_resolver(PyObject *host_resolver);
-struct aws_client_bootstrap *aws_py_get_client_bootstrap(PyObject *client_bootstrap);
-struct aws_tls_ctx *aws_py_get_tls_ctx(PyObject *tls_ctx);
-struct aws_tls_connection_options *aws_py_get_tls_connection_options(PyObject *tls_connection_options);
+struct aws_event_loop_group *get_aws_event_loop_group(PyObject *event_loop_group);
+struct aws_host_resolver *get_aws_host_resolver(PyObject *host_resolver);
+struct aws_client_bootstrap *get_aws_client_bootstrap(PyObject *client_bootstrap);
+struct aws_tls_ctx *get_aws_tls_ctx(PyObject *tls_ctx);
+struct aws_tls_connection_options *get_aws_tls_connection_options(PyObject *tls_connection_options);
 
 #endif /* AWS_CRT_PYTHON_IO_H */

--- a/source/mqtt_client.c
+++ b/source/mqtt_client.c
@@ -18,21 +18,23 @@
 
 const char *s_capsule_name_mqtt_client = "aws_mqtt_client";
 
-/*******************************************************************************
- * New Client
- ******************************************************************************/
+struct mqtt_client_binding {
+    struct aws_mqtt_client native;
+
+    /* Dependencies that must outlive us */
+    PyObject *bootstrap;
+    PyObject *tls_ctx;
+};
 
 static void s_mqtt_python_client_destructor(PyObject *client_capsule) {
 
-    assert(PyCapsule_CheckExact(client_capsule));
+    struct mqtt_client_binding *client = PyCapsule_GetPointer(client_capsule, s_capsule_name_mqtt_client);
+    assert(client);
 
-    struct mqtt_python_client *py_client = PyCapsule_GetPointer(client_capsule, s_capsule_name_mqtt_client);
-    assert(py_client);
-
-    struct aws_allocator *allocator = py_client->native_client.allocator;
-
-    aws_mqtt_client_clean_up(&py_client->native_client);
-    aws_mem_release(allocator, py_client);
+    aws_mqtt_client_clean_up(&client->native);
+    Py_DECREF(client->bootstrap);
+    Py_DECREF(client->tls_ctx);
+    aws_mem_release(aws_crt_python_get_allocator(), client);
 }
 
 PyObject *aws_py_mqtt_client_new(PyObject *self, PyObject *args) {
@@ -40,41 +42,46 @@ PyObject *aws_py_mqtt_client_new(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_crt_python_get_allocator();
 
-    struct mqtt_python_client *py_client = NULL;
-
-    PyObject *bootstrap_capsule = NULL;
-
-    if (!PyArg_ParseTuple(args, "O", &bootstrap_capsule)) {
-        goto error;
+    PyObject *bootstrap_py;
+    PyObject *tls_ctx_py;
+    if (!PyArg_ParseTuple(args, "OO", &bootstrap_py, &tls_ctx_py)) {
+        return NULL;
     }
 
-    if (!bootstrap_capsule || !PyCapsule_CheckExact(bootstrap_capsule)) {
-        PyErr_SetNone(PyExc_ValueError);
-        goto error;
-    }
-    struct aws_client_bootstrap *bootstrap = PyCapsule_GetPointer(bootstrap_capsule, s_capsule_name_client_bootstrap);
+    struct aws_client_bootstrap *bootstrap = aws_py_get_client_bootstrap(bootstrap_py);
     if (!bootstrap) {
-        goto error;
+        return NULL;
     }
 
-    py_client = aws_mem_acquire(allocator, sizeof(struct mqtt_python_client));
-    if (!py_client) {
+    struct mqtt_client_binding *client = aws_mem_calloc(allocator, 1, sizeof(struct mqtt_client_binding));
+    if (!client) {
         PyErr_SetAwsLastError();
-        goto error;
+        return NULL;
     }
-    AWS_ZERO_STRUCT(*py_client);
 
-    if (aws_mqtt_client_init(&py_client->native_client, allocator, bootstrap)) {
+    /* From hereon, we need to clean up if errors occur */
+
+    PyObject *capsule = PyCapsule_New(client, s_capsule_name_mqtt_client, s_mqtt_python_client_destructor);
+    if (!capsule) {
+        goto capsule_new_failed;
+    }
+
+    if (aws_mqtt_client_init(&client->native, allocator, bootstrap)) {
         PyErr_SetAwsLastError();
-        goto error;
+        goto client_init_failed;
     }
 
-    return PyCapsule_New(py_client, s_capsule_name_mqtt_client, s_mqtt_python_client_destructor);
+    /* From hereon, nothing will fail */
 
-error:
-    if (py_client) {
-        aws_mem_release(allocator, py_client);
-    }
+    client->bootstrap = bootstrap_py;
+    Py_INCREF(client->bootstrap);
+    client->tls_ctx = tls_ctx_py;
+    Py_INCREF(client->tls_ctx);
+    return capsule;
 
+client_init_failed:
+    Py_DECREF(capsule);
+capsule_new_failed:
+    aws_mem_release(allocator, client);
     return NULL;
 }

--- a/source/mqtt_client.c
+++ b/source/mqtt_client.c
@@ -48,7 +48,7 @@ PyObject *aws_py_mqtt_client_new(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    struct aws_client_bootstrap *bootstrap = aws_py_get_client_bootstrap(bootstrap_py);
+    struct aws_client_bootstrap *bootstrap = get_aws_client_bootstrap(bootstrap_py);
     if (!bootstrap) {
         return NULL;
     }
@@ -84,4 +84,20 @@ client_init_failed:
 capsule_new_failed:
     aws_mem_release(allocator, client);
     return NULL;
+}
+
+struct aws_mqtt_client *get_aws_mqtt_client(PyObject *mqtt_client) {
+    struct aws_mqtt_client *native = NULL;
+
+    PyObject *binding_capsule = PyObject_GetAttrString(mqtt_client, "_binding");
+    if (binding_capsule) {
+        struct mqtt_client_binding *binding = PyCapsule_GetPointer(binding_capsule, s_capsule_name_mqtt_client);
+        if (binding) {
+            native = &binding->native;
+            assert(native);
+        }
+        Py_DECREF(binding_capsule);
+    }
+
+    return native;
 }

--- a/source/mqtt_client.h
+++ b/source/mqtt_client.h
@@ -23,6 +23,6 @@ PyObject *aws_py_mqtt_client_new(PyObject *self, PyObject *args);
 
 /* Given a python object, return a pointer to its underlying native type.
  * If NULL is returned, a python error has been set */
-struct aws_mqtt_client *aws_py_get_mqtt_client(PyObject *mqtt_client);
+struct aws_mqtt_client *get_aws_mqtt_client(PyObject *mqtt_client);
 
 #endif /* AWS_CRT_PYTHON_MQTT_CLIENT_H */

--- a/source/mqtt_client.h
+++ b/source/mqtt_client.h
@@ -19,13 +19,10 @@
 
 #include <aws/mqtt/client.h>
 
-/** Name string for client capsules. */
-extern const char *s_capsule_name_mqtt_client;
-
-struct mqtt_python_client {
-    struct aws_mqtt_client native_client;
-};
-
 PyObject *aws_py_mqtt_client_new(PyObject *self, PyObject *args);
+
+/* Given a python object, return a pointer to its underlying native type.
+ * If NULL is returned, a python error has been set */
+struct aws_mqtt_client *aws_py_get_mqtt_client(PyObject *mqtt_client);
 
 #endif /* AWS_CRT_PYTHON_MQTT_CLIENT_H */

--- a/source/mqtt_client_connection.h
+++ b/source/mqtt_client_connection.h
@@ -21,9 +21,6 @@
 
 #include "module.h"
 
-/** Name string for client_connection capsules. */
-extern const char *s_capsule_name_mqtt_client_connection;
-
 PyObject *aws_py_mqtt_client_connection_new(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_connect(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_reconnect(PyObject *self, PyObject *args);
@@ -32,5 +29,9 @@ PyObject *aws_py_mqtt_client_connection_subscribe(PyObject *self, PyObject *args
 PyObject *aws_py_mqtt_client_connection_unsubscribe(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_ping(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_disconnect(PyObject *self, PyObject *args);
+
+/* Given a python object, return a pointer to its underlying native type.
+ * If NULL is returned, a python error has been set */
+struct aws_mqtt_client_connection *aws_py_get_mqtt_client_connection(PyObject *mqtt_client_connection);
 
 #endif /* MQTT_CLIENT_CONNECTION_H */

--- a/source/mqtt_client_connection.h
+++ b/source/mqtt_client_connection.h
@@ -32,6 +32,6 @@ PyObject *aws_py_mqtt_client_connection_disconnect(PyObject *self, PyObject *arg
 
 /* Given a python object, return a pointer to its underlying native type.
  * If NULL is returned, a python error has been set */
-struct aws_mqtt_client_connection *aws_py_get_mqtt_client_connection(PyObject *mqtt_client_connection);
+struct aws_mqtt_client_connection *get_aws_mqtt_client_connection(PyObject *mqtt_client_connection);
 
 #endif /* MQTT_CLIENT_CONNECTION_H */


### PR DESCRIPTION
- Address lifetime issues.
- Improved error-handling.
- Scrubbed IO and MQTT so far...

Details:
We've found that Python's garbage collector, once it's determined that a **collection** of inter-dependent objects may be destroyed together, maybe destroy the individual objects in any order. In pure Python-land this is fine, but in C we require that objects be destroyed in order, according to their dependencies. We found that we could enforce destruction ordering by doing Py_INCREF in C, rather than references between Python objects. I **believe** this is because, when C refounting is done, Python can't track the dependencies and find **collections** of objects to clean up all at once. It has to wait until refcounts from C-land reach 0. If this theory is correct, then a downside of this approach is that a circular references will prevent any of the objects involved from **ever** getting cleaned up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
