### PR TITLE
Set exception when attribute isn't found

### DIFF
--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -64,7 +64,7 @@ PyObject *aws_py_credentials_new(PyObject *self, PyObject *args) {
 }
 
 struct aws_credentials *aws_py_get_credentials(PyObject *credentials) {
-    return aws_py_get_binding(credentials, s_capsule_name_credentials);
+    return aws_py_get_binding(credentials, s_capsule_name_credentials, "AwsCredentials");
 }
 
 enum credentials_member {
@@ -148,7 +148,10 @@ static void s_credentials_provider_capsule_destructor(PyObject *capsule) {
 
 struct aws_credentials_provider *aws_py_get_credentials_provider(PyObject *credentials_provider) {
     AWS_PY_RETURN_NATIVE_FROM_BINDING(
-        credentials_provider, s_capsule_name_credentials_provider, credentials_provider_binding);
+        credentials_provider,
+        s_capsule_name_credentials_provider,
+        "AwsCredentialsProviderBase",
+        credentials_provider_binding);
 }
 
 static int s_aws_string_to_cstr_and_ssize(

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -147,15 +147,8 @@ static void s_credentials_provider_capsule_destructor(PyObject *capsule) {
 }
 
 struct aws_credentials_provider *aws_py_get_credentials_provider(PyObject *credentials_provider) {
-    struct credentials_provider_binding *binding =
-        aws_py_get_binding(credentials_provider, s_capsule_name_credentials_provider);
-    if (binding) {
-        if (binding->native) {
-            return binding->native;
-        }
-        PyErr_Format(PyExc_TypeError, "%s._binding.native is NULL", Py_TYPE(credentials_provider)->tp_name);
-    }
-    return NULL;
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(
+        credentials_provider, s_capsule_name_credentials_provider, credentials_provider_binding);
 }
 
 static int s_aws_string_to_cstr_and_ssize(

--- a/source/auth_signer.c
+++ b/source/auth_signer.c
@@ -31,15 +31,7 @@ static void s_signer_capsule_destructor(PyObject *py_capsule) {
 }
 
 struct aws_signer *aws_py_get_signer(PyObject *py_signer) {
-    struct aws_signer *native = NULL;
-
-    PyObject *py_capsule = PyObject_GetAttrString(py_signer, "_binding");
-    if (py_capsule) {
-        native = PyCapsule_GetPointer(py_capsule, s_capsule_name_signer);
-        Py_DECREF(py_capsule);
-    }
-
-    return native;
+    return aws_py_get_binding(py_signer, s_capsule_name_signer);
 }
 
 PyObject *aws_py_signer_new_aws(PyObject *self, PyObject *args) {

--- a/source/auth_signer.c
+++ b/source/auth_signer.c
@@ -31,7 +31,7 @@ static void s_signer_capsule_destructor(PyObject *py_capsule) {
 }
 
 struct aws_signer *aws_py_get_signer(PyObject *py_signer) {
-    return aws_py_get_binding(py_signer, s_capsule_name_signer);
+    return aws_py_get_binding(py_signer, s_capsule_name_signer, "AwsSigner");
 }
 
 PyObject *aws_py_signer_new_aws(PyObject *self, PyObject *args) {

--- a/source/auth_signing_config.c
+++ b/source/auth_signing_config.c
@@ -178,19 +178,11 @@ error:
 }
 
 struct aws_signing_config_aws *aws_py_get_signing_config(PyObject *py_signing_config) {
-    struct aws_signing_config_aws *native = NULL;
-
-    PyObject *py_capsule = PyObject_GetAttrString(py_signing_config, "_binding");
-    if (py_capsule) {
-        struct config_binding *binding = PyCapsule_GetPointer(py_capsule, s_capsule_name_signing_config);
-        if (binding) {
-            native = &binding->native;
-            AWS_FATAL_ASSERT(native);
-        }
-        Py_DECREF(py_capsule);
+    struct config_binding *binding = aws_py_get_binding(py_signing_config, s_capsule_name_signing_config);
+    if (!binding) {
+        return NULL;
     }
-
-    return native;
+    return &binding->native;
 }
 
 /**

--- a/source/auth_signing_config.c
+++ b/source/auth_signing_config.c
@@ -178,11 +178,8 @@ error:
 }
 
 struct aws_signing_config_aws *aws_py_get_signing_config(PyObject *py_signing_config) {
-    struct config_binding *binding = aws_py_get_binding(py_signing_config, s_capsule_name_signing_config);
-    if (!binding) {
-        return NULL;
-    }
-    return &binding->native;
+    AWS_PY_RETURN_NATIVE_REF_FROM_BINDING(
+        py_signing_config, s_capsule_name_signing_config, "AwsSigningConfig", config_binding);
 }
 
 /**

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -56,7 +56,8 @@ static void s_connection_destroy(struct http_connection_binding *connection) {
 }
 
 struct aws_http_connection *aws_py_get_http_connection(PyObject *connection) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(connection, s_capsule_name_http_connection, http_connection_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(
+        connection, s_capsule_name_http_connection, "HttpConnectionBase", http_connection_binding);
 }
 
 static void s_connection_release(struct http_connection_binding *connection) {

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -56,19 +56,7 @@ static void s_connection_destroy(struct http_connection_binding *connection) {
 }
 
 struct aws_http_connection *aws_py_get_http_connection(PyObject *connection) {
-    struct aws_http_connection *native = NULL;
-
-    PyObject *capsule = PyObject_GetAttrString(connection, "_binding");
-    if (capsule) {
-        struct http_connection_binding *binding = PyCapsule_GetPointer(capsule, s_capsule_name_http_connection);
-        if (binding) {
-            native = binding->native;
-            AWS_FATAL_ASSERT(native);
-        }
-        Py_DECREF(capsule);
-    }
-
-    return native;
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(connection, s_capsule_name_http_connection, http_connection_binding);
 }
 
 static void s_connection_release(struct http_connection_binding *connection) {
@@ -214,7 +202,8 @@ PyObject *aws_py_http_client_connection_new(PyObject *self, PyObject *args) {
         }
 
         connection->tls_ctx = PyObject_GetAttrString(tls_options_py, "tls_ctx"); /* Creates new reference */
-        if (!connection->tls_ctx) {
+        if (!connection->tls_ctx || connection->tls_ctx == Py_None) {
+            PyErr_SetString(PyExc_TypeError, "tls_connection_options.tls_ctx is invalid");
             goto error;
         }
     }

--- a/source/http_headers.c
+++ b/source/http_headers.c
@@ -32,15 +32,7 @@ static void s_headers_capsule_destructor(PyObject *py_capsule) {
 }
 
 struct aws_http_headers *aws_py_get_http_headers(PyObject *http_headers) {
-    struct aws_http_headers *native = NULL;
-
-    PyObject *py_capsule = PyObject_GetAttrString(http_headers, "_binding");
-    if (py_capsule) {
-        native = s_headers_from_capsule(py_capsule);
-        Py_DECREF(py_capsule);
-    }
-
-    return native;
+    return aws_py_get_binding(http_headers, s_capsule_name_headers);
 }
 
 PyObject *aws_py_http_headers_new_from_native(struct aws_http_headers *headers) {

--- a/source/http_headers.c
+++ b/source/http_headers.c
@@ -32,7 +32,7 @@ static void s_headers_capsule_destructor(PyObject *py_capsule) {
 }
 
 struct aws_http_headers *aws_py_get_http_headers(PyObject *http_headers) {
-    return aws_py_get_binding(http_headers, s_capsule_name_headers);
+    return aws_py_get_binding(http_headers, s_capsule_name_headers, "HttpHeaders");
 }
 
 PyObject *aws_py_http_headers_new_from_native(struct aws_http_headers *headers) {

--- a/source/http_message.c
+++ b/source/http_message.c
@@ -51,18 +51,7 @@ static struct http_message_binding *s_binding_from_capsule(PyObject *capsule) {
 }
 
 struct aws_http_message *aws_py_get_http_message(PyObject *http_message) {
-    struct aws_http_message *native = NULL;
-
-    PyObject *capsule = PyObject_GetAttrString(http_message, "_binding");
-    if (capsule) {
-        struct http_message_binding *message_binding = s_binding_from_capsule(capsule);
-        if (message_binding) {
-            native = message_binding->native;
-        }
-        Py_DECREF(capsule);
-    }
-
-    return native;
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(http_message, s_capsule_name_http_message, http_message_binding);
 }
 
 PyObject *aws_py_http_message_new_request(PyObject *self, PyObject *args) {

--- a/source/http_message.c
+++ b/source/http_message.c
@@ -51,7 +51,8 @@ static struct http_message_binding *s_binding_from_capsule(PyObject *capsule) {
 }
 
 struct aws_http_message *aws_py_get_http_message(PyObject *http_message) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(http_message, s_capsule_name_http_message, http_message_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(
+        http_message, s_capsule_name_http_message, "HttpMessageBase", http_message_binding);
 }
 
 PyObject *aws_py_http_message_new_request(PyObject *self, PyObject *args) {

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -42,7 +42,7 @@ struct http_stream_binding {
 };
 
 struct aws_http_stream *aws_py_get_http_stream(PyObject *stream) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(stream, s_capsule_name_http_stream, http_stream_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(stream, s_capsule_name_http_stream, "HttpStreamBase", http_stream_binding);
 }
 
 static int s_on_incoming_headers(

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -42,19 +42,7 @@ struct http_stream_binding {
 };
 
 struct aws_http_stream *aws_py_get_http_stream(PyObject *stream) {
-    struct aws_http_stream *native = NULL;
-
-    PyObject *capsule = PyObject_GetAttrString(stream, "_binding");
-    if (capsule) {
-        struct http_stream_binding *binding = PyCapsule_GetPointer(capsule, s_capsule_name_http_stream);
-        if (binding) {
-            native = binding->native;
-            AWS_FATAL_ASSERT(native);
-        }
-        Py_DECREF(capsule);
-    }
-
-    return native;
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(stream, s_capsule_name_http_stream, http_stream_binding);
 }
 
 static int s_on_incoming_headers(

--- a/source/io.c
+++ b/source/io.c
@@ -167,16 +167,7 @@ elg_init_failed:
 }
 
 struct aws_event_loop_group *aws_py_get_event_loop_group(PyObject *event_loop_group) {
-    struct aws_event_loop_group *native = NULL;
-
-    PyObject *elg_capsule = PyObject_GetAttrString(event_loop_group, "_binding");
-    if (elg_capsule) {
-        native = PyCapsule_GetPointer(elg_capsule, s_capsule_name_elg);
-        assert(native);
-        Py_DECREF(elg_capsule);
-    }
-
-    return native;
+    return aws_py_get_binding(event_loop_group, s_capsule_name_elg);
 }
 
 struct host_resolver_binding {
@@ -248,19 +239,11 @@ resolver_init_failed:
 }
 
 struct aws_host_resolver *aws_py_get_host_resolver(PyObject *host_resolver) {
-    struct aws_host_resolver *native = NULL;
-
-    PyObject *binding_capsule = PyObject_GetAttrString(host_resolver, "_binding");
-    if (binding_capsule) {
-        struct host_resolver_binding *binding = PyCapsule_GetPointer(binding_capsule, s_capsule_name_host_resolver);
-        if (binding) {
-            native = &binding->native;
-            assert(native);
-        }
-        Py_DECREF(binding_capsule);
+    struct host_resolver_binding *binding = aws_py_get_binding(host_resolver, s_capsule_name_host_resolver);
+    if (!binding) {
+        return NULL;
     }
-
-    return native;
+    return &binding->native;
 }
 
 struct client_bootstrap_binding {
@@ -340,20 +323,7 @@ bootstrap_new_failed:
 }
 
 struct aws_client_bootstrap *aws_py_get_client_bootstrap(PyObject *client_bootstrap) {
-    struct aws_client_bootstrap *native = NULL;
-
-    PyObject *binding_capsule = PyObject_GetAttrString(client_bootstrap, "_binding");
-    if (binding_capsule) {
-        struct client_bootstrap_binding *binding =
-            PyCapsule_GetPointer(binding_capsule, s_capsule_name_client_bootstrap);
-        if (binding) {
-            native = binding->native;
-            assert(native);
-        }
-        Py_DECREF(binding_capsule);
-    }
-
-    return native;
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(client_bootstrap, s_capsule_name_client_bootstrap, client_bootstrap_binding);
 }
 
 static void s_tls_ctx_destructor(PyObject *tls_ctx_capsule) {
@@ -472,16 +442,7 @@ ctx_options_failure:
 }
 
 struct aws_tls_ctx *aws_py_get_tls_ctx(PyObject *tls_ctx) {
-    struct aws_tls_ctx *native = NULL;
-
-    PyObject *capsule = PyObject_GetAttrString(tls_ctx, "_binding");
-    if (capsule) {
-        native = PyCapsule_GetPointer(capsule, s_capsule_name_tls_ctx);
-        assert(native);
-        Py_DECREF(capsule);
-    }
-
-    return native;
+    return aws_py_get_binding(tls_ctx, s_capsule_name_tls_ctx);
 }
 
 struct tls_connection_options_binding {
@@ -550,20 +511,12 @@ capsule_new_failed:
 }
 
 struct aws_tls_connection_options *aws_py_get_tls_connection_options(PyObject *tls_connection_options) {
-    struct aws_tls_connection_options *native = NULL;
-
-    PyObject *binding_capsule = PyObject_GetAttrString(tls_connection_options, "_binding");
-    if (binding_capsule) {
-        struct tls_connection_options_binding *binding =
-            PyCapsule_GetPointer(binding_capsule, s_capsule_name_tls_conn_options);
-        if (binding) {
-            native = &binding->native;
-            assert(native);
-        }
-        Py_DECREF(binding_capsule);
+    struct tls_connection_options_binding *binding =
+        aws_py_get_binding(tls_connection_options, s_capsule_name_tls_conn_options);
+    if (!binding) {
+        return NULL;
     }
-
-    return native;
+    return &binding->native;
 }
 
 PyObject *aws_py_tls_connection_options_set_alpn_list(PyObject *self, PyObject *args) {
@@ -793,13 +746,5 @@ PyObject *aws_py_input_stream_new(PyObject *self, PyObject *args) {
 }
 
 struct aws_input_stream *aws_py_get_input_stream(PyObject *input_stream) {
-    struct aws_input_stream *native = NULL;
-
-    PyObject *py_capsule = PyObject_GetAttrString(input_stream, "_binding");
-    if (py_capsule) {
-        native = PyCapsule_GetPointer(py_capsule, s_capsule_name_input_stream);
-        Py_DECREF(py_capsule);
-    }
-
-    return native;
+    return aws_py_get_binding(input_stream, s_capsule_name_input_stream);
 }

--- a/source/io.c
+++ b/source/io.c
@@ -167,7 +167,7 @@ elg_init_failed:
 }
 
 struct aws_event_loop_group *aws_py_get_event_loop_group(PyObject *event_loop_group) {
-    return aws_py_get_binding(event_loop_group, s_capsule_name_elg);
+    return aws_py_get_binding(event_loop_group, s_capsule_name_elg, "EventLoopGroup");
 }
 
 struct host_resolver_binding {
@@ -239,11 +239,8 @@ resolver_init_failed:
 }
 
 struct aws_host_resolver *aws_py_get_host_resolver(PyObject *host_resolver) {
-    struct host_resolver_binding *binding = aws_py_get_binding(host_resolver, s_capsule_name_host_resolver);
-    if (!binding) {
-        return NULL;
-    }
-    return &binding->native;
+    AWS_PY_RETURN_NATIVE_REF_FROM_BINDING(
+        host_resolver, s_capsule_name_host_resolver, "HostResolverBase", host_resolver_binding);
 }
 
 struct client_bootstrap_binding {
@@ -323,7 +320,8 @@ bootstrap_new_failed:
 }
 
 struct aws_client_bootstrap *aws_py_get_client_bootstrap(PyObject *client_bootstrap) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(client_bootstrap, s_capsule_name_client_bootstrap, client_bootstrap_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(
+        client_bootstrap, s_capsule_name_client_bootstrap, "ClientBootstrap", client_bootstrap_binding);
 }
 
 static void s_tls_ctx_destructor(PyObject *tls_ctx_capsule) {
@@ -442,7 +440,7 @@ ctx_options_failure:
 }
 
 struct aws_tls_ctx *aws_py_get_tls_ctx(PyObject *tls_ctx) {
-    return aws_py_get_binding(tls_ctx, s_capsule_name_tls_ctx);
+    return aws_py_get_binding(tls_ctx, s_capsule_name_tls_ctx, "TlsContextBase");
 }
 
 struct tls_connection_options_binding {
@@ -511,12 +509,11 @@ capsule_new_failed:
 }
 
 struct aws_tls_connection_options *aws_py_get_tls_connection_options(PyObject *tls_connection_options) {
-    struct tls_connection_options_binding *binding =
-        aws_py_get_binding(tls_connection_options, s_capsule_name_tls_conn_options);
-    if (!binding) {
-        return NULL;
-    }
-    return &binding->native;
+    AWS_PY_RETURN_NATIVE_REF_FROM_BINDING(
+        tls_connection_options,
+        s_capsule_name_tls_conn_options,
+        "TlsConnectionOptions",
+        tls_connection_options_binding);
 }
 
 PyObject *aws_py_tls_connection_options_set_alpn_list(PyObject *self, PyObject *args) {
@@ -746,5 +743,5 @@ PyObject *aws_py_input_stream_new(PyObject *self, PyObject *args) {
 }
 
 struct aws_input_stream *aws_py_get_input_stream(PyObject *input_stream) {
-    return aws_py_get_binding(input_stream, s_capsule_name_input_stream);
+    return aws_py_get_binding(input_stream, s_capsule_name_input_stream, "InputStream");
 }

--- a/source/module.c
+++ b/source/module.c
@@ -228,26 +228,38 @@ PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf) {
 #endif /* PY_MAJOR_VERSION */
 }
 
-void *aws_py_get_binding(PyObject *obj, const char *capsule_name) {
-    if (!obj) {
-        return PyErr_Format(PyExc_TypeError, "'NULL' object has no attribute '_binding'");
+void *aws_py_get_binding(PyObject *obj, const char *capsule_name, const char *class_name) {
+    if (!obj || obj == Py_None) {
+        return PyErr_Format(PyExc_TypeError, "Excepted '%s', received 'NoneType'");
     }
 
     PyObject *py_binding = PyObject_GetAttrString(obj, "_binding"); /* new reference */
     if (!py_binding) {
-        return PyErr_Format(PyExc_AttributeError, "'%s' object has no attribute '_binding'", Py_TYPE(obj)->tp_name);
+        return PyErr_Format(
+            PyExc_AttributeError,
+            "Expected valid '%s', received '%s' (no '_binding' attribute)",
+            class_name,
+            Py_TYPE(obj)->tp_name);
     }
 
     void *binding = NULL;
     if (!PyCapsule_CheckExact(py_binding)) {
-        PyErr_Format(PyExc_TypeError, "'_binding' must be a capsule, not '%s'", Py_TYPE(py_binding)->tp_name);
+        PyErr_Format(
+            PyExc_TypeError,
+            "Expected valid '%s', received '%s' ('_binding' attribute is not a capsule)",
+            class_name,
+            Py_TYPE(obj)->tp_name);
         goto done;
     }
 
     binding = PyCapsule_GetPointer(py_binding, capsule_name);
     if (!binding) {
         PyErr_Format(
-            PyExc_TypeError, "'_binding' must contain '%s', not '%s'", capsule_name, PyCapsule_GetName(py_binding));
+            PyExc_TypeError,
+            "Expected valid '%s', received '%s' ('_binding' attribute does not contain '%s')",
+            class_name,
+            Py_TYPE(obj)->tp_name,
+            capsule_name);
         goto done;
     }
 

--- a/source/module.c
+++ b/source/module.c
@@ -230,7 +230,7 @@ PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf) {
 
 void *aws_py_get_binding(PyObject *obj, const char *capsule_name, const char *class_name) {
     if (!obj || obj == Py_None) {
-        return PyErr_Format(PyExc_TypeError, "Excepted '%s', received 'NoneType'");
+        return PyErr_Format(PyExc_TypeError, "Excepted '%s', received 'NoneType'", class_name);
     }
 
     PyObject *py_binding = PyObject_GetAttrString(obj, "_binding"); /* new reference */

--- a/source/module.c
+++ b/source/module.c
@@ -229,31 +229,25 @@ PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf) {
 }
 
 void *aws_py_get_binding(PyObject *obj, const char *capsule_name) {
-    AWS_FATAL_ASSERT(obj);
+    if (!obj) {
+        return PyErr_Format(PyExc_TypeError, "'NULL' object has no attribute '_binding'");
+    }
 
     PyObject *py_binding = PyObject_GetAttrString(obj, "_binding"); /* new reference */
     if (!py_binding) {
-        return PyErr_Format(PyExc_AttributeError, "'%s' object has no attribute '_bindings'", Py_TYPE(obj)->tp_name);
+        return PyErr_Format(PyExc_AttributeError, "'%s' object has no attribute '_binding'", Py_TYPE(obj)->tp_name);
     }
 
     void *binding = NULL;
     if (!PyCapsule_CheckExact(py_binding)) {
-        PyErr_Format(
-            PyExc_TypeError,
-            "'%s._binding must be a capsule, not '%s'",
-            Py_TYPE(obj)->tp_name,
-            Py_TYPE(py_binding)->tp_name);
+        PyErr_Format(PyExc_TypeError, "'_binding' must be a capsule, not '%s'", Py_TYPE(py_binding)->tp_name);
         goto done;
     }
 
     binding = PyCapsule_GetPointer(py_binding, capsule_name);
     if (!binding) {
         PyErr_Format(
-            PyExc_TypeError,
-            "'%s._binding' must contain '%s', not '%s'",
-            Py_TYPE(obj)->tp_name,
-            capsule_name,
-            PyCapsule_GetName(py_binding));
+            PyExc_TypeError, "'_binding' must contain '%s', not '%s'", capsule_name, PyCapsule_GetName(py_binding));
         goto done;
     }
 

--- a/source/module.h
+++ b/source/module.h
@@ -69,4 +69,27 @@ PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf);
 /* Allocator that calls into PyObject_[Malloc|Free|Realloc] */
 struct aws_allocator *aws_py_get_allocator(void);
 
+/* Return the capsule contents of obj._binding
+ * On error, NULL is returned and a python exception is set.
+ * This should be used ONLY be used by other aws_py_get_XYZ() functions */
+void *aws_py_get_binding(PyObject *obj, const char *capsule_name);
+
+/* Contents of an aws_py_get_XYZ() function where a binding struct is used */
+#define AWS_PY_RETURN_BINDING_ARROW_NATIVE(PYOBJ, CAPSULE_NAME, BINDING_TYPE)                                          \
+    struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME));                                        \
+    if (binding) {                                                                                                     \
+        if (binding->native) {                                                                                         \
+            return binding->native;                                                                                    \
+        }                                                                                                              \
+        PyErr_Format(PyExc_TypeError, "%s._binding.native is NULL", Py_TYPE(PYOBJ)->tp_name);                          \
+    }                                                                                                                  \
+    return NULL;
+
+#define AWS_PY_RETURN_BINDING_DOT_NATIVE(PYOBJ, CAPSULE_NAME, BINDING_TYPE)                                            \
+    struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME));                                        \
+    if (binding) {                                                                                                     \
+        return &binding.native;                                                                                        \
+    }                                                                                                                  \
+    return NULL;
+
 #endif /* AWS_CRT_PYTHON_MODULE_H */

--- a/source/module.h
+++ b/source/module.h
@@ -71,18 +71,26 @@ struct aws_allocator *aws_py_get_allocator(void);
 
 /* Return the capsule ptr from obj._binding
  * On error, NULL is returned and a python exception is set. */
-void *aws_py_get_binding(PyObject *obj, const char *capsule_name);
+void *aws_py_get_binding(PyObject *obj, const char *capsule_name, const char *class_name);
 
 /* Contents of aws_py_get_XYZ() function where obj._binding->native is returned.
  * NOTE: only works where native is stored by ptr. */
-#define AWS_PY_RETURN_NATIVE_FROM_BINDING(PYOBJ, CAPSULE_NAME, BINDING_TYPE)                                           \
-    struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME));                                        \
+#define AWS_PY_RETURN_NATIVE_FROM_BINDING(PYOBJ, CAPSULE_NAME, CLASS_NAME, BINDING_TYPE)                               \
+    struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME), (CLASS_NAME));                          \
     if (binding) {                                                                                                     \
         if (binding->native) {                                                                                         \
             return binding->native;                                                                                    \
         }                                                                                                              \
-        PyErr_Format(PyExc_TypeError, "%s._binding.native is NULL", Py_TYPE(PYOBJ)->tp_name);                          \
+        PyErr_Format(PyExc_TypeError, "Expected valid '%s', but '_binding.native' is NULL", (CLASS_NAME));             \
     }                                                                                                                  \
-    return NULL;
+    return NULL
+
+/* Shorthand for `return &obj._binding->native;` */
+#define AWS_PY_RETURN_NATIVE_REF_FROM_BINDING(PYOBJ, CAPSULE_NAME, CLASS_NAME, BINDING_TYPE)                           \
+    struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME), (CLASS_NAME));                          \
+    if (!binding) {                                                                                                    \
+        return NULL;                                                                                                   \
+    }                                                                                                                  \
+    return &binding->native
 
 #endif /* AWS_CRT_PYTHON_MODULE_H */

--- a/source/module.h
+++ b/source/module.h
@@ -69,26 +69,19 @@ PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf);
 /* Allocator that calls into PyObject_[Malloc|Free|Realloc] */
 struct aws_allocator *aws_py_get_allocator(void);
 
-/* Return the capsule contents of obj._binding
- * On error, NULL is returned and a python exception is set.
- * This should be used ONLY be used by other aws_py_get_XYZ() functions */
+/* Return the capsule ptr from obj._binding
+ * On error, NULL is returned and a python exception is set. */
 void *aws_py_get_binding(PyObject *obj, const char *capsule_name);
 
-/* Contents of an aws_py_get_XYZ() function where a binding struct is used */
-#define AWS_PY_RETURN_BINDING_ARROW_NATIVE(PYOBJ, CAPSULE_NAME, BINDING_TYPE)                                          \
+/* Contents of aws_py_get_XYZ() function where obj._binding->native is returned.
+ * NOTE: only works where native is stored by ptr. */
+#define AWS_PY_RETURN_NATIVE_FROM_BINDING(PYOBJ, CAPSULE_NAME, BINDING_TYPE)                                           \
     struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME));                                        \
     if (binding) {                                                                                                     \
         if (binding->native) {                                                                                         \
             return binding->native;                                                                                    \
         }                                                                                                              \
         PyErr_Format(PyExc_TypeError, "%s._binding.native is NULL", Py_TYPE(PYOBJ)->tp_name);                          \
-    }                                                                                                                  \
-    return NULL;
-
-#define AWS_PY_RETURN_BINDING_DOT_NATIVE(PYOBJ, CAPSULE_NAME, BINDING_TYPE)                                            \
-    struct BINDING_TYPE *binding = aws_py_get_binding((PYOBJ), (CAPSULE_NAME));                                        \
-    if (binding) {                                                                                                     \
-        return &binding.native;                                                                                        \
     }                                                                                                                  \
     return NULL;
 

