### PR TITLE
mqtt builder

### DIFF
--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -70,10 +70,15 @@ def _builder(
     elif ca_filepath or ca_dirpath:
         tls_ctx_options.override_default_trust_store_from_path(ca_dirpath, ca_filepath)
 
-    port = 443 if use_websockets else 8883
-    if awscrt.io.is_alpn_available():
+    if use_websockets:
         port = 443
-        tls_ctx_options.alpn_list = ['x-amzn-mqtt-ca']
+        if awscrt.io.is_alpn_available():
+            tls_ctx_options.alpn_list = ['http/1.1']
+    else:
+        port = 8883
+        if awscrt.io.is_alpn_available():
+            port = 443
+            tls_ctx_options.alpn_list = ['x-amzn-mqtt-ca']
 
     port = kwargs.get('port', port)
 

--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -15,7 +15,6 @@ import awscrt.auth
 import awscrt.io
 import awscrt.mqtt
 
-
 """
 Required Arguments:
     endpoint
@@ -52,7 +51,26 @@ Optional Arguments:
 def _check_required_kwargs(**kwargs):
     for required in ['client_bootstrap', 'endpoint', 'client_id']:
         if not kwargs.get(required):
-            raise TypeError("Builder needs keyword-only argument 'client_bootstrap'")
+            raise TypeError("Builder needs keyword-only argument '{}'".format(required))
+
+
+_metrics_str = None
+
+
+def _get_metrics_str():
+    global _metrics_str
+    if _metrics_str is None:
+        try:
+            import pkg_resources
+            try:
+                version = pkg_resources.get_distribution("awscrt").version
+                _metrics_str = "?SDK=PythonV2&Version={}".format(version)
+            except pkg_resources.DistributionNotFound:
+                _metrics_str = "?SDK=PythonV2&Version=dev"
+        except BaseException:
+            _metrics_str = ""
+
+    return _metrics_str
 
 
 def _builder(
@@ -91,9 +109,7 @@ def _builder(
 
     username = kwargs.get('username', '')
     if kwargs.get('enable_metrics_collection', True):
-        username += '?SDK=PythonV2&Version=0.4.1'  # TODO: read version from somewhere. pkg_resources?
-
-    # TODO: auto resubscribe for them via callback interception
+        username += _get_metrics_str()
 
     client_bootstrap = kwargs.get('client_bootstrap')
     tls_ctx = awscrt.io.ClientTlsContext(tls_ctx_options)

--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -1,0 +1,167 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import awscrt.auth
+import awscrt.io
+import awscrt.mqtt
+
+
+"""
+Required Arguments:
+    endpoint
+    client_bootstrap
+    client_id
+
+Optional Arguments:
+    ca_filepath,
+    ca_dirpath,
+    ca_bytes,
+
+    port
+    on_connection_interrupted
+    on_connection_resumed
+    reconnect_min_timeout_secs
+    reconnect_max_timeout_secs
+    clean_session
+    keep_alive_secs
+    ping_timeout_ms
+    will
+    username
+    password
+
+    tcp_connect_timeout_ms: 3000 (3 seconds) by default
+    tcp_keepalive
+    tcp_keepalive_timeout_secs
+    tcp_keepalive_interval_secs
+    tcp_keepalive_max_probes
+
+    enable_metrics_collection
+"""
+
+
+def _check_required_kwargs(**kwargs):
+    for required in ['client_bootstrap', 'endpoint', 'client_id']:
+        if not kwargs.get(required):
+            raise TypeError("Builder needs keyword-only argument 'client_bootstrap'")
+
+
+def _builder(
+        tls_ctx_options,
+        use_websockets=False,
+        websocket_handshake_transform=None,
+        websocket_proxy_options=None,
+        **kwargs):
+
+    ca_bytes = kwargs.get('ca_bytes')
+    ca_filepath = kwargs.get('ca_filepath')
+    ca_dirpath = kwargs.get('ca_dirpath')
+    if ca_bytes:
+        tls_ctx_options.override_default_trust_store(ca_bytes)
+    elif ca_filepath or ca_dirpath:
+        tls_ctx_options.override_default_trust_store_from_path(ca_dirpath, ca_filepath)
+
+    port = 443 if use_websockets else 8883
+    if awscrt.io.is_alpn_available():
+        port = 443
+        tls_ctx_options.alpn_list = ['x-amzn-mqtt-ca']
+
+    port = kwargs.get('port', port)
+
+    socket_options = awscrt.io.SocketOptions()
+    socket_options.connect_timeout_ms = kwargs.get('tcp_connect_timeout_ms', 3000)
+    socket_options.keep_alive = kwargs.get('tcp_keepalive', False)
+    socket_options.keep_alive_timeout_secs = kwargs.get('tcp_keepalive_timeout_secs', 0)
+    socket_options.keep_alive_interval_secs = kwargs.get('tcp_keep_alive_interval_secs', 0)
+    socket_options.keep_alive_max_probes = kwargs.get('tcp_keep_alive_max_probes', 0)
+
+    username = kwargs.get('username', '')
+    if kwargs.get('enable_metrics_collection', True):
+        username += '?SDK=PythonV2&Version=0.4.1'  # TODO: read version from somewhere. pkg_resources?
+
+    # TODO: auto resubscribe for them via callback interception
+
+    client_bootstrap = kwargs.get('client_bootstrap')
+    tls_ctx = awscrt.io.ClientTlsContext(tls_ctx_options)
+    mqtt_client = awscrt.mqtt.Client(client_bootstrap, tls_ctx)
+
+    return awscrt.mqtt.Connection(
+        client=mqtt_client,
+        on_connection_interrupted=kwargs.get('on_connection_interrupted'),
+        on_connection_resumed=kwargs.get('on_connection_resumed'),
+        client_id=kwargs.get('client_id'),
+        host_name=kwargs.get('endpoint'),
+        port=port,
+        clean_session=kwargs.get('clean_session', False),
+        reconnect_min_timeout_secs=kwargs.get('reconnect_min_timeout_secs', 5),
+        reconnect_max_timeout_secs=kwargs.get('reconnect_max_timeout_secs', 60),
+        keep_alive_secs=kwargs.get('keep_alive_secs', 3600),
+        ping_timeout_ms=kwargs.get('ping_timeout_ms', 3000),
+        will=kwargs.get('will'),
+        username=username,
+        password=kwargs.get('password'),
+        socket_options=socket_options,
+        use_websockets=use_websockets,
+        websocket_handshake_transform=websocket_handshake_transform,
+        websocket_proxy_options=websocket_proxy_options,
+    )
+
+
+def mtls_from_path(cert_filepath, pri_key_filepath, **kwargs):
+    _check_required_kwargs(**kwargs)
+    tls_ctx_options = awscrt.io.TlsContextOptions.create_client_with_mtls_from_path(cert_filepath, pri_key_filepath)
+    return _builder(tls_ctx_options, **kwargs)
+
+
+def mtls_from_bytes(cert_bytes, pri_key_bytes, **kwargs):
+    _check_required_kwargs(**kwargs)
+    tls_ctx_options = awscrt.io.TlsContextOptions.create_client_with_mtls(cert_bytes, pri_key_bytes)
+    return _builder(tls_ctx_options, **kwargs)
+
+
+def websockets_with_default_aws_signing(region, credentials_provider=None, websocket_proxy_options=None, **kwargs):
+    _check_required_kwargs(**kwargs)
+
+    if credentials_provider is None:
+        credentials_provider = awscrt.auth.AwsCredentialsProvider.new_default_chain(kwargs.get('client_bootstrap'))
+
+    def _should_sign_params(name):
+        blacklist = ['x-amz-date', 'x-amz-security-token']
+        return not (name.lower() in blacklist)
+
+    def _sign_websocket_handshake_request(handshake_args):
+        # handshake_args need to know when transform is done
+        try:
+            signing_config = awscrt.auth.AwsSigningConfig(
+                algorithm=awscrt.auth.AwsSigningAlgorithm.SigV4QueryParam,
+                credentials_provider=credentials_provider,
+                region=region,
+                service='iotdevicegateway',
+                should_sign_param=_should_sign_param,
+                sign_body=False)
+
+            signing_future = awscrt.auth.aws_sign_request(handshake_args.http_request, signing_config)
+            signing_future.add_done_callback(lambda x: handshake_args.set_done(x.exception()))
+        except Exception as e:
+            handshake_args.set_done(e)
+
+    return websockets_with_custom_handshake(_sign_websocket_handshake_request, websocket_proxy_options, **kwargs)
+
+
+def websockets_with_custom_handshake(websocket_handshake_transform, websocket_proxy_options=None, **kwargs):
+    _check_required_kwargs(**kwargs)
+    tls_ctx_options = awscrt.io.TlsContextOptions()
+    return _builder(tls_ctx_options=tls_ctx_options,
+                    use_websockets=True,
+                    websocket_handshake_transform=websocket_handshake_transform,
+                    websocket_proxy_options=websocket_proxy_options,
+                    **kwargs)

--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -4,7 +4,7 @@ The following arguments are common to all builder functions:
 
 Required Arguments:
 
-    endpoint (str): Name of AWS IoT endpoint.
+    endpoint (str): Host name of AWS IoT server.
 
     client_bootstrap (awscrt.io.ClientBootstrap): Client bootstrap used to establish connection.
 
@@ -56,7 +56,9 @@ Optional Arguments:
 
     password (str): Password to connect with.
 
-    port (int): Override the default port number on the server to connect to.
+    port (int): Override default server port.
+            Default port is 443 if system supports ALPN or websockets are being used.
+            Otherwise, default port is 8883.
 
     tcp_connect_timeout_ms (int): Milliseconds to wait for TCP connect response. Default is 3000ms (3 seconds).
 

--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -134,7 +134,7 @@ def websockets_with_default_aws_signing(region, credentials_provider=None, webso
     if credentials_provider is None:
         credentials_provider = awscrt.auth.AwsCredentialsProvider.new_default_chain(kwargs.get('client_bootstrap'))
 
-    def _should_sign_params(name):
+    def _should_sign_param(name):
         blacklist = ['x-amz-date', 'x-amz-security-token']
         return not (name.lower() in blacklist)
 

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -67,8 +67,6 @@ class Client(NativeResource):
 
 
 class Connection(NativeResource):
-    """ TODO: document all attributes """
-
     def __init__(self,
                  client,
                  host_name,
@@ -224,11 +222,6 @@ class Connection(NativeResource):
                 transform_args.set_done(e)
 
     def connect(self):
-        """
-        All arguments to connect() are deprecated.
-        Set these properties on the instance before calling connect().
-        """
-
         future = Future()
 
         def on_connect(error_code, return_code, session_present):

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 
 import _awscrt
-import warnings
 from concurrent.futures import Future
 from enum import IntEnum
 from awscrt import NativeResource

--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -97,13 +97,13 @@ mqtt_client = mqtt.Client(client_bootstrap, tls_context)
 print("Connecting to {}:{} with client-id:{}".format(args.endpoint, port, CLIENT_ID))
 mqtt_connection = mqtt.Connection(
     client=mqtt_client,
+    host_name=args.endpoint,
+    port=port,
+    client_id=CLIENT_ID,
     on_connection_interrupted=on_connection_interrupted,
     on_connection_resumed=on_connection_resumed)
 
-connect_results = mqtt_connection.connect(
-    client_id=CLIENT_ID,
-    host_name=args.endpoint,
-    port=port).result(TIMEOUT)
+connect_results = mqtt_connection.connect().result(TIMEOUT)
 assert(connect_results['session_present'] == False)
 
 # Subscribe

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -173,7 +173,6 @@ PyObject *aws_py_mqtt_client_connection_new(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    printf("got here A\n");
     /* From hereon, we need to clean up if errors occur */
 
     py_connection->native = aws_mqtt_client_connection_new(client);
@@ -192,7 +191,6 @@ PyObject *aws_py_mqtt_client_connection_new(PyObject *self, PyObject *args) {
         PyErr_SetAwsLastError();
         goto set_interruption_failed;
     }
-    printf("got here B\n");
 
     if (PyObject_IsTrue(use_websocket_py)) {
         if (aws_mqtt_client_connection_use_websockets(
@@ -206,7 +204,6 @@ PyObject *aws_py_mqtt_client_connection_new(PyObject *self, PyObject *args) {
             goto use_websockets_failed;
         }
     }
-    printf("got here C\n");
 
     PyObject *self_proxy = PyWeakref_NewProxy(self_py, NULL);
     if (!self_proxy) {

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 from __future__ import absolute_import
+from awscrt import awsiot_mqtt_connection_builder
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions, LogLevel, init_logging
 from awscrt.mqtt import Client, Connection, QoS
 from test import NativeResourceTest
@@ -20,9 +21,12 @@ import os
 import unittest
 import boto3
 import botocore.exceptions
+import tempfile
 import time
 import uuid
 import warnings
+
+TIMEOUT = 10.0
 
 
 class MqttClientTest(NativeResourceTest):
@@ -33,13 +37,15 @@ class MqttClientTest(NativeResourceTest):
 class Config:
     cache = None
 
-    def __init__(self, endpoint, cert, key):
+    def __init__(self, endpoint, cert, key, region):
         self.cert = cert
         self.key = key
         self.endpoint = endpoint
+        self.region = region
 
     @staticmethod
     def get():
+        """Raises SkipTest if credentials aren't set up correctly"""
         if Config.cache:
             return Config.cache
 
@@ -50,39 +56,47 @@ class Config:
         except NameError:  # Python 2 has no ResourceWarning
             pass
 
-        secrets = boto3.client('secretsmanager')
-        response = secrets.get_secret_value(SecretId='unit-test/endpoint')
-        endpoint = response['SecretString']
-        response = secrets.get_secret_value(SecretId='unit-test/certificate')
-        cert = response['SecretString'].encode('utf8')
-        response = secrets.get_secret_value(SecretId='unit-test/privatekey')
-        key = response['SecretString'].encode('utf8')
-        Config.cache = Config(endpoint, cert, key)
+        try:
+            secrets = boto3.client('secretsmanager')
+            response = secrets.get_secret_value(SecretId='unit-test/endpoint')
+            endpoint = response['SecretString']
+            response = secrets.get_secret_value(SecretId='unit-test/certificate')
+            cert = response['SecretString'].encode('utf8')
+            response = secrets.get_secret_value(SecretId='unit-test/privatekey')
+            key = response['SecretString'].encode('utf8')
+            region = secrets.meta.region_name
+            Config.cache = Config(endpoint, cert, key, region)
+        except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as ex:
+            raise unittest.SkipTest("No credentials")
+
         return Config.cache
+
+
+def create_client_id():
+    return 'aws-crt-python-unit-test-{0}'.format(uuid.uuid4())
 
 
 class MqttConnectionTest(NativeResourceTest):
     TEST_TOPIC = '/test/me/senpai'
     TEST_MSG = 'NOTICE ME!'.encode('utf8')
-    TIMEOUT = 10.0
 
     def _test_connection(self):
-        try:
-            config = Config.get()
-        except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as ex:
-            return self.skipTest("No credentials")
+        config = Config.get()
 
         tls_opts = TlsContextOptions.create_client_with_mtls(config.cert, config.key)
         tls = ClientTlsContext(tls_opts)
         client = Client(ClientBootstrap(EventLoopGroup()), tls)
-        connection = Connection(client)
-        connection.connect('aws-crt-python-unit-test-{0}'.format(uuid.uuid4()),
-                           config.endpoint, 8883).result(self.TIMEOUT)
+        connection = Connection(
+            client=client,
+            client_id=create_client_id(),
+            host_name=config.endpoint,
+            port=8883)
+        connection.connect().result(TIMEOUT)
         return connection
 
     def test_connect_disconnect(self):
         connection = self._test_connection()
-        connection.disconnect().result(self.TIMEOUT)
+        connection.disconnect().result(TIMEOUT)
 
     def test_pub_sub(self):
         connection = self._test_connection()
@@ -93,28 +107,28 @@ class MqttConnectionTest(NativeResourceTest):
 
         # subscribe
         subscribed, packet_id = connection.subscribe(self.TEST_TOPIC, QoS.AT_LEAST_ONCE, on_message)
-        suback = subscribed.result(self.TIMEOUT)
+        suback = subscribed.result(TIMEOUT)
         self.assertEqual(packet_id, suback['packet_id'])
         self.assertEqual(self.TEST_TOPIC, suback['topic'])
         self.assertIs(QoS.AT_LEAST_ONCE, suback['qos'])
 
         # publish
         published, packet_id = connection.publish(self.TEST_TOPIC, self.TEST_MSG, QoS.AT_LEAST_ONCE)
-        puback = published.result(self.TIMEOUT)
+        puback = published.result(TIMEOUT)
         self.assertEqual(packet_id, puback['packet_id'])
 
         # receive message
-        rcv_topic, rcv_payload = received.result(self.TIMEOUT)
+        rcv_topic, rcv_payload = received.result(TIMEOUT)
         self.assertEqual(self.TEST_TOPIC, rcv_topic)
         self.assertEqual(self.TEST_MSG, rcv_payload)
 
         # unsubscribe
         unsubscribed, packet_id = connection.unsubscribe(self.TEST_TOPIC)
-        unsuback = unsubscribed.result(self.TIMEOUT)
+        unsuback = unsubscribed.result(TIMEOUT)
         self.assertEqual(packet_id, unsuback['packet_id'])
 
         # disconnect
-        connection.disconnect().result(self.TIMEOUT)
+        connection.disconnect().result(TIMEOUT)
 
     def test_on_message(self):
         connection = self._test_connection()
@@ -127,19 +141,71 @@ class MqttConnectionTest(NativeResourceTest):
 
         # subscribe without callback
         subscribed, packet_id = connection.subscribe(self.TEST_TOPIC, QoS.AT_LEAST_ONCE)
-        subscribed.result(self.TIMEOUT)
+        subscribed.result(TIMEOUT)
 
         # publish
         published, packet_id = connection.publish(self.TEST_TOPIC, self.TEST_MSG, QoS.AT_LEAST_ONCE)
-        puback = published.result(self.TIMEOUT)
+        puback = published.result(TIMEOUT)
 
         # receive message
-        rcv_topic, rcv_payload = received.result(self.TIMEOUT)
+        rcv_topic, rcv_payload = received.result(TIMEOUT)
         self.assertEqual(self.TEST_TOPIC, rcv_topic)
         self.assertEqual(self.TEST_MSG, rcv_payload)
 
         # disconnect
-        connection.disconnect().result(self.TIMEOUT)
+        connection.disconnect().result(TIMEOUT)
+
+
+class MqttBuilderTest(unittest.TestCase):# DO NOT COMMIT THIS LINE (NativeResourceTest):
+    def _create_bootstrap(self):
+        elg = EventLoopGroup(1)
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        return bootstrap
+
+    def _test_connection(self, connection):
+        connection.connect().result(TIMEOUT)
+        connection.disconnect().result(TIMEOUT)
+
+    def test_mtls_from_bytes(self):
+        config = Config.get()
+        connection = awsiot_mqtt_connection_builder.mtls_from_bytes(
+            cert_bytes=config.cert,
+            pri_key_bytes=config.key,
+            endpoint=config.endpoint,
+            client_id=create_client_id(),
+            client_bootstrap=self._create_bootstrap())
+        self._test_connection(connection)
+
+    def test_mtls_from_path(self):
+        config = Config.get()
+
+        # test "from path" builder by writing secrets to tempfiles
+        with tempfile.NamedTemporaryFile() as cert_file:
+            with tempfile.NamedTemporaryFile() as key_file:
+                cert_file.write(config.cert)
+                cert_file.flush()
+
+                key_file.write(config.key)
+                key_file.flush()
+
+                connection = awsiot_mqtt_connection_builder.mtls_from_path(
+                    cert_filepath=cert_file.name,
+                    pri_key_filepath=key_file.name,
+                    endpoint=config.endpoint,
+                    client_id=create_client_id(),
+                    client_bootstrap=self._create_bootstrap())
+
+        self._test_connection(connection)
+
+    def test_websockets_default(self):
+        config = Config.get()
+        connection = awsiot_mqtt_connection_builder.websockets_with_default_aws_signing(
+            endpoint=config.endpoint,
+            region=config.region,
+            client_id=create_client_id(),
+            client_bootstrap=self._create_bootstrap())
+        self._test_connection(connection)
 
 
 if __name__ == 'main':

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -202,6 +202,7 @@ class MqttBuilderTest(NativeResourceTest):
 
         self._test_connection(connection)
 
+    @unittest.skip("Build machines not set up to run this yet")
     def test_websockets_default(self):
         config = Config.get()
         elg = EventLoopGroup()
@@ -216,6 +217,7 @@ class MqttBuilderTest(NativeResourceTest):
             client_bootstrap=bootstrap)
         self._test_connection(connection)
 
+    @unittest.skip("Build machines not set up to run this yet")
     @unittest.skipIf(PROXY_HOST is None, 'requires "proxyhost" and "proxyport" env vars')
     def test_websockets_proxy(self):
         config = Config.get()


### PR DESCRIPTION
- Builder functions return an MQTT Connection configured for use with AWS IoT.
- MQTT Connection() class rejiggered to be more builder-friendly. Million args are passed to constructor instead of connect().

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
