### PR TITLE
Resubscribe

### DIFF
--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -175,7 +175,6 @@ class HttpClientStream(HttpStreamBase):
             self._completion_future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
 
 
-
 class HttpMessageBase(NativeResource):
     """
     Base for HttpRequest and HttpResponse classes.

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -141,12 +141,6 @@ class HttpStreamBase(NativeResource):
         if self._on_body_cb:
             self._on_body_cb(self, chunk)
 
-    def _on_complete(self, error_code):
-        if error_code == 0:
-            self._completion_future.set_result(None)
-        else:
-            self._completion_future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
-
 
 class HttpClientStream(HttpStreamBase):
     __slots__ = ('_response_status_code', '_on_response_cb', '_on_body_cb')
@@ -173,6 +167,13 @@ class HttpClientStream(HttpStreamBase):
 
         if self._on_response_cb:
             self._on_response_cb(self, status_code, name_value_pairs)
+
+    def _on_complete(self, error_code):
+        if error_code == 0:
+            self._completion_future.set_result(self._response_status_code)
+        else:
+            self._completion_future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
+
 
 
 class HttpMessageBase(NativeResource):

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -24,12 +24,14 @@ class QoS(IntEnum):
     AT_LEAST_ONCE = 1
     EXACTLY_ONCE = 2
 
+
 def _try_qos(qos_value):
     """Return None if the value cannot be converted to Qos (ex: 0x80 subscribe failure)"""
     try:
         return QoS(qos_value)
-    except:
+    except BaseException:
         return None
+
 
 class ConnectReturnCode(IntEnum):
     ACCEPTED = 0

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -132,6 +132,7 @@ class Connection(NativeResource):
                 will,
                 username,
                 password,
+                clean_session,
                 on_connect,
             )
 

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -24,6 +24,12 @@ class QoS(IntEnum):
     AT_LEAST_ONCE = 1
     EXACTLY_ONCE = 2
 
+def _try_qos(qos_value):
+    """Return None if the value cannot be converted to Qos (ex: 0x80 subscribe failure)"""
+    try:
+        return QoS(qos_value)
+    except:
+        return None
 
 class ConnectReturnCode(IntEnum):
     ACCEPTED = 0
@@ -57,7 +63,7 @@ class Client(NativeResource):
 
 
 class Connection(NativeResource):
-    __slots__ = ('client')
+    __slots__ = ('client', '_on_connection_interrupted_cb', '_on_connection_resumed_cb')
 
     def __init__(self,
                  client,
@@ -66,8 +72,8 @@ class Connection(NativeResource):
                  reconnect_min_timeout_sec=5.0,
                  reconnect_max_timeout_sec=60.0):
         """
