### PR TITLE
Explicit setup

### DIFF
--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -62,9 +62,9 @@ class HttpClientConnection(HttpConnectionBase):
     def new(cls,
             host_name,
             port,
+            bootstrap,
             socket_options=None,
             tls_connection_options=None,
-            bootstrap=None,
             proxy_options=None):
         """
         Initiates a new connection to host_name and port using socket_options and tls_connection_options if supplied.

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -77,14 +77,11 @@ class DefaultHostResolver(HostResolverBase):
 class ClientBootstrap(NativeResource):
     __slots__ = ()
 
-    def __init__(self, event_loop_group, host_resolver=None):
+    def __init__(self, event_loop_group, host_resolver):
         assert isinstance(event_loop_group, EventLoopGroup)
-        assert isinstance(host_resolver, HostResolverBase) or host_resolver is None
+        assert isinstance(host_resolver, HostResolverBase)
 
         super(ClientBootstrap, self).__init__()
-
-        if host_resolver is None:
-            host_resolver = DefaultHostResolver(event_loop_group)
 
         self._binding = _awscrt.client_bootstrap_new(event_loop_group, host_resolver)
 

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -83,9 +83,11 @@ if args.verbose:
 # you only want one of these.
 event_loop_group = io.EventLoopGroup(1)
 
+host_resolver = io.DefaultHostResolver(event_loop_group)
+
  # client bootstrap knows how to connect all the pieces. In this case it also has the default dns resolver
 # baked in.
-client_bootstrap = io.ClientBootstrap(event_loop_group)
+client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
 
 url = urlparse(args.url)
 port = 443
@@ -149,8 +151,13 @@ socket_options = io.SocketOptions()
 socket_options.connect_timeout_ms = args.connect_timeout
 
 hostname = url.hostname
-connect_future = http.HttpClientConnection.new(hostname, port, socket_options,
-                                               tls_connection_options, client_bootstrap)
+connect_future = http.HttpClientConnection.new(
+    host_name=hostname,
+    port=port,
+    socket_options=socket_options,
+    tls_connection_options=tls_connection_options,
+    bootstrap=client_bootstrap)
+
 connection = connect_future.result(10)
 connection.shutdown_future.add_done_callback(on_connection_shutdown)
 

--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -66,7 +66,8 @@ def on_receive_message(topic, message):
 # Run
 args = parser.parse_args()
 event_loop_group = io.EventLoopGroup(1)
-client_bootstrap = io.ClientBootstrap(event_loop_group)
+host_resolver = io.DefaultHostResolver(event_loop_group)
+client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
 
 tls_options = None
 if args.cert or args.key or args.root_ca:

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -91,7 +91,8 @@ class TestProvider(NativeResourceTest):
         scoped_env = ScopedEnvironmentVariable('AWS_SHARED_CREDENTIALS_FILE', 'test/resources/credentials_test')
 
         event_loop_group = awscrt.io.EventLoopGroup()
-        bootstrap = awscrt.io.ClientBootstrap(event_loop_group)
+        host_resolver = awscrt.io.DefaultHostResolver(event_loop_group)
+        bootstrap = awscrt.io.ClientBootstrap(event_loop_group, host_resolver)
         provider = awscrt.auth.AwsCredentialsProvider.new_default_chain(bootstrap)
 
         future = provider.get_credentials()

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 import awscrt.exceptions
 from awscrt.http import HttpClientConnection, HttpClientStream, HttpHeaders, HttpProxyOptions, HttpRequest
-from awscrt.io import TlsContextOptions, ClientTlsContext, TlsConnectionOptions
+from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
 from concurrent.futures import Future
 from io import open  # Python2's built-in open() doesn't return a stream
 import os
@@ -107,8 +107,12 @@ class TestClient(NativeResourceTest):
         else:
             tls_conn_opt = None
 
-        connection_future = HttpClientConnection.new(self.hostname,
-                                                     self.port,
+        event_loop_group = EventLoopGroup()
+        host_resolver = DefaultHostResolver(event_loop_group)
+        bootstrap = ClientBootstrap(event_loop_group, host_resolver)
+        connection_future = HttpClientConnection.new(host_name=self.hostname,
+                                                     port=self.port,
+                                                     bootstrap=bootstrap,
                                                      tls_connection_options=tls_conn_opt,
                                                      proxy_options=proxy_options)
         return connection_future.result(self.timeout)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -32,10 +32,6 @@ class DefaultHostResolverTest(NativeResourceTest):
 
 
 class ClientBootstrapTest(NativeResourceTest):
-    def test_init_defaults(self):
-        event_loop_group = EventLoopGroup()
-        bootstrap = ClientBootstrap(event_loop_group)
-
     def test_init(self):
         event_loop_group = EventLoopGroup()
         host_resolver = DefaultHostResolver(event_loop_group)

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -35,7 +35,10 @@ PROXY_PORT = int(os.environ.get('proxyport', '0'))
 
 class MqttClientTest(NativeResourceTest):
     def test_lifetime(self):
-        client = Client(ClientBootstrap(EventLoopGroup()))
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        client = Client(bootstrap)
 
 
 class Config:
@@ -86,10 +89,14 @@ class MqttConnectionTest(NativeResourceTest):
 
     def _test_connection(self):
         config = Config.get()
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
 
         tls_opts = TlsContextOptions.create_client_with_mtls(config.cert, config.key)
         tls = ClientTlsContext(tls_opts)
-        client = Client(ClientBootstrap(EventLoopGroup()), tls)
+
+        client = Client(bootstrap, tls)
         connection = Connection(
             client=client,
             client_id=create_client_id(),


### PR DESCRIPTION
Remove default arguments that resulted in heavyweight objects being created.

Yes, it's more boilerplate, but it prevents someone from accidentally creating a new EventLoopGroup with each HTTP or MQTT connection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
