### PR TITLE
AwsCrtError class instead of error_code ints

### DIFF
--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 import _awscrt
 from awscrt import isinstance_str, NativeResource
+import awscrt.exceptions
 from awscrt.http import HttpRequest
 from awscrt.io import ClientBootstrap
 from concurrent.futures import Future
@@ -143,7 +144,7 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
         def _on_complete(error_code, access_key_id, secret_access_key, session_token):
             try:
                 if error_code:
-                    future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
+                    future.set_exception(awscrt.exceptions.from_code(error_code))
                 else:
                     credentials = AwsCredentials(access_key_id, secret_access_key, session_token)
                     future.set_result(credentials)
@@ -334,7 +335,7 @@ def aws_sign_request(http_request, signing_config):
     def _on_complete(error_code):
         try:
             if error_code:
-                future.set_exception(Exception(error_code))  # TODO: Actual exceptions for error_codes
+                future.set_exception(awscrt.exceptions.from_code(error_code))
             else:
                 future.set_result(http_request)
         except Exception as e:

--- a/awscrt/exceptions.py
+++ b/awscrt/exceptions.py
@@ -41,5 +41,5 @@ class AwsCrtError(Exception):
         self.message = message
 
     def __repr__(self):
-        return "{}(code={}, name={}, message={})".format(
-            self.__class__.__name__, self.code, repr(self.name), repr(self.message))
+        return "{0}(name={1}, message={2}, code={3})".format(
+            self.__class__.__name__, repr(self.name), repr(self.message), self.code)

--- a/awscrt/exceptions.py
+++ b/awscrt/exceptions.py
@@ -43,3 +43,6 @@ class AwsCrtError(Exception):
     def __repr__(self):
         return "{0}(name={1}, message={2}, code={3})".format(
             self.__class__.__name__, repr(self.name), repr(self.message), self.code)
+
+    def __str__(self):
+        return self.__repr__()

--- a/awscrt/exceptions.py
+++ b/awscrt/exceptions.py
@@ -1,0 +1,45 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import _awscrt
+
+
+def from_code(code):
+    """Given an AWS Common Runtime error-code, return an exception"""
+    builtin = _awscrt.get_corresponding_builtin_exception(code)
+    if builtin:
+        return builtin()
+
+    name = _awscrt.get_error_name(code)
+    msg = _awscrt.get_error_message(code)
+    return AwsCrtError(code=code, name=name, message=msg)
+
+
+class AwsCrtError(Exception):
+    """
+    Base exception class for AWS Common Runtime exceptions.
+
+    Attributes:
+        code (int): Int value of error.
+        name (str): Name of error.
+        message (str): Message about error.
+    """
+
+    def __init__(self, code, name, message):
+        self.code = code
+        self.name = name
+        self.message = message
+
+    def __repr__(self):
+        return "{}(code={}, name={}, message={})".format(
+            self.__class__.__name__, self.code, repr(self.name), repr(self.message))

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -124,8 +124,8 @@ if scheme == 'https':
         tls_connection_options.set_alpn_list(args.alpn)
 
 # invoked up on the connection closing
