### PR TITLE
Get version# in setup.py back in alignment with tag#

### DIFF
--- a/continuous-delivery/test-version-exists
+++ b/continuous-delivery/test-version-exists
@@ -12,6 +12,12 @@ if [ "$CURRENT_TAG" != "$CURRENT_TAG_VERSION" ]; then
     exit 1
 fi
 
+SETUP_PY_VERSION=$(python setup.py --version)
+if [ "$CURRENT_TAG" != "$SETUP_PY_VERSION" ]; then
+    echo "Current tag version does not match version in setup.py: $CURRENT_TAG != $SETUP_PY_VERSION"
+    exit 1
+fi
+
 if pip install --no-cache-dir -vvv awscrt==$CURRENT_TAG_VERSION; then
     echo "$CURRENT_TAG_VERSION is already in pypi, cut a new tag if you want to upload another version."
     exit 1

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ def awscrt_ext():
 
 setuptools.setup(
     name="awscrt",
-    version="0.5.7",
+    version="0.5.11",
     author="Amazon Web Services, Inc",
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",


### PR DESCRIPTION
We did a bunch of tagged releases without changing the version in setup.py.
I bumped each one up by .1 today: setup.py became 0.5.7 and the tag became v0.5.10
Those don't match.
Now they will match with the next release.
Oye.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