--- a/source/mqtt_client.c
+++ b/source/mqtt_client.c
@@ -87,9 +87,5 @@ client_init_failed:
 }
 
 struct aws_mqtt_client *aws_py_get_mqtt_client(PyObject *mqtt_client) {
-    struct mqtt_client_binding *binding = aws_py_get_binding(mqtt_client, s_capsule_name_mqtt_client);
-    if (!binding) {
-        return NULL;
-    }
-    return &binding->native;
+    AWS_PY_RETURN_NATIVE_REF_FROM_BINDING(mqtt_client, s_capsule_name_mqtt_client, "Client", mqtt_client_binding);
 }

--- a/source/mqtt_client.c
+++ b/source/mqtt_client.c
@@ -87,17 +87,9 @@ client_init_failed:
 }
 
 struct aws_mqtt_client *aws_py_get_mqtt_client(PyObject *mqtt_client) {
-    struct aws_mqtt_client *native = NULL;
-
-    PyObject *binding_capsule = PyObject_GetAttrString(mqtt_client, "_binding");
-    if (binding_capsule) {
-        struct mqtt_client_binding *binding = PyCapsule_GetPointer(binding_capsule, s_capsule_name_mqtt_client);
-        if (binding) {
-            native = &binding->native;
-            assert(native);
-        }
-        Py_DECREF(binding_capsule);
+    struct mqtt_client_binding *binding = aws_py_get_binding(mqtt_client, s_capsule_name_mqtt_client);
+    if (!binding) {
+        return NULL;
     }
-
-    return native;
+    return &binding->native;
 }

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -203,20 +203,7 @@ connection_new_failed:
 }
 
 struct aws_mqtt_client_connection *aws_py_get_mqtt_client_connection(PyObject *mqtt_connection) {
-    struct aws_mqtt_client_connection *native = NULL;
-
-    PyObject *binding_capsule = PyObject_GetAttrString(mqtt_connection, "_binding");
-    if (binding_capsule) {
-        struct mqtt_connection_binding *binding =
-            PyCapsule_GetPointer(binding_capsule, s_capsule_name_mqtt_client_connection);
-        if (binding) {
-            native = binding->native;
-            assert(native);
-        }
-        Py_DECREF(binding_capsule);
-    }
-
-    return native;
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(mqtt_connection, s_capsule_name_mqtt_client_connection, mqtt_connection_binding);
 }
 
 /*******************************************************************************

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -203,7 +203,8 @@ connection_new_failed:
 }
 
 struct aws_mqtt_client_connection *aws_py_get_mqtt_client_connection(PyObject *mqtt_connection) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(mqtt_connection, s_capsule_name_mqtt_client_connection, mqtt_connection_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(
+        mqtt_connection, s_capsule_name_mqtt_client_connection, "Connection", mqtt_connection_binding);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
I used to think PyObject_GetAttrString() set an exception when returning NULL, but it does not.

So go through and make sure we set an exception where necessary. This mostly effects the aws_py_get_XYZ() functions, which are super copy-pasty, so replace their implementations with helper functions/macros that have great error messages while I'm at it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