-def on_connection_shutdown(err_code):
-    print('connection close with error code {}'.format(err_code))
+def on_connection_shutdown(shutdown_future):
+    print('connection close with error: {}'.format(shutdown_future.exception())
 
 
 # invoked by the http request call as the response body is received in chunks
@@ -152,7 +152,7 @@ hostname = url.hostname
 connect_future = http.HttpClientConnection.new(hostname, port, socket_options,
                                                tls_connection_options, client_bootstrap)
 connection = connect_future.result(10)
-connection.add_shutdown_callback(on_connection_shutdown)
+connection.shutdown_future.add_done_callback(on_connection_shutdown)
 
 request = http.HttpRequest(args.method, body_stream=data_stream)
 

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -125,7 +125,7 @@ if scheme == 'https':
 
 # invoked up on the connection closing
 def on_connection_shutdown(shutdown_future):
-    print('connection close with error: {}'.format(shutdown_future.exception())
+    print('connection close with error: {}'.format(shutdown_future.exception()))
 
 
 # invoked by the http request call as the response body is received in chunks

--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -34,8 +34,8 @@ parser.add_argument('--root-ca', help="File path to root certificate authority, 
 
 io.init_logging(LogLevel.Trace, 'stderr')
 
-def on_connection_interrupted(connection, error_code):
-    print("Connection has been interrupted with error code", error_code)
+def on_connection_interrupted(connection, error):
+    print("Connection has been interrupted with error", error)
 
 def on_connection_resumed(connection, return_code, session_present):
     print("Connection has been resumed with return code", return_code, "and session present:", session_present)

--- a/source/module.h
+++ b/source/module.h
@@ -29,6 +29,7 @@ struct aws_string;
 
 #if PY_MAJOR_VERSION >= 3
 #    define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#    define PyString_FromString PyUnicode_FromString
 #    define READABLE_BYTES_FORMAT_STR "y#"
 #else
 #    define READABLE_BYTES_FORMAT_STR "s#"
@@ -64,6 +65,16 @@ PyObject *PyErr_AwsLastError(void);
  *
  * The Python error indicator MUST be set and the GIL MUST be held when calling this function. */
 int aws_py_raise_error(void);
+
+/**
+ * Return built-in Python exception type corresponding to an AWS_ERROR_ code.
+ * Ex: AWS_ERROR_OOM -> MemoryError.
+ * Returns None if there is no match.
+ */
+PyObject *aws_py_get_corresponding_builtin_exception(PyObject *self, PyObject *args);
+
+PyObject *aws_py_get_error_name(PyObject *self, PyObject *args);
+PyObject *aws_py_get_error_message(PyObject *self, PyObject *args);
 
 /* Create a write-only memoryview from the remaining free space in an aws_byte_buf */
 PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf);

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,0 +1,33 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import awscrt.exceptions
+import unittest
+
+
+class AwsCrtErrorTest(unittest.TestCase):
+    def test_error_code_conversion(self):
+        err = awscrt.exceptions.from_code(0)
+        self.assertEqual(0, err.code)
+        self.assertEqual("AWS_ERROR_SUCCESS", err.name)
+        self.assertTrue("success" in err.message.lower())
+
+    def test_error_code_remaps_to_corresponding_builtins(self):
+        err = awscrt.exceptions.from_code(1)
+        self.assertEqual(MemoryError, type(err))
+
+    def test_bad_error_code_wont_crash(self):
+        err = awscrt.exceptions.from_code(999999999)
+        self.assertEqual(999999999, err.code)
+        self.assertIsNotNone(err.name)
+        self.assertIsNotNone(err.message)

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -206,6 +206,8 @@ class TestClient(NativeResourceTest):
         shutdown_error = connection.shutdown_future.exception(self.timeout)
         self.assertIsInstance(shutdown_error, awscrt.exceptions.AwsCrtError)
 
+        self._stop_server()
+
     def test_shutdown_error_http(self):
         return self._test_shutdown_error(secure=False)
 

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -119,19 +119,19 @@ class TestClient(NativeResourceTest):
         # register shutdown callback
         shutdown_callback_results = []
 
-        def shutdown_callback(error_code):
-            shutdown_callback_results.append(error_code)
+        def shutdown_callback(error):
+            shutdown_callback_results.append(error)
 
         connection.add_shutdown_callback(shutdown_callback)
 
         # close connection
-        shutdown_error_code_from_close_future = connection.close().result(self.timeout)
+        shutdown_error_from_close_future = connection.close().result(self.timeout)
 
-        # assert that error code was reported via close_future and shutdown callback
-        # error_code should be 0 (normal shutdown)
-        self.assertEqual(0, shutdown_error_code_from_close_future)
+        # assert that error was reported via close_future and shutdown callback
+        # error should be None (normal shutdown)
+        self.assertEqual(None, shutdown_error_from_close_future)
         self.assertEqual(1, len(shutdown_callback_results))
-        self.assertEqual(0, shutdown_callback_results[0])
+        self.assertEqual(None, shutdown_callback_results[0])
         self.assertFalse(connection.is_open())
 
         self._stop_server()
@@ -151,16 +151,16 @@ class TestClient(NativeResourceTest):
         # Subscribing for the shutdown callback shouldn't affect the refcount of the HttpClientConnection.
         close_future = Future()
 
-        def on_close(error_code):
-            close_future.set_result(error_code)
+        def on_close(error):
+            close_future.set_result(error)
 
         connection.add_shutdown_callback(on_close)
 
         # This should cause the GC to collect the HttpClientConnection
         del connection
 
-        close_code = close_future.result(self.timeout)
-        self.assertEqual(0, close_code)
+        close_error = close_future.result(self.timeout)
+        self.assertEqual(None, close_error)
         self._stop_server()
 
     def test_connection_closes_on_zero_refcount_http(self):
@@ -195,7 +195,7 @@ class TestClient(NativeResourceTest):
             test_asset_bytes = test_asset.read()
             self.assertEqual(test_asset_bytes, response.body)
 
-        self.assertEqual(0, connection.close().result(self.timeout))
+        self.assertEqual(None, connection.close().result(self.timeout))
 
         self._stop_server()
 
@@ -234,7 +234,7 @@ class TestClient(NativeResourceTest):
             self.assertIsNotNone(server_received)
             self.assertEqual(server_received, outgoing_body_bytes)
 
-        self.assertEqual(0, connection.close().result(self.timeout))
+        self.assertEqual(None, connection.close().result(self.timeout))
         self._stop_server()
 
     def test_put_http(self):


### PR DESCRIPTION
- Example: `AwsCrtError(name='AWS_IO_SOCKET_CLOSED', message='socket is closed.', code=1051)`
- Remap to built-in python exceptions where possible (Ex: Return `MemoryError` instead of `AwsCrtError(name='AWS_ERROR_OOM')`
- In the future, I still intend to code-gen a class for each AWS_ERROR int, but this is a forwards-compatible stand-in until then (generated classes will all inherit from AwsCrtError).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
