### PR TITLE
Support sloppy shutdowns

### DIFF
--- a/awscrt/awsiot_mqtt_connection_builder.py
+++ b/awscrt/awsiot_mqtt_connection_builder.py
@@ -60,7 +60,7 @@ Optional Arguments:
             Default port is 443 if system supports ALPN or websockets are being used.
             Otherwise, default port is 8883.
 
-    tcp_connect_timeout_ms (int): Milliseconds to wait for TCP connect response. Default is 3000ms (3 seconds).
+    tcp_connect_timeout_ms (int): Milliseconds to wait for TCP connect response. Default is 5000ms (5 seconds).
 
     tcp_keepalive (bool): Whether to use TCP keep-alive. Default is False. If True, periodically transmit messages
             for detecting a disconnected peer.
@@ -151,7 +151,7 @@ def _builder(
     port = kwargs.get('port', port)
 
     socket_options = awscrt.io.SocketOptions()
-    socket_options.connect_timeout_ms = kwargs.get('tcp_connect_timeout_ms', 3000)
+    socket_options.connect_timeout_ms = kwargs.get('tcp_connect_timeout_ms', 5000)
     socket_options.keep_alive = kwargs.get('tcp_keepalive', False)
     socket_options.keep_alive_timeout_secs = kwargs.get('tcp_keepalive_timeout_secs', 0)
     socket_options.keep_alive_interval_secs = kwargs.get('tcp_keep_alive_interval_secs', 0)

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -51,14 +51,21 @@ class EventLoopGroup(NativeResource):
     Classes that need to do async work will ask the EventLoopGroup for an event-loop to use.
     """
 
-    __slots__ = ()
+    __slots__ = ('shutdown_event')
 
     def __init__(self, num_threads=0):
         """
         num_threads: Number of event-loops to create. Pass 0 to create one for each processor on the machine.
         """
         super(EventLoopGroup, self).__init__()
-        self._binding = _awscrt.event_loop_group_new(num_threads)
+
+        shutdown_event = threading.Event()
+
+        def on_shutdown():
+            shutdown_event.set()
+
+        self.shutdown_event = shutdown_event
+        self._binding = _awscrt.event_loop_group_new(num_threads, on_shutdown)
 
 
 class HostResolverBase(NativeResource):

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -40,7 +40,7 @@ parser.add_argument(
     required=False,
     type=int,
     help='INT: time in milliseconds to wait for a connection.',
-    default=3000)
+    default=5000)
 parser.add_argument(
     '-H',
     '--header',

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -213,7 +213,10 @@ static void s_on_get_credentials_complete(struct aws_credentials *credentials, v
     }
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     PyObject *result = PyObject_CallFunction(
         on_complete_cb,

--- a/source/auth_signer.c
+++ b/source/auth_signer.c
@@ -50,7 +50,10 @@ static void s_signing_complete(struct aws_signing_result *signing_result, int er
     }
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     PyObject *py_result = PyObject_CallFunction(async_data->py_on_complete, "(i)", error_code);
     if (py_result) {

--- a/source/auth_signing_config.c
+++ b/source/auth_signing_config.c
@@ -56,7 +56,10 @@ static bool s_should_sign_param(const struct aws_byte_cursor *name, void *userda
     AWS_FATAL_ASSERT(binding->py_should_sign_param_fn != Py_None);
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return should_sign; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     PyObject *py_result = PyObject_CallFunction(binding->py_should_sign_param_fn, "(s#)", name->ptr, name->len);
     if (py_result) {

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -83,7 +83,10 @@ static void s_on_connection_shutdown(struct aws_http_connection *native_connecti
     struct http_connection_binding *connection = user_data;
     AWS_FATAL_ASSERT(!connection->shutdown_called);
 
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     connection->shutdown_called = true;
 
@@ -117,7 +120,10 @@ static void s_on_client_connection_setup(
 
     connection->native = native_connection;
 
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     /* If setup was successful, encapsulate binding so we can pass it to python */
     PyObject *capsule = NULL;

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -199,12 +199,12 @@ static void s_on_stream_complete(struct aws_http_stream *native_stream, int erro
     stream->native = native_stream;
 
     PyObject *result = PyObject_CallMethod(stream->self_proxy, "_on_complete", "(i)", error_code);
-    if (!result) {
-        /* This function must succeed. Can't leave a Future incomplete. */
+    if (result) {
+        Py_DECREF(result);
+    } else {
+        /* Callback might fail during application shutdown */
         PyErr_WriteUnraisable(PyErr_Occurred());
-        AWS_FATAL_ASSERT(0);
     }
-    Py_DECREF(result);
 
     /* DECREF python self, we don't need to force it to stay alive any longer. */
     PyObject *self = PyWeakref_GetObject(stream->self_proxy);

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -95,7 +95,10 @@ static int s_on_incoming_header_block_done(
     int aws_result = AWS_OP_SUCCESS;
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     /* Set this just in case callback fires before aws_http_connection_make_request() has even returned */
     stream->native = native_stream;
@@ -171,7 +174,10 @@ static int s_on_incoming_body(
     int aws_result = AWS_OP_SUCCESS;
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     PyObject *result = PyObject_CallMethod(
         stream->self_proxy, "_on_body", "(" READABLE_BYTES_FORMAT_STR ")", (const char *)data->ptr, data_len);
@@ -193,7 +199,10 @@ static void s_on_stream_complete(struct aws_http_stream *native_stream, int erro
     struct http_stream_binding *stream = user_data;
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     /* Set this just in case callback fires before aws_http_connection_make_request() has even returned */
     stream->native = native_stream;

--- a/source/io.c
+++ b/source/io.c
@@ -110,7 +110,10 @@ static void s_elg_native_cleanup_complete(void *user_data) {
     aws_mem_release(aws_py_get_allocator(), elg_binding);
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     PyObject *result = PyObject_CallFunction(shutdown_complete, "()");
     if (result) {
@@ -268,7 +271,10 @@ static void s_client_bootstrap_on_shutdown_complete(void *user_data) {
     PyObject *shutdown_complete = bootstrap->shutdown_complete;
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     Py_XDECREF(bootstrap->host_resolver);
     Py_XDECREF(bootstrap->event_loop_group);
@@ -644,7 +650,10 @@ static int s_aws_input_stream_py_seek(
     PyObject *method_result = NULL;
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     method_result = PyObject_CallMethod(impl->io, "seek", "(li)", &offset, &basis);
     if (!method_result) {
@@ -671,7 +680,10 @@ int s_aws_input_stream_py_read(struct aws_input_stream *stream, struct aws_byte_
     PyObject *method_result = NULL;
 
     /*************** GIL ACQUIRE ***************/
-    PyGILState_STATE state = PyGILState_Ensure();
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
 
     memory_view = aws_py_memory_view_from_byte_buffer(dest);
     if (!memory_view) {

--- a/source/io.c
+++ b/source/io.c
@@ -35,75 +35,48 @@ bool aws_py_socket_options_init(struct aws_socket_options *socket_options, PyObj
 
     bool success = false;
 
-    /* These references all need to be cleaned up before function returns */
-    PyObject *sock_domain = NULL;
-    PyObject *sock_type = NULL;
-    PyObject *connect_timeout_ms = NULL;
-    PyObject *keep_alive = NULL;
-    PyObject *keep_alive_interval = NULL;
-    PyObject *keep_alive_timeout = NULL;
-    PyObject *keep_alive_max_probes = NULL;
-
-    sock_domain = PyObject_GetAttrString(py_socket_options, "domain");
-    if (!PyIntEnum_Check(sock_domain)) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.domain is invalid");
+    socket_options->domain = PyObject_GetAttrAsIntEnum(py_socket_options, "SocketOptions", "domain");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->domain = (enum aws_socket_domain)PyIntEnum_AsLong(sock_domain);
 
-    sock_type = PyObject_GetAttrString(py_socket_options, "type");
-    if (!PyIntEnum_Check(sock_type)) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.type is invalid");
+    socket_options->type = PyObject_GetAttrAsIntEnum(py_socket_options, "SocketOptions", "type");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->type = (enum aws_socket_type)PyIntEnum_AsLong(sock_type);
 
-    connect_timeout_ms = PyObject_GetAttrString(py_socket_options, "connect_timeout_ms");
-    if (!PyLongOrInt_Check(connect_timeout_ms)) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.connect_timeout_ms is invalid");
+    socket_options->connect_timeout_ms =
+        PyObject_GetAttrAsUint32(py_socket_options, "SocketOptions", "connect_timeout_ms");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->connect_timeout_ms = (uint32_t)PyLong_AsLong(connect_timeout_ms);
 
-    keep_alive = PyObject_GetAttrString(py_socket_options, "keep_alive");
-    if (!keep_alive) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.keep_alive is invalid");
+    socket_options->keepalive = PyObject_GetAttrAsBool(py_socket_options, "SocketOptions", "keep_alive");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->keepalive = (bool)PyObject_IsTrue(keep_alive);
 
-    keep_alive_interval = PyObject_GetAttrString(py_socket_options, "keep_alive_interval_secs");
-    if (!PyLongOrInt_Check(keep_alive_interval)) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.keep_alive_interval_secs is invalid");
+    socket_options->keep_alive_interval_sec =
+        PyObject_GetAttrAsUint16(py_socket_options, "SocketOptions", "keep_alive_interval_secs");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->keep_alive_interval_sec = (uint16_t)PyLong_AsLong(keep_alive_interval);
 
-    keep_alive_timeout = PyObject_GetAttrString(py_socket_options, "keep_alive_timeout_secs");
-    if (!PyLongOrInt_Check(keep_alive_timeout)) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.keep_alive_timeout_secs is invalid");
+    socket_options->keep_alive_timeout_sec =
+        PyObject_GetAttrAsUint16(py_socket_options, "SocketOptions", "keep_alive_timeout_secs");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->keep_alive_timeout_sec = (uint16_t)PyLong_AsLong(keep_alive_timeout);
 
-    keep_alive_max_probes = PyObject_GetAttrString(py_socket_options, "keep_alive_max_probes");
-    if (!PyLongOrInt_Check(keep_alive_timeout)) {
-        PyErr_SetString(PyExc_TypeError, "SocketOptions.keep_alive_max_probes is invalid");
+    socket_options->keep_alive_max_failed_probes =
+        PyObject_GetAttrAsUint16(py_socket_options, "SocketOptions", "keep_alive_max_probes");
+    if (PyErr_Occurred()) {
         goto done;
     }
-    socket_options->keep_alive_max_failed_probes = (uint16_t)PyLong_AsLong(keep_alive_max_probes);
 
     success = true;
 
 done:
-    Py_DECREF(sock_domain);
-    Py_DECREF(sock_type);
-    Py_DECREF(connect_timeout_ms);
-    Py_DECREF(keep_alive);
-    Py_DECREF(keep_alive_interval);
-    Py_DECREF(keep_alive_timeout);
-    Py_DECREF(keep_alive_max_probes);
-
     if (!success) {
         AWS_ZERO_STRUCT(*socket_options);
     }

--- a/source/module.c
+++ b/source/module.c
@@ -596,10 +596,10 @@ PyMODINIT_FUNC INIT_FN(void) {
         s_module_doc,
         -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
         s_module_methods,
-        NULL,
-        NULL,
-        NULL,
-        s_module_free,
+        NULL, /* slots for multi-phase initialization */
+        NULL, /* traversal fn to call during GC traversal */
+        NULL, /* clear fn to call during GC clear */
+        s_module_free, /* fn to call during deallocation of the module object */
     };
     PyObject *m = PyModule_Create(&s_module_def);
 #elif PY_MAJOR_VERSION == 2

--- a/source/module.c
+++ b/source/module.c
@@ -596,9 +596,9 @@ PyMODINIT_FUNC INIT_FN(void) {
         s_module_doc,
         -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
         s_module_methods,
-        NULL, /* slots for multi-phase initialization */
-        NULL, /* traversal fn to call during GC traversal */
-        NULL, /* clear fn to call during GC clear */
+        NULL,          /* slots for multi-phase initialization */
+        NULL,          /* traversal fn to call during GC traversal */
+        NULL,          /* clear fn to call during GC clear */
         s_module_free, /* fn to call during deallocation of the module object */
     };
     PyObject *m = PyModule_Create(&s_module_def);

--- a/source/module.c
+++ b/source/module.c
@@ -381,6 +381,15 @@ PyObject *aws_py_memory_view_from_byte_buffer(struct aws_byte_buf *buf) {
 #endif /* PY_MAJOR_VERSION */
 }
 
+int aws_py_gilstate_ensure(PyGILState_STATE *out_state) {
+    if (AWS_LIKELY(Py_IsInitialized())) {
+        *out_state = PyGILState_Ensure();
+        return AWS_OP_SUCCESS;
+    }
+
+    return aws_raise_error(AWS_ERROR_INVALID_STATE);
+}
+
 void *aws_py_get_binding(PyObject *obj, const char *capsule_name, const char *class_name) {
     if (!obj || obj == Py_None) {
         return PyErr_Format(PyExc_TypeError, "Excepted '%s', received 'NoneType'", class_name);

--- a/source/module.c
+++ b/source/module.c
@@ -632,7 +632,7 @@ PyMODINIT_FUNC PyInit__awscrt(void) {
 
 #elif PY_MAJOR_VERSION == 2
 
-PyMODINIT_FUNC PyInit__awscrt(void) {
+PyMODINIT_FUNC init_awscrt(void) {
     if (!Py_InitModule3(s_module_name, s_module_methods, s_module_doc)) {
         AWS_FATAL_ASSERT(0 && "Failed to initialize _awscrt");
     }

--- a/source/module.c
+++ b/source/module.c
@@ -576,12 +576,13 @@ PyDoc_STRVAR(s_module_doc, "C extension for binding AWS implementations of MQTT,
  ******************************************************************************/
 
 static void s_module_free(void) {
-    aws_hash_table_clean_up(&s_py_to_aws_error_map);
-    aws_hash_table_clean_up(&s_aws_to_py_error_map);
-
     if (s_logger_init) {
         aws_logger_clean_up(&s_logger);
     }
+
+    aws_hash_table_clean_up(&s_py_to_aws_error_map);
+    aws_hash_table_clean_up(&s_aws_to_py_error_map);
+
     aws_mqtt_library_clean_up();
     aws_auth_library_clean_up();
     aws_http_library_clean_up();

--- a/source/module.h
+++ b/source/module.h
@@ -43,8 +43,12 @@ PyObject *PyString_FromAwsString(const struct aws_string *aws_str);
 int PyIntEnum_Check(PyObject *int_enum_obj);
 long PyIntEnum_AsLong(PyObject *int_enum_obj);
 
-/* Python 2/3 compatible check. Return whether object is a PyLong (OR PyInt in python2). */
-int PyLongOrInt_Check(PyObject *obj);
+/* Return the named attribute, converted to the specified type.
+ * If conversion cannot occur a python exception is set (check PyExc_Occurred()) */
+uint32_t PyObject_GetAttrAsUint32(PyObject *o, const char *class_name, const char *attr_name);
+uint16_t PyObject_GetAttrAsUint16(PyObject *o, const char *class_name, const char *attr_name);
+bool PyObject_GetAttrAsBool(PyObject *o, const char *class_name, const char *attr_name);
+int PyObject_GetAttrAsIntEnum(PyObject *o, const char *class_name, const char *attr_name);
 
 /* Create cursor from PyString, PyBytes, or PyUnicode.
  * If conversion cannot occur, cursor->ptr will be NULL but no python exception is set */

--- a/test/appexit_http.py
+++ b/test/appexit_http.py
@@ -1,0 +1,145 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from __future__ import absolute_import
+import awscrt.http
+import awscrt.io
+import enum
+import sys
+
+# Application for use with the test_appexit unit tests.
+# Performs an HTTP request and shuts everything down,
+# with the opportunity to exit the application at any stage.
+
+Stage = enum.Enum('Stage', [
+    'Start',
+    'EventLoopGroupStart',
+    'HostResolverStart',
+    'ClientBootstrapStart',
+    'TlsConnectionOptionsStart',
+    'HttpClientStart',
+    'HttpClientConnected',
+    'HttpStreamStart',
+    'HttpStreamReceivingBody',
+    'HttpStreamDone',
+    'HttpConnectionClose',
+    'HttpConnectionDone',
+    'TlsConnectionOptionsDone',
+    'ClientBootstrapDone',
+    'HostResolverDone',
+    'EventLoopGroupDone',
+    'Done',
+])
+
+
+EXIT_STAGE = Stage.Done
+TIMEOUT = 10.0
+REQUEST_HOST = 's3.amazonaws.com'
+REQUEST_PATH = '/code-sharing-aws-crt/elastigirl.png'
+REQUEST_PORT = 443
+
+
+def set_stage(stage):
+    print("Stage:", stage)
+    if stage.value >= EXIT_STAGE.value:
+        print("Exiting now")
+        sys.exit()
+
+
+if __name__ == '__main__':
+    EXIT_STAGE = Stage[sys.argv[1]]
+
+    awscrt.io.init_logging(awscrt.io.LogLevel.Trace, 'stdout')
+
+    set_stage(Stage.Start)
+
+    # EventLoopGroupStart
+    elg = awscrt.io.EventLoopGroup()
+    set_stage(Stage.EventLoopGroupStart)
+
+    # HostResolverStart
+    resolver = awscrt.io.DefaultHostResolver(elg)
+    set_stage(Stage.HostResolverStart)
+
+    # ClientBootstrapStart
+    bootstrap = awscrt.io.ClientBootstrap(elg, resolver)
+    set_stage(Stage.ClientBootstrapStart)
+
+    # TlsConnectionOptionsStart
+    tls_ctx_opt = awscrt.io.TlsContextOptions()
+    tls_ctx = awscrt.io.ClientTlsContext(tls_ctx_opt)
+    tls_conn_opt = tls_ctx.new_connection_options()
+    tls_conn_opt.set_server_name(REQUEST_HOST)
+    set_stage(Stage.TlsConnectionOptionsStart)
+
+    # HttpClientStart
+    connection_future = awscrt.http.HttpClientConnection.new(
+        host_name=REQUEST_HOST,
+        port=REQUEST_PORT,
+        bootstrap=bootstrap,
+        tls_connection_options=tls_conn_opt)
+    set_stage(Stage.HttpClientStart)
+
+    # HttpClientConnected
+    http_connection = connection_future.result(TIMEOUT)
+    set_stage(Stage.HttpClientConnected)
+
+    # HttpStreamStart
+    request = awscrt.http.HttpRequest(path=REQUEST_PATH)
+    request.headers.add('Host', REQUEST_HOST)
+
+    def on_incoming_body(http_stream, chunk):
+        set_stage(Stage.HttpStreamReceivingBody)
+
+    http_stream = http_connection.request(request, on_body=on_incoming_body)
+    set_stage(Stage.HttpStreamStart)
+
+    # HttpStreamDone
+    status_code = http_stream.completion_future.result(TIMEOUT)
+    assert(status_code == 200)
+    del http_stream
+    set_stage(Stage.HttpStreamDone)
+
+    # HttpConnectionClose
+    shutdown_future = http_connection.close()
+    set_stage(Stage.HttpConnectionClose)
+
+    # HttpConnectionDone
+    del http_connection
+    shutdown_future.result(TIMEOUT)
+    set_stage(Stage.HttpConnectionDone)
+
+    # TlsConnectionOptionsDone
+    del tls_conn_opt
+    del tls_ctx
+    del tls_ctx_opt
+    set_stage(Stage.TlsConnectionOptionsDone)
+
+    # ClientBootstrapDone
+    shutdown_event = bootstrap.shutdown_event
+    del bootstrap
+    shutdown_event.wait(TIMEOUT)
+    set_stage(Stage.ClientBootstrapDone)
+
+    # HostResolverDone
+    del resolver
+    set_stage(Stage.HostResolverDone)
+
+    # EventLoopGroupDone
+    shutdown_event = elg.shutdown_event
+    del elg
+    shutdown_event.wait(TIMEOUT)
+    set_stage(Stage.EventLoopGroupDone)
+
+    # Done
+    set_stage(Stage.Done)

--- a/test/appexit_http.py
+++ b/test/appexit_http.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
     set_stage(Stage.TlsConnectionOptionsStart)
 
     # HttpClientStart
-    connection_future = awscrt.http.HttpClientConnection.new(
+    http_connection = awscrt.http.HttpClientConnection.new(
         host_name=REQUEST_HOST,
         port=REQUEST_PORT,
         bootstrap=bootstrap,
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     set_stage(Stage.HttpClientStart)
 
     # HttpClientConnected
-    http_connection = connection_future.result(TIMEOUT)
+    http_connection = http_connection.result(TIMEOUT)
     set_stage(Stage.HttpClientConnected)
 
     # HttpStreamStart
@@ -118,6 +118,7 @@ if __name__ == '__main__':
     status_code = http_stream.completion_future.result(TIMEOUT)
     assert(status_code == 200)
     del http_stream
+    del request
     set_stage(Stage.HttpStreamDone)
 
     # HttpConnectionClose

--- a/test/appexit_http.py
+++ b/test/appexit_http.py
@@ -16,6 +16,7 @@ import awscrt.http
 import awscrt.io
 import enum
 import sys
+import threading
 
 # Application for use with the test_appexit unit tests.
 # Performs an HTTP request and shuts everything down,
@@ -31,6 +32,7 @@ Stage = enum.Enum('Stage', [
     'HttpClientConnected',
     'HttpStreamStart',
     'HttpStreamReceivingBody',
+    'HttpStreamReceivingBodyMainThread',
     'HttpStreamDone',
     'HttpConnectionClose',
     'HttpConnectionDone',
@@ -43,7 +45,7 @@ Stage = enum.Enum('Stage', [
 
 
 EXIT_STAGE = Stage.Done
-TIMEOUT = 10.0
+TIMEOUT = 30.0
 REQUEST_HOST = 's3.amazonaws.com'
 REQUEST_PATH = '/code-sharing-aws-crt/elastigirl.png'
 REQUEST_PORT = 443
@@ -98,11 +100,19 @@ if __name__ == '__main__':
     request = awscrt.http.HttpRequest(path=REQUEST_PATH)
     request.headers.add('Host', REQUEST_HOST)
 
+    receiving_body_event = threading.Event()
+
     def on_incoming_body(http_stream, chunk):
+        # HttpStreamReceivingBody: Exit from event-loop thread while receiving body
         set_stage(Stage.HttpStreamReceivingBody)
+        receiving_body_event.set()
 
     http_stream = http_connection.request(request, on_body=on_incoming_body)
     set_stage(Stage.HttpStreamStart)
+
+    # HttpStreamReceivingBodyMainThread: Exit from main thread while receiving body
+    assert receiving_body_event.wait(TIMEOUT)
+    set_stage(Stage.HttpStreamReceivingBodyMainThread)
 
     # HttpStreamDone
     status_code = http_stream.completion_future.result(TIMEOUT)
@@ -111,12 +121,12 @@ if __name__ == '__main__':
     set_stage(Stage.HttpStreamDone)
 
     # HttpConnectionClose
-    shutdown_future = http_connection.close()
+    connection_shutdown_future = http_connection.close()
     set_stage(Stage.HttpConnectionClose)
 
     # HttpConnectionDone
     del http_connection
-    shutdown_future.result(TIMEOUT)
+    connection_shutdown_future.result(TIMEOUT)
     set_stage(Stage.HttpConnectionDone)
 
     # TlsConnectionOptionsDone
@@ -126,9 +136,9 @@ if __name__ == '__main__':
     set_stage(Stage.TlsConnectionOptionsDone)
 
     # ClientBootstrapDone
-    shutdown_event = bootstrap.shutdown_event
+    bootstrap_shutdown_event = bootstrap.shutdown_event
     del bootstrap
-    shutdown_event.wait(TIMEOUT)
+    assert bootstrap_shutdown_event.wait(TIMEOUT)
     set_stage(Stage.ClientBootstrapDone)
 
     # HostResolverDone
@@ -136,9 +146,9 @@ if __name__ == '__main__':
     set_stage(Stage.HostResolverDone)
 
     # EventLoopGroupDone
-    shutdown_event = elg.shutdown_event
+    elg_shutdown_event = elg.shutdown_event
     del elg
-    shutdown_event.wait(TIMEOUT)
+    assert elg_shutdown_event.wait(TIMEOUT)
     set_stage(Stage.EventLoopGroupDone)
 
     # Done

--- a/test/appexit_http.py
+++ b/test/appexit_http.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import awscrt.http
 import awscrt.io
 import enum

--- a/test/test_appexit.py
+++ b/test/test_appexit.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import absolute_import, print_function
 import subprocess
 import sys
 import unittest
@@ -22,8 +23,6 @@ class TestAppExit(unittest.TestCase):
     def _run_to_stage(self, module_name, stage):
         args = [sys.executable, '-m', module_name, stage.name]
 
-        print(subprocess.list2cmdline(args))
-
         process = subprocess.Popen(
             args,
             stdout=subprocess.PIPE,
@@ -33,8 +32,11 @@ class TestAppExit(unittest.TestCase):
 
         # only print output if test failed
         if process.returncode != 0:
+            print(subprocess.list2cmdline(args))
+
             for line in output.splitlines():
                 print(line.decode())
+
             self.assertEqual(0, process.returncode)
 
     def test_http(self):

--- a/test/test_appexit.py
+++ b/test/test_appexit.py
@@ -1,0 +1,46 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import subprocess
+import sys
+import unittest
+
+
+class TestAppExit(unittest.TestCase):
+    """Test that the application can exit with at any moment without native code somehow crashing python"""
+
+    def _run_to_stage(self, module_name, stage):
+        args = "{python} -m {module_name} {stage}".format(
+            python=sys.executable,
+            module_name=module_name,
+            stage=stage.name)
+
+        print(args)
+
+        process = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+
+        output = process.communicate()[0]
+
+        # only print output if test failed
+        if process.returncode != 0:
+            for line in output.splitlines():
+                print(line.decode())
+            self.assertEqual(0, process.returncode)
+
+    def test_http(self):
+        import test.appexit_http
+        for stage in test.appexit_http.Stage:
+            self._run_to_stage('test.appexit_http', stage)

--- a/test/test_appexit.py
+++ b/test/test_appexit.py
@@ -20,12 +20,9 @@ class TestAppExit(unittest.TestCase):
     """Test that the application can exit with at any moment without native code somehow crashing python"""
 
     def _run_to_stage(self, module_name, stage):
-        args = "{python} -m {module_name} {stage}".format(
-            python=sys.executable,
-            module_name=module_name,
-            stage=stage.name)
+        args = [sys.executable, '-m', module_name, stage.name]
 
-        print(args)
+        print(subprocess.list2cmdline(args))
 
         process = subprocess.Popen(
             args,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -24,6 +24,12 @@ class EventLoopGroupTest(NativeResourceTest):
     def test_1_thread(self):
         event_loop_group = EventLoopGroup(1)
 
+    def test_shutdown_complete(self):
+        event_loop_group = EventLoopGroup()
+        shutdown_event = event_loop_group.shutdown_event
+        del event_loop_group
+        self.assertTrue(shutdown_event.wait(TIMEOUT))
+
 
 class DefaultHostResolverTest(NativeResourceTest):
     def test_init(self):

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -208,8 +208,7 @@ class MqttBuilderTest(NativeResourceTest):
                 pri_key_filepath=key_filepath,
                 endpoint=config.endpoint,
                 client_id=create_client_id(),
-                client_bootstrap=bootstrap,
-                tcp_connect_timeout_ms=TIMEOUT * 1000)
+                client_bootstrap=bootstrap)
 
         finally:
             shutil.rmtree(tmp_dirpath)
@@ -228,8 +227,7 @@ class MqttBuilderTest(NativeResourceTest):
             credentials_provider=cred_provider,
             endpoint=config.endpoint,
             client_id=create_client_id(),
-            client_bootstrap=bootstrap,
-            tcp_connect_timeout_ms=TIMEOUT * 1000)
+            client_bootstrap=bootstrap)
         self._test_connection(connection)
 
     @unittest.skip("Build machines not set up to run this yet")
@@ -246,8 +244,7 @@ class MqttBuilderTest(NativeResourceTest):
             endpoint=config.endpoint,
             region=config.region,
             client_id=create_client_id(),
-            client_bootstrap=bootstrap,
-            tcp_connect_timeout_ms=TIMEOUT * 1000)
+            client_bootstrap=bootstrap)
         self._test_connection(connection)
 
 

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -208,7 +208,8 @@ class MqttBuilderTest(NativeResourceTest):
                 pri_key_filepath=key_filepath,
                 endpoint=config.endpoint,
                 client_id=create_client_id(),
-                client_bootstrap=bootstrap)
+                client_bootstrap=bootstrap,
+                tcp_connect_timeout_ms=TIMEOUT * 1000)
 
         finally:
             shutil.rmtree(tmp_dirpath)
@@ -227,7 +228,8 @@ class MqttBuilderTest(NativeResourceTest):
             credentials_provider=cred_provider,
             endpoint=config.endpoint,
             client_id=create_client_id(),
-            client_bootstrap=bootstrap)
+            client_bootstrap=bootstrap,
+            tcp_connect_timeout_ms=TIMEOUT * 1000)
         self._test_connection(connection)
 
     @unittest.skip("Build machines not set up to run this yet")
@@ -244,7 +246,8 @@ class MqttBuilderTest(NativeResourceTest):
             endpoint=config.endpoint,
             region=config.region,
             client_id=create_client_id(),
-            client_bootstrap=bootstrap)
+            client_bootstrap=bootstrap,
+            tcp_connect_timeout_ms=TIMEOUT * 1000)
         self._test_connection(connection)
 
 


### PR DESCRIPTION
Add tests that ensure we can shutdown cleanly with native stuff still running. Added lots of stuff to make this work and get our CI more robust.

Windows CI is now required! 🎉🎉🎉 It always passes! 🎉🎉🎉

- test_appexit.py: runs sample apps that exit with native stuff still running. Checks that exit-code is zero.
  - appexit_http.py: sample app that makes an HTTP request
  - TODO: mqtt sample app
- Expose EventLoopGroup shutdown to python.
- Don't acquire GIL during application shutdown. Attempting to do so will crash.
- Python 2 runs shutdown fn. It didn't used to, and the logger would raises errors during shutdown.
- Don't AWS_FATAL_ASSERT that python callbacks succeed. They often fail during shutdown.
- Increase connection timeouts to 5s by default. elasticurl and mqtt-builder used 3s, which often failed on Windows CI.
- Add/use helper functions for reading basic types from PyObject attributes (ex: `PyObject_GetAttrAsUint16()`). Fixed a bug, simplified a bunch of code, and makes error reporting more robust.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
