### PR TITLE
Fix wait-for-pypi script

### DIFF
--- a/codebuild/cd/publish_to_prod_pypi.yml
+++ b/codebuild/cd/publish_to_prod_pypi.yml
@@ -22,7 +22,7 @@ phases:
       - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
       - python3 continuous-delivery/pull-pypirc.py prod
       - python3 -m twine upload -r pypi ../dist/*
-      - python3 continuous-delivery/wait-for-pypi.py awscrt $CURRENT_TAG_VERSION --index-url https://pypi.org/simple
+      - python3 continuous-delivery/wait-for-pypi.py awscrt $CURRENT_TAG_VERSION --index https://pypi.python.org/pypi
   post_build:
     commands:
       - echo Build completed on `date`

--- a/codebuild/cd/publish_to_test_pypi.yml
+++ b/codebuild/cd/publish_to_test_pypi.yml
@@ -22,7 +22,7 @@ phases:
       - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
       - python3 continuous-delivery/pull-pypirc.py alpha
       - python3 -m twine upload -r testpypi ../dist/*
-      - python3 continuous-delivery/wait-for-pypi.py awscrt $CURRENT_TAG_VERSION --index-url https://testpypi.python.org/simple
+      - python3 continuous-delivery/wait-for-pypi.py awscrt $CURRENT_TAG_VERSION --index https://test.pypi.org/pypi
   post_build:
     commands:
       - echo Build completed on `date`

--- a/continuous-delivery/wait-for-pypi.py
+++ b/continuous-delivery/wait-for-pypi.py
@@ -5,13 +5,13 @@ import time
 
 DEFAULT_TIMEOUT = 1800
 DEFAULT_INTERVAL = 5
-DEFAULT_INDEX_URL = 'https://pypi.org/simple'
+DEFAULT_INDEX_URL = 'https://pypi.python.org/pypi'
 
 
 def wait(package, version, index_url=DEFAULT_INDEX_URL, timeout=DEFAULT_TIMEOUT, interval=DEFAULT_INTERVAL):
     give_up_time = time.time() + timeout
     while True:
-        output = subprocess.check_output([sys.executable, '-m', 'pip', '--index', index_url, 'search', package])
+        output = subprocess.check_output([sys.executable, '-m', 'pip', 'search', '--index', index_url, package])
         output = output.decode()
 
         # output looks like: 'awscrt (0.3.1)  - A common runtime for AWS Python projects\n...'
@@ -28,12 +28,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('package', help="Packet name")
     parser.add_argument('version', help="Package version")
-    parser.add_argument('-i', '--index-url', default=DEFAULT_INDEX_URL, help="PyPI URL")
-    parser.add_argument('--timeout', type=float, default=DEFAULT_TIMEOUT, help="Give up after N seconds.")
-    parser.add_argument('--interval', type=float, default=DEFAULT_INTERVAL, help="Query PyPI every N seconds")
+    parser.add_argument('--index', default=DEFAULT_INDEX_URL, metavar='<url>',
+                        help="Base URL of Python Package Index. (default {})".format(DEFAULT_INDEX_URL))
+    parser.add_argument('--timeout', type=float, default=DEFAULT_TIMEOUT, metavar='<sec>',
+                        help="Give up after N seconds.")
+    parser.add_argument('--interval', type=float, default=DEFAULT_INTERVAL, metavar='<sec>',
+                        help="Query PyPI every N seconds")
     args = parser.parse_args()
 
-    if wait(args.package, args.version, args.index_url, args.timeout, args.interval):
+    if wait(args.package, args.version, args.index, args.timeout, args.interval):
         print('{} {} is available in pypi'.format(args.package, args.version))
     else:
         exit("Timed out waiting for pypi to report {} {} as latest".format(args.package, args.version))

--- a/continuous-delivery/wait-for-pypi.py
+++ b/continuous-delivery/wait-for-pypi.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import time
 
-DEFAULT_TIMEOUT = 1800
+DEFAULT_TIMEOUT = 60 * 30 # 30 min
 DEFAULT_INTERVAL = 5
 DEFAULT_INDEX_URL = 'https://pypi.python.org/pypi'
 

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ def awscrt_ext():
 
 setuptools.setup(
     name="awscrt",
-    version="0.3.2",
+    version="0.3.3",
     author="Amazon Web Services, Inc",
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",


### PR DESCRIPTION
the way custom URLs work for `pip install` is different than how they work for `pip search`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