-        on_connection_interrupted: optional callback, with signature (error_code)
-        on_connection_resumed: optional callback, with signature (error_code, session_present)
+        on_connection_interrupted: optional callback, with signature (connection, error_code)
+        on_connection_resumed: optional callback, with signature (connection, error_code, session_present)
         """
 
         assert isinstance(client, Client)
@@ -76,12 +82,22 @@ class Connection(NativeResource):
 
         super(Connection, self).__init__()
         self.client = client
+        self._on_connection_interrupted_cb = on_connection_interrupted
+        self._on_connection_resumed_cb = on_connection_resumed
 
         self._binding = _awscrt.mqtt_client_connection_new(
             client,
-            on_connection_interrupted,
-            on_connection_resumed,
+            self._on_connection_interrupted,
+            self._on_connection_resumed,
         )
+
+    def _on_connection_interrupted(self, error_code):
+        if self._on_connection_interrupted_cb:
+            self._on_connection_interrupted_cb(self, error_code)
+
+    def _on_connection_resumed(self, error_code, session_present):
+        if self._on_connection_resumed_cb:
+            self._on_connection_resumed_cb(self, error_code, session_present)
 
     def connect(self,
                 client_id,
@@ -162,12 +178,15 @@ class Connection(NativeResource):
         future = Future()
         packet_id = 0
 
-        def suback(packet_id, topic, qos):
-            future.set_result(dict(
-                packet_id=packet_id,
-                topic=topic,
-                qos=QoS(qos),
-            ))
+        def suback(packet_id, topic, qos, error_code):
+            if error_code:
+                future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
+            else:
+                future.set_result(dict(
+                    packet_id=packet_id,
+                    topic=topic,
+                    qos=_try_qos(qos),
+                ))
 
         try:
             assert callable(callback)
@@ -189,6 +208,40 @@ class Connection(NativeResource):
 
         try:
             packet_id = _awscrt.mqtt_client_connection_unsubscribe(self._binding, topic, unsuback)
+
+        except Exception as e:
+            future.set_exception(e)
+
+        return future, packet_id
+
+    def resubscribe_existing_topics(self):
+        """
+        Subscribe again to all current topics.
+        This is to help when resuming a connection with a clean session.
+
+        Returns (future, packet_id).
+        When the resubscribe is complete, the future will contain a dict. The dict will contain:
+        ['packet_id']: the packet ID of the server's response, or None if there were no topics to resubscribe to.
+        ['topics']: A list of (topic, qos) tuples, where qos will be None if the topic failed to resubscribe.
+        If there were no topics to resubscribe to then the list will be empty.
+        """
+        packet_id = 0
+        future = Future()
+
+        def on_suback(packet_id, topic_qos_tuples, error_code):
+            if error_code:
+                future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
+            else:
+                future.set_result(dict(
+                    packet_id=packet_id,
+                    topics=[(topic, _try_qos(qos)) for (topic, qos) in topic_qos_tuples],
+                ))
+
+        try:
+            packet_id = _awscrt.mqtt_client_connection_resubscribe_existing_topics(self._binding, on_suback)
+            if packet_id is None:
+                # There were no topics to resubscribe to.
+                future.set_result(dict(packet_id=None, topics=[]))
 
         except Exception as e:
             future.set_exception(e)

--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,7 @@ def awscrt_ext():
 
 setuptools.setup(
     name="awscrt",
-    version="0.2.26",
+    version="0.3.0",
     author="Amazon Web Services, Inc",
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -141,7 +141,7 @@ static void s_on_client_connection_setup(
     }
 
     /* Invoke on_setup, then clear our reference to it */
-    PyObject *result = PyObject_CallFunction(connection->on_setup, "(Ni)", capsule ? capsule : Py_None, error_code);
+    PyObject *result = PyObject_CallFunction(connection->on_setup, "(Oi)", capsule ? capsule : Py_None, error_code);
     if (!result) {
         /* This function must succeed. Can't leave a Future incomplete. */
         PyErr_WriteUnraisable(PyErr_Occurred());
@@ -161,8 +161,7 @@ static void s_on_client_connection_setup(
         s_connection_destroy(connection);
     }
 
-    /* Py_XDECREF(capsule); ??? Not sure why this deletes capsule. It's referenced by HttpConnection._binding !!! */
-
+    Py_XDECREF(capsule);
     Py_XDECREF(result);
     PyGILState_Release(state);
 }

--- a/source/io.c
+++ b/source/io.c
@@ -128,7 +128,7 @@ static void s_elg_capsule_destructor(PyObject *elg_capsule) {
 
     /* Must use async cleanup.
      * We could deadlock if we ran the synchronous cleanup from an event-loop thread. */
-    aws_event_loop_group_cleanup_async(elg, s_elg_native_cleanup_complete, elg);
+    aws_event_loop_group_clean_up_async(elg, s_elg_native_cleanup_complete, elg);
 }
 
 PyObject *aws_py_event_loop_group_new(PyObject *self, PyObject *args) {

--- a/source/module.c
+++ b/source/module.c
@@ -257,6 +257,7 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(mqtt_client_connection_reconnect, METH_VARARGS),
     AWS_PY_METHOD_DEF(mqtt_client_connection_publish, METH_VARARGS),
     AWS_PY_METHOD_DEF(mqtt_client_connection_subscribe, METH_VARARGS),
+    AWS_PY_METHOD_DEF(mqtt_client_connection_resubscribe_existing_topics, METH_VARARGS),
     AWS_PY_METHOD_DEF(mqtt_client_connection_unsubscribe, METH_VARARGS),
     AWS_PY_METHOD_DEF(mqtt_client_connection_disconnect, METH_VARARGS),
 

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -789,10 +789,10 @@ static void s_suback_multi_callback(
     }
 
     for (size_t i = 0; i < num_topics; ++i) {
-        struct aws_mqtt_topic_subscription *sub_i;
+        struct aws_mqtt_topic_subscription sub_i;
         aws_array_list_get_at(topic_subacks, &sub_i, i);
 
-        PyObject *tuple = Py_BuildValue("(s#i)", sub_i->topic.ptr, sub_i->topic.len, sub_i->qos);
+        PyObject *tuple = Py_BuildValue("(s#i)", sub_i.topic.ptr, sub_i.topic.len, sub_i.qos);
         if (!tuple) {
             error_code = aws_py_raise_error();
             goto done_prepping_args;

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -416,16 +416,18 @@ PyObject *aws_py_mqtt_client_connection_connect(PyObject *self, PyObject *args) 
     }
 
     struct aws_byte_cursor client_id_cur = aws_byte_cursor_from_array(client_id, client_id_len);
-    struct aws_mqtt_connection_options options = {.host_name = server_name_cur,
-                                                  .port = port_number,
-                                                  .socket_options = &socket_options,
-                                                  .tls_options = tls_ctx ? &tls_options : NULL,
-                                                  .client_id = client_id_cur,
-                                                  .keep_alive_time_secs = keep_alive_time,
-                                                  .ping_timeout_ms = ping_timeout,
-                                                  .on_connection_complete = s_on_connect,
-                                                  .user_data = py_connection,
-                                                  .clean_session = is_clean_session};
+    struct aws_mqtt_connection_options options = {
+        .host_name = server_name_cur,
+        .port = port_number,
+        .socket_options = &socket_options,
+        .tls_options = tls_ctx ? &tls_options : NULL,
+        .client_id = client_id_cur,
+        .keep_alive_time_secs = keep_alive_time,
+        .ping_timeout_ms = ping_timeout,
+        .on_connection_complete = s_on_connect,
+        .user_data = py_connection,
+        .clean_session = is_clean_session,
+    };
     if (aws_mqtt_client_connection_connect(py_connection->native, &options)) {
         PyErr_SetAwsLastError();
         goto error;

--- a/source/mqtt_client_connection.h
+++ b/source/mqtt_client_connection.h
@@ -27,6 +27,7 @@ PyObject *aws_py_mqtt_client_connection_reconnect(PyObject *self, PyObject *args
 PyObject *aws_py_mqtt_client_connection_publish(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_subscribe(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_unsubscribe(PyObject *self, PyObject *args);
+PyObject *aws_py_mqtt_client_connection_resubscribe_existing_topics(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_disconnect(PyObject *self, PyObject *args);
 
 /* Given a python object, return a pointer to its underlying native type.

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -169,9 +169,10 @@ class TestClient(NativeResourceTest):
         stream = connection.request(request, response.on_response, response.on_body)
 
         # wait for stream to complete
-        stream.completion_future.result(self.timeout)
+        stream_completion_result = stream.completion_future.result(self.timeout)
 
         self.assertEqual(200, response.status_code)
+        self.assertEqual(200, stream_completion_result)
 
         with open(test_asset_path, 'rb') as test_asset:
             test_asset_bytes = test_asset.read()
@@ -206,9 +207,10 @@ class TestClient(NativeResourceTest):
             http_stream = connection.request(request, response.on_response, response.on_body)
 
             # wait for stream to complete
-            http_stream.completion_future.result(self.timeout)
+            stream_completion_result = http_stream.completion_future.result(self.timeout)
 
             self.assertEqual(200, response.status_code)
+            self.assertEqual(200, stream_completion_result)
 
             # compare what we sent against what the server received
             server_received = self.server.put_requests.get('/' + test_asset_path)


### PR DESCRIPTION
MQTT changes:
- added `mqtt.Connection.resubscribe_to_existing_topics()`
- `clean_session` flag is no longer ignored
- interrupted/resumed callbacks take additional `connection` arg
- Detect when server rejects the subscription

HTTP changes:
- `HttpStream.completion_future.result()` returns status_code instead of None 

Update dependencies:
- aws-c-common v0.4.12
- aws-c-io v0.4.12
- aws-c-mqtt to v0.4.9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
