### PR TITLE
Callbacks take kwargs in the suggested manner

### DIFF
--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -237,12 +237,11 @@ def websockets_with_default_aws_signing(region, credentials_provider, websocket_
     """
     _check_required_kwargs(**kwargs)
 
-    def _should_sign_param(**kwargs):
+    def _should_sign_param(name, **kwargs):
         blacklist = ['x-amz-date', 'x-amz-security-token']
-        name = kwargs['name']
         return not (name.lower() in blacklist)
 
-    def _sign_websocket_handshake_request(transform_args):
+    def _sign_websocket_handshake_request(transform_args, **kwargs):
         # transform_args need to know when transform is done
         try:
             signing_config = awscrt.auth.AwsSigningConfig(

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -109,19 +109,19 @@ class Connection(NativeResource):
 
             on_connection_interrupted (function): Optional callback invoked whenever the MQTT connection is lost.
                     The MQTT client will automatically attempt to reconnect.
-                    The function should take **kwargs and return nothing.
-                    The kwargs contain:
-                        'connection': This MQTT Connection
-                        'error': awscrt.exceptions.AwsCrtError
+                    The function should take the following arguments return nothing.
+                        connection (Connection): This MQTT Connection.
+                        error (awscrt.exceptions.AwsCrtError): Exception which caused connection loss.
+                        **kwargs (dict): Forward-compatibility kwargs.
 
             on_connection_resumed (function): Optional callback invoked whenever the MQTT connection
-                    is automatically resumed. Function should take **kwargs and return nothing.
-                    The kwargs contain:
-                        'connection': This MQTT Connection
-                        'return_code': ConnectReturnCode received from the server.
-                        'session_present': True if resuming existing session. False if new session.
+                    is automatically resumed. Function should take the following arguments and return nothing:
+                        connection (Connection): This MQTT Connection
+                        return_code (ConnectReturnCode): Connect return code received from the server.
+                        session_present (bool): True if resuming existing session. False if new session.
                                 Note that the server has forgotten all previous subscriptions if this is False.
                                 Subscriptions can be re-established via resubscribe_existing_topics().
+                        **kwargs (dict): Forward-compatibility kwargs.
 
             reconnect_min_timeout_secs (int): Minimum time to wait between reconnect attempts.
                 Wait starts at min and doubles with each attempt until max is reached.
@@ -155,11 +155,14 @@ class Connection(NativeResource):
             websocket_proxy_options: optional awscrt.http.HttpProxyOptions for
                     websocket connections.
 
-            websocket_handshake_transform: optional function with signature:
-                    (WebsocketHandshakeTransformArgs) -> None
-                    If provided, function is called each time a websocket connection
-                    is attempted. The function may modify the websocket handshake
-                    request. See WebsocketHandshakeTransformArgs for more info.
+            websocket_handshake_transform: optional function to transform websocket handshake request.
+                    If provided, function is called each time a websocket connection is attempted.
+                    The function may modify the request before it is sent to the server.
+                    See WebsocketHandshakeTransformArgs for more info.
+                    Function should take the following arguments and return nothing:
+                        transform_args (WebsocketHandshakeTransformArgs): Contains request to be transformed.
+                                Function must call transform_args.done() when complete.
+                        **kwargs (dict): Forward-compatibility kwargs.
         """
 
         assert isinstance(client, Client)
@@ -300,10 +303,10 @@ class Connection(NativeResource):
     def subscribe(self, topic, qos, callback=None):
         """
         callback: Optional callback invoked when message received.
-                Function should take **kwargs and return nothing.
-                The kwargs contain:
-                    'topic' (str): Topic receiving message.
-                    'payload' (bytes): Payload of message.
+                Function should take the following arguments and return nothing:
+                    topic (str): Topic receiving message.
+                    payload (bytes): Payload of message.
+                    **kwargs (dict): Forward-compatibility kwargs.
         """
 
         future = Future()
@@ -342,10 +345,10 @@ class Connection(NativeResource):
     def on_message(self, callback):
         """
         callback: Callback invoked when message received, or None to disable.
-                Function should take **kwargs and return nothing.
-                The kwargs contain:
-                    'topic' (str): Topic receiving message.
-                    'payload' (bytes): Payload of message.
+                Function should take the following arguments and return nothing:
+                    topic (str): Topic receiving message.
+                    payload (bytes): Payload of message.
+                    **kwargs (dict): Forward-compatibility kwargs.
         """
         assert callable(callback) or callback is None
 

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -171,7 +171,7 @@ def on_connection_shutdown(shutdown_future):
 
 
 # invoked by the http request call as the response body is received in chunks
-def on_incoming_body(http_stream, chunk):
+def on_incoming_body(http_stream, chunk, **kwargs):
     output.write(chunk)
 
 
@@ -232,7 +232,7 @@ if args.header:
 # invoked as soon as the response headers are received
 
 
-def response_received_cb(http_stream, status_code, headers):
+def response_received_cb(http_stream, status_code, headers, **kwargs):
     if args.include:
         print('Response Code: {}'.format(status_code))
         print_header_list(headers)

--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -34,10 +34,10 @@ parser.add_argument('--root-ca', help="File path to root certificate authority, 
 
 io.init_logging(LogLevel.Trace, 'stderr')
 
-def on_connection_interrupted(connection, error):
+def on_connection_interrupted(connection, error, **kwargs):
     print("Connection has been interrupted with error", error)
 
-def on_connection_resumed(connection, return_code, session_present):
+def on_connection_resumed(connection, return_code, session_present, **kwargs):
     print("Connection has been resumed with return code", return_code, "and session present:", session_present)
 
     if not session_present:
@@ -59,8 +59,8 @@ def on_connection_resumed(connection, return_code, session_present):
 
 receive_results = {}
 receive_event = threading.Event()
-def on_receive_message(**kwargs):
-    receive_results.update(kwargs)
+def on_receive_message(topic, payload, **kwargs):
+    receive_results.update(locals())
     receive_event.set()
 
 # Run

--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -60,7 +60,8 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 receive_results = {}
 receive_event = threading.Event()
 def on_receive_message(topic, payload, **kwargs):
-    receive_results.update(locals())
+    receive_results['topic'] = topic
+    receive_results['payload'] = payload
     receive_event.set()
 
 # Run

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ def awscrt_ext():
 
 setuptools.setup(
     name="awscrt",
-    version="0.5.2",
+    version="0.5.3",
     author="Amazon Web Services, Inc",
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -139,7 +139,7 @@ class TestSigningConfig(NativeResourceTest):
         self.assertIs(should_sign_param, cfg.should_sign_param)
         self.assertEqual(use_double_uri_encode, cfg.use_double_uri_encode)
         self.assertEqual(should_normalize_uri_path, cfg.should_normalize_uri_path)
-        self.assertEqual(body_signing_type, cfg.body_signing_type)
+        self.assertIs(body_signing_type, cfg.body_signing_type)
 
     def test_replace(self):
         credentials_provider = awscrt.auth.AwsCredentialsProvider.new_static(

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -46,12 +46,12 @@ class Response(object):
         self.headers = None
         self.body = bytearray()
 
-    def on_response(self, **kwargs):
-        self.status_code = kwargs['status_code']
-        self.headers = HttpHeaders(kwargs['headers'])
+    def on_response(self, http_stream, status_code, headers, **kwargs):
+        self.status_code = status_code
+        self.headers = HttpHeaders(headers)
 
-    def on_body(self, **kwargs):
-        self.body.extend(kwargs['chunk'])
+    def on_body(self, http_stream, chunk, **kwargs):
+        self.body.extend(chunk)
 
 
 class TestRequestHandler(SimpleHTTPRequestHandler):


### PR DESCRIPTION
No API changes here, just fixing up existing callbacks. 

- Add "forward compatibility kwargs" to callbacks that were missing it.
- Put back named args in functions that were **only** taking `(**kwargs)`. This is much nicer to read and write. This is what they Python SDK team had meant, but I didn't totally understand on the first pass.
  - Ex: ~~def my_msg_cb(**kwargs)~~ -> `def my_msg_cb(topic, message, **kwargs)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
