### PR TITLE
Actually bind Credentials to aws_credentials

### DIFF
--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -25,19 +25,12 @@ class Credentials(NativeResource):
 
     __slots__ = ()
 
-    @classmethod
-    def create(cls, access_key_id, secret_access_key, session_token=None):
+    def __init__(self, access_key_id, secret_access_key, session_token=None):
         assert isinstance_str(access_key_id)
         assert isinstance_str(secret_access_key)
         assert isinstance_str(session_token) or session_token is None
 
-        return cls._from_binding(_awscrt.credentials_new(access_key_id, secret_access_key, session_token))
-
-    @classmethod
-    def _from_binding(cls, credentials_binding):
-        credentials = cls()
-        credentials._binding = credentials_binding
-        return credentials
+        self._binding = _awscrt.credentials_new(access_key_id, secret_access_key, session_token)
 
     @property
     def access_key_id(self):
@@ -66,12 +59,12 @@ class CredentialsProviderBase(NativeResource):
         """
         future = Future()
 
-        def _on_complete(error_code, credentials_binding):
+        def _on_complete(error_code, access_key_id, secret_access_key, session_token):
             try:
                 if error_code:
                     future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
                 else:
-                    credentials = Credentials._from_binding(credentials_binding)
+                    credentials = Credentials(access_key_id, secret_access_key, session_token)
                     future.set_result(credentials)
 
             except Exception as e:

--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -30,6 +30,7 @@ class Credentials(NativeResource):
         assert isinstance_str(secret_access_key)
         assert isinstance_str(session_token) or session_token is None
 
+        super(Credentials, self).__init__()
         self._binding = _awscrt.credentials_new(access_key_id, secret_access_key, session_token)
 
     @property

--- a/source/auth.h
+++ b/source/auth.h
@@ -19,13 +19,6 @@
 struct aws_credentials;
 
 PyObject *aws_py_credentials_new(PyObject *self, PyObject *args);
-
-/**
- * Create Capsule to own pre-existing aws_credentials struct.
- * The aws_credentials are destroyed when the capsule is destroyed.
- */
-PyObject *aws_py_credentials_new_binding_capsule(struct aws_credentials *owned_credentials);
-
 PyObject *aws_py_credentials_access_key_id(PyObject *self, PyObject *args);
 PyObject *aws_py_credentials_secret_access_key(PyObject *self, PyObject *args);
 PyObject *aws_py_credentials_session_token(PyObject *self, PyObject *args);

--- a/source/auth.h
+++ b/source/auth.h
@@ -16,6 +16,20 @@
  */
 #include "module.h"
 
+struct aws_credentials;
+
+PyObject *aws_py_credentials_new(PyObject *self, PyObject *args);
+
+/**
+ * Create Capsule to own pre-existing aws_credentials struct.
+ * The aws_credentials are destroyed when the capsule is destroyed.
+ */
+PyObject *aws_py_credentials_new_binding_capsule(struct aws_credentials *owned_credentials);
+
+PyObject *aws_py_credentials_access_key_id(PyObject *self, PyObject *args);
+PyObject *aws_py_credentials_secret_access_key(PyObject *self, PyObject *args);
+PyObject *aws_py_credentials_session_token(PyObject *self, PyObject *args);
+
 PyObject *aws_py_credentials_provider_get_credentials(PyObject *self, PyObject *args);
 PyObject *aws_py_credentials_provider_shutdown(PyObject *self, PyObject *args);
 
@@ -25,6 +39,7 @@ PyObject *aws_py_credentials_provider_new_static(PyObject *self, PyObject *args)
 /* Given a python object, return a pointer to its underlying native type.
  * If NULL is returned, a python error has been set */
 
+struct aws_credentials *aws_py_get_credentials(PyObject *credentials);
 struct aws_credentials_provider *aws_py_get_credentials_provider(PyObject *credentials_provider);
 
 #endif // AWS_CRT_PYTHON_AUTH_H

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -427,7 +427,7 @@ PyObject *aws_py_credentials_provider_new_static(PyObject *self, PyObject *args)
         allocator,
         aws_byte_cursor_from_array(access_key_id, access_key_id_len),
         aws_byte_cursor_from_array(secret_access_key, secret_access_key_len),
-        aws_byte_cursor_from_array(session_token, session_token ? session_token_len : 0));
+        aws_byte_cursor_from_array(session_token, session_token_len));
 
     if (!binding->native) {
         PyErr_SetAwsLastError();

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -20,7 +20,162 @@
 #include <aws/auth/credentials.h>
 #include <aws/common/string.h>
 
+static const char *s_capsule_name_credentials = "aws_credentials";
 static const char *s_capsule_name_credentials_provider = "aws_credentials_provider";
+
+/**
+ * Binds python Credentials to native aws_credentials.
+ */
+struct credentials_binding {
+    struct aws_credentials *native;
+};
+
+static void s_credentials_capsule_destructor(PyObject *capsule) {
+    struct credentials_binding *binding = PyCapsule_GetPointer(capsule, s_capsule_name_credentials);
+
+    if (binding->native) {
+        aws_credentials_destroy(binding->native);
+    }
+
+    aws_mem_release(aws_py_get_allocator(), binding);
+}
+
+static PyObject *s_new_credentials_capsule_and_binding(struct credentials_binding **out_binding) {
+    struct credentials_binding *binding = aws_mem_calloc(aws_py_get_allocator(), 1, sizeof(struct credentials_binding));
+    if (!binding) {
+        return PyErr_AwsLastError();
+    }
+
+    PyObject *capsule = PyCapsule_New(binding, s_capsule_name_credentials, s_credentials_capsule_destructor);
+    if (!capsule) {
+        aws_mem_release(aws_py_get_allocator(), binding);
+        return NULL;
+    }
+
+    *out_binding = binding;
+    return capsule;
+}
+
+PyObject *aws_py_credentials_new(PyObject *self, PyObject *args) {
+    (void)self;
+
+    struct aws_byte_cursor access_key_id;
+    struct aws_byte_cursor secret_access_key;
+    struct aws_byte_cursor session_token; /* session_token is optional */
+    if (!PyArg_ParseTuple(
+            args,
+            "s#s#z#",
+            &access_key_id.ptr,
+            &access_key_id.len,
+            &secret_access_key.ptr,
+            &secret_access_key.len,
+            &session_token.ptr,
+            &session_token.len)) {
+        return NULL;
+    }
+
+    struct credentials_binding *binding;
+    PyObject *capsule = s_new_credentials_capsule_and_binding(&binding);
+    if (!capsule) {
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur.
+     * Fortunately, the capsule destructor will clean up anything stored inside the binding */
+
+    binding->native = aws_credentials_new_from_cursors(
+        aws_py_get_allocator(), &access_key_id, &secret_access_key, session_token.ptr ? &session_token : NULL);
+    if (!binding->native) {
+        PyErr_SetAwsLastError();
+        goto error;
+    }
+
+    return capsule;
+
+error:
+    Py_DECREF(capsule);
+    return NULL;
+}
+
+PyObject *aws_py_credentials_new_binding_capsule(struct aws_credentials *owned_credentials) {
+    struct credentials_binding *binding;
+    PyObject *capsule = s_new_credentials_capsule_and_binding(&binding);
+    if (!capsule) {
+        return NULL;
+    }
+
+    binding->native = owned_credentials;
+    return capsule;
+}
+
+struct aws_credentials *aws_py_get_credentials(PyObject *credentials) {
+    struct aws_credentials *native = NULL;
+
+    PyObject *capsule = PyObject_GetAttrString(credentials, "_binding");
+    if (capsule) {
+        struct credentials_binding *binding = PyCapsule_GetPointer(capsule, s_capsule_name_credentials);
+        if (binding) {
+            native = binding->native;
+        }
+        Py_DECREF(capsule);
+    }
+
+    return native;
+}
+
+enum credentials_member {
+    CREDENTIALS_MEMBER_ACCESS_KEY_ID,
+    CREDENTIALS_MEMBER_SECRET_ACCESS_KEY,
+    CREDENTIALS_MEMBER_SESSION_TOKEN,
+};
+
+static PyObject *s_credentials_get_member_str(PyObject *args, enum credentials_member member) {
+    PyObject *capsule;
+    if (!PyArg_ParseTuple(args, "O", &capsule)) {
+        return NULL;
+    }
+
+    const struct credentials_binding *binding = PyCapsule_GetPointer(capsule, s_capsule_name_credentials);
+    if (!binding) {
+        return NULL;
+    }
+
+    const struct aws_string *str;
+    switch (member) {
+        case CREDENTIALS_MEMBER_ACCESS_KEY_ID:
+            str = binding->native->access_key_id;
+            break;
+        case CREDENTIALS_MEMBER_SECRET_ACCESS_KEY:
+            str = binding->native->secret_access_key;
+            break;
+        case CREDENTIALS_MEMBER_SESSION_TOKEN:
+            str = binding->native->session_token;
+            break;
+        default:
+            AWS_FATAL_ASSERT(0);
+    }
+
+    if (!str) {
+        Py_RETURN_NONE;
+    }
+
+    return PyString_FromAwsString(str);
+}
+
+PyObject *aws_py_credentials_access_key_id(PyObject *self, PyObject *args) {
+    (void)self;
+    return s_credentials_get_member_str(args, CREDENTIALS_MEMBER_ACCESS_KEY_ID);
+}
+
+PyObject *aws_py_credentials_secret_access_key(PyObject *self, PyObject *args) {
+    (void)self;
+    return s_credentials_get_member_str(args, CREDENTIALS_MEMBER_SECRET_ACCESS_KEY);
+}
+
+PyObject *aws_py_credentials_session_token(PyObject *self, PyObject *args) {
+    (void)self;
+    return s_credentials_get_member_str(args, CREDENTIALS_MEMBER_SESSION_TOKEN);
+}
 
 /**
  * Binds a Python CredentialsProvider to a native aws_credentials_provider.
@@ -82,45 +237,21 @@ static void s_on_get_credentials_complete(struct aws_credentials *credentials, v
     PyObject *on_complete_cb = user_data;
 
     /* NOTE: This callback doesn't currently supply an error_code, but it should. */
-    int error_code = AWS_ERROR_UNKNOWN;
-
-    /* Note that we don't actually bind the native aws_credentials to the python Credentials class,
-     * we simply copy the contents back and forth. */
-    const char *access_key_id = NULL;
-    Py_ssize_t access_key_id_len = 0;
-    const char *secret_access_key = NULL;
-    Py_ssize_t secret_access_key_len = 0;
-    const char *session_token = NULL;
-    Py_ssize_t session_token_len = 0;
-
-    if (credentials) {
-        error_code = AWS_ERROR_SUCCESS;
-
-        if (s_aws_string_to_cstr_and_ssize(credentials->access_key_id, &access_key_id, &access_key_id_len)) {
-            error_code = aws_last_error();
-        }
-        if (s_aws_string_to_cstr_and_ssize(
-                credentials->secret_access_key, &secret_access_key, &secret_access_key_len)) {
-            error_code = aws_last_error();
-        }
-        if (s_aws_string_to_cstr_and_ssize(credentials->session_token, &session_token, &session_token_len)) {
-            error_code = aws_last_error();
-        }
-    }
+    int error_code = credentials ? AWS_ERROR_SUCCESS : AWS_ERROR_UNKNOWN;
 
     /*************** GIL ACQUIRE ***************/
     PyGILState_STATE state = PyGILState_Ensure();
 
-    PyObject *result = PyObject_CallFunction(
-        on_complete_cb,
-        "(is#s#s#)",
-        error_code,
-        access_key_id,
-        access_key_id_len,
-        secret_access_key,
-        secret_access_key_len,
-        session_token,
-        session_token_len);
+    PyObject *credentials_binding_capsule = NULL;
+    if (credentials) {
+        credentials_binding_capsule = aws_py_credentials_new_binding_capsule(credentials);
+        if (!credentials_binding_capsule) {
+            error_code = aws_py_raise_error();
+            aws_credentials_destroy(credentials);
+        }
+    }
+
+    PyObject *result = PyObject_CallFunction(on_complete_cb, "(iO)", error_code, credentials_binding_capsule);
     if (result) {
         Py_DECREF(result);
     } else {
@@ -128,6 +259,7 @@ static void s_on_get_credentials_complete(struct aws_credentials *credentials, v
     }
 
     Py_DECREF(on_complete_cb);
+    Py_XDECREF(credentials_binding_capsule);
 
     PyGILState_Release(state);
     /*************** GIL RELEASE ***************/
@@ -274,7 +406,7 @@ PyObject *aws_py_credentials_provider_new_static(PyObject *self, PyObject *args)
         allocator,
         aws_byte_cursor_from_array(access_key_id, access_key_id_len),
         aws_byte_cursor_from_array(secret_access_key, secret_access_key_len),
-        aws_byte_cursor_from_array(session_token, session_token_len));
+        aws_byte_cursor_from_array(session_token, session_token ? session_token_len : 0));
 
     if (!binding->native) {
         PyErr_SetAwsLastError();

--- a/source/module.c
+++ b/source/module.c
@@ -99,6 +99,10 @@ struct aws_byte_cursor aws_byte_cursor_from_pystring(PyObject *str) {
     return aws_byte_cursor_from_array(NULL, 0);
 }
 
+PyObject *PyString_FromAwsString(const struct aws_string *aws_str) {
+    return PyString_FromStringAndSize(aws_string_c_str(aws_str), aws_str->len);
+}
+
 int PyIntEnum_Check(PyObject *int_enum_obj) {
 #if PY_MAJOR_VERSION == 2
     return PyInt_Check(int_enum_obj);
@@ -280,6 +284,10 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(http_request_new, METH_VARARGS),
 
     /* Auth */
+    AWS_PY_METHOD_DEF(credentials_new, METH_VARARGS),
+    AWS_PY_METHOD_DEF(credentials_access_key_id, METH_VARARGS),
+    AWS_PY_METHOD_DEF(credentials_secret_access_key, METH_VARARGS),
+    AWS_PY_METHOD_DEF(credentials_session_token, METH_VARARGS),
     AWS_PY_METHOD_DEF(credentials_provider_get_credentials, METH_VARARGS),
     AWS_PY_METHOD_DEF(credentials_provider_shutdown, METH_VARARGS),
     AWS_PY_METHOD_DEF(credentials_provider_new_chain_default, METH_VARARGS),

--- a/source/module.h
+++ b/source/module.h
@@ -25,6 +25,7 @@
 #include <aws/common/common.h>
 
 struct aws_byte_buf;
+struct aws_string;
 
 #if PY_MAJOR_VERSION >= 3
 #    define PyString_FromStringAndSize PyUnicode_FromStringAndSize
@@ -36,6 +37,7 @@ struct aws_byte_buf;
 /* AWS Specific Helpers */
 #define PyBool_FromAwsResult(result) PyBool_FromLong((result) == AWS_OP_SUCCESS)
 #define PyString_FromAwsByteCursor(cursor) PyString_FromStringAndSize((const char *)(cursor)->ptr, (cursor)->len)
+PyObject *PyString_FromAwsString(const struct aws_string *aws_str);
 
 int PyIntEnum_Check(PyObject *int_enum_obj);
 long PyIntEnum_AsLong(PyObject *int_enum_obj);

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -12,10 +12,14 @@
 # permissions and limitations under the License.
 
 from __future__ import absolute_import
-from awscrt.auth import DefaultCredentialsProviderChain, StaticCredentialsProvider
+from awscrt.auth import Credentials, DefaultCredentialsProviderChain, StaticCredentialsProvider
 from awscrt.io import ClientBootstrap, EventLoopGroup
 import os
 from test import NativeResourceTest
+
+EXAMPLE_ACCESS_KEY_ID = 'example_access_key_id'
+EXAMPLE_SECRET_ACCESS_KEY = 'example_secret_access_key'
+EXAMPLE_SESSION_TOKEN = 'example_session_token'
 
 
 class ScopedEnvironmentVariable(object):
@@ -34,24 +38,34 @@ class ScopedEnvironmentVariable(object):
         else:
             os.environ[self.key] = self.prev_value
 
+class TestCredentials(NativeResourceTest):
+    def test_create(self):
+        credentials = Credentials.create(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY, EXAMPLE_SESSION_TOKEN)
+        self.assertEqual(EXAMPLE_ACCESS_KEY_ID, credentials.access_key_id)
+        self.assertEqual(EXAMPLE_SECRET_ACCESS_KEY, credentials.secret_access_key)
+        self.assertEqual(EXAMPLE_SESSION_TOKEN, credentials.session_token)
+
+    def test_create_no_session_token(self):
+        credentials = Credentials.create(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY)
+        self.assertEqual(EXAMPLE_ACCESS_KEY_ID, credentials.access_key_id)
+        self.assertEqual(EXAMPLE_SECRET_ACCESS_KEY, credentials.secret_access_key)
+        self.assertIsNone(credentials.session_token)
+
+
 
 class TestProvider(NativeResourceTest):
-    example_access_key_id = 'example_access_key_id'
-    example_secret_access_key = 'example_secret_access_key'
-    example_session_token = 'example_session_token'
-
     def test_static_provider(self):
         provider = StaticCredentialsProvider(
-            self.example_access_key_id,
-            self.example_secret_access_key,
-            self.example_session_token)
+            EXAMPLE_ACCESS_KEY_ID,
+            EXAMPLE_SECRET_ACCESS_KEY,
+            EXAMPLE_SESSION_TOKEN)
 
         future = provider.get_credentials()
         credentials = future.result()
 
-        self.assertEqual(self.example_access_key_id, credentials.access_key_id)
-        self.assertEqual(self.example_secret_access_key, credentials.secret_access_key)
-        self.assertEqual(self.example_session_token, credentials.session_token)
+        self.assertEqual(EXAMPLE_ACCESS_KEY_ID, credentials.access_key_id)
+        self.assertEqual(EXAMPLE_SECRET_ACCESS_KEY, credentials.secret_access_key)
+        self.assertEqual(EXAMPLE_SESSION_TOKEN, credentials.session_token)
 
     # TODO: test currently broken because None session_token comes back as empty string do to inconsistent use of
     # aws_byte_cursor by value/pointer in aws-c-auth APIs.

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -38,6 +38,7 @@ class ScopedEnvironmentVariable(object):
         else:
             os.environ[self.key] = self.prev_value
 
+
 class TestCredentials(NativeResourceTest):
     def test_create(self):
         credentials = Credentials(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY, EXAMPLE_SESSION_TOKEN)
@@ -50,7 +51,6 @@ class TestCredentials(NativeResourceTest):
         self.assertEqual(EXAMPLE_ACCESS_KEY_ID, credentials.access_key_id)
         self.assertEqual(EXAMPLE_SECRET_ACCESS_KEY, credentials.secret_access_key)
         self.assertIsNone(credentials.session_token)
-
 
 
 class TestProvider(NativeResourceTest):

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -40,13 +40,13 @@ class ScopedEnvironmentVariable(object):
 
 class TestCredentials(NativeResourceTest):
     def test_create(self):
-        credentials = Credentials.create(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY, EXAMPLE_SESSION_TOKEN)
+        credentials = Credentials(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY, EXAMPLE_SESSION_TOKEN)
         self.assertEqual(EXAMPLE_ACCESS_KEY_ID, credentials.access_key_id)
         self.assertEqual(EXAMPLE_SECRET_ACCESS_KEY, credentials.secret_access_key)
         self.assertEqual(EXAMPLE_SESSION_TOKEN, credentials.session_token)
 
     def test_create_no_session_token(self):
-        credentials = Credentials.create(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY)
+        credentials = Credentials(EXAMPLE_ACCESS_KEY_ID, EXAMPLE_SECRET_ACCESS_KEY)
         self.assertEqual(EXAMPLE_ACCESS_KEY_ID, credentials.access_key_id)
         self.assertEqual(EXAMPLE_SECRET_ACCESS_KEY, credentials.secret_access_key)
         self.assertIsNone(credentials.session_token)


### PR DESCRIPTION
Previously, the `Credentials` class was pure python and I assumed we'd just copy data out as necessary.
When binding the signers I realized this was making things more complicated than if we'd just bound it directly to the `aws_credentials` struct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
