### PR TITLE
Add CI for Python 2.7, 3.4, 3.5, 3.6

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -25,7 +25,29 @@
             "variables": {
                 "openssl_include": "=/opt/openssl/include",
                 "openssl_lib": "=/opt/openssl/lib"
-            }
+            },
+            "post_build_steps": [
+                ["echo", "------ Python 3.6 ------"],
+                ["/opt/python/cp36-cp36m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
+                ["/opt/python/cp36-cp36m/bin/python", "-m", "unittest", "discover", "--verbose"],
+                ["/opt/python/cp36-cp36m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp36-cp36m/bin/python", "elasticurl.py"],
+                ["echo", "------ Python 3.5 ------"],
+                ["/opt/python/cp35-cp35m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
+                ["/opt/python/cp35-cp35m/bin/python", "-m", "unittest", "discover", "--verbose"],
+                ["/opt/python/cp35-cp35m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp35-cp35m/bin/python", "elasticurl.py"],
+                ["echo", "------ Python 3.4 ------"],
+                ["/opt/python/cp34-cp34m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
+                ["/opt/python/cp34-cp34m/bin/python", "-m", "unittest", "discover", "--verbose"],
+                ["/opt/python/cp34-cp34m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp34-cp34m/bin/python", "elasticurl.py"],
+                ["echo", "------ Python 2.7 narrow-unicode ------"],
+                ["/opt/python/cp27-cp27m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
+                ["/opt/python/cp27-cp27m/bin/python", "-m", "unittest", "discover", "--verbose"],
+                ["/opt/python/cp27-cp27m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp27-cp27m/bin/python", "elasticurl.py"],
+                ["echo", "------ Python 2.7 wide-unicode ------"],
+                ["/opt/python/cp27-cp27mu/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
+                ["/opt/python/cp27-cp27mu/bin/python", "-m", "unittest", "discover", "--verbose"],
+                ["/opt/python/cp27-cp27mu/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp27-cp27mu/bin/python", "elasticurl.py"]
+            ]
         }
     },
     "targets": {

--- a/builder.json
+++ b/builder.json
@@ -30,23 +30,23 @@
                 ["echo", "------ Python 3.6 ------"],
                 ["/opt/python/cp36-cp36m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
                 ["/opt/python/cp36-cp36m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["/opt/python/cp36-cp36m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp36-cp36m/bin/python", "elasticurl.py"],
+                ["/opt/python/cp37-cp37m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp36-cp36m/bin/python", "elasticurl.py"],
                 ["echo", "------ Python 3.5 ------"],
                 ["/opt/python/cp35-cp35m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
                 ["/opt/python/cp35-cp35m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["/opt/python/cp35-cp35m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp35-cp35m/bin/python", "elasticurl.py"],
+                ["/opt/python/cp37-cp37m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp35-cp35m/bin/python", "elasticurl.py"],
                 ["echo", "------ Python 3.4 ------"],
                 ["/opt/python/cp34-cp34m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
                 ["/opt/python/cp34-cp34m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["/opt/python/cp34-cp34m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp34-cp34m/bin/python", "elasticurl.py"],
+                ["/opt/python/cp37-cp37m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp34-cp34m/bin/python", "elasticurl.py"],
                 ["echo", "------ Python 2.7 narrow-unicode ------"],
                 ["/opt/python/cp27-cp27m/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
                 ["/opt/python/cp27-cp27m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["/opt/python/cp27-cp27m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp27-cp27m/bin/python", "elasticurl.py"],
+                ["/opt/python/cp37-cp37m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp27-cp27m/bin/python", "elasticurl.py"],
                 ["echo", "------ Python 2.7 wide-unicode ------"],
                 ["/opt/python/cp27-cp27mu/bin/python", "setup.py", "--verbose", "build_ext", "--include-dirs{openssl_include}", "--library-dirs{openssl_lib}", "install"],
                 ["/opt/python/cp27-cp27mu/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["/opt/python/cp27-cp27mu/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp27-cp27mu/bin/python", "elasticurl.py"]
+                ["/opt/python/cp37-cp37m/bin/python", "aws-c-http/integration-testing/http_client_test.py", "/opt/python/cp27-cp27mu/bin/python", "elasticurl.py"]
             ]
         }
     },

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -10,10 +10,11 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+from __future__ import print_function
 import argparse
 import sys
 import os
-from io import BytesIO
+from io import BytesIO, open # Python2's built-in open() doesn't return a stream
 from awscrt import io, http
 try:
     from urllib.parse import urlparse

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import argparse
 import sys
 import os
-from io import BytesIO, open # Python2's built-in open() doesn't return a stream
+from io import BytesIO, open  # Python2's built-in open() doesn't return a stream
 from awscrt import io, http
 try:
     from urllib.parse import urlparse

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import print_function
 import distutils.ccompiler
 import glob
 import os

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from awscrt.http import HttpClientConnection, HttpClientStream, HttpHeaders, HttpRequest
 from awscrt.io import TlsContextOptions, ClientTlsContext, TlsConnectionOptions
 from concurrent.futures import Future
-from io import open # Python2's built-in open() doesn't return a stream
+from io import open  # Python2's built-in open() doesn't return a stream
 import ssl
 from test import NativeResourceTest
 import threading

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from awscrt.http import HttpClientConnection, HttpClientStream, HttpHeaders, HttpRequest
 from awscrt.io import TlsContextOptions, ClientTlsContext, TlsConnectionOptions
 from concurrent.futures import Future
+from io import open # Python2's built-in open() doesn't return a stream
 import ssl
 from test import NativeResourceTest
 import threading


### PR DESCRIPTION
only `manylinux` builds are running all variants for now.

Also fix python 2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
