### PR TITLE
use python3 in release script

### DIFF
--- a/continuous-delivery/test-version-exists
+++ b/continuous-delivery/test-version-exists
@@ -12,13 +12,13 @@ if [ "$CURRENT_TAG" != "$CURRENT_TAG_VERSION" ]; then
     exit 1
 fi
 
-SETUP_PY_VERSION=$(python setup.py --version)
+SETUP_PY_VERSION=$(python3 setup.py --version)
 if [ "$CURRENT_TAG" != "$SETUP_PY_VERSION" ]; then
     echo "Current tag version does not match version in setup.py: $CURRENT_TAG != $SETUP_PY_VERSION"
     exit 1
 fi
 
-if pip install --no-cache-dir -vvv awscrt==$CURRENT_TAG_VERSION; then
+if python3 -m pip install --no-cache-dir -vvv awscrt==$CURRENT_TAG_VERSION; then
     echo "$CURRENT_TAG_VERSION is already in pypi, cut a new tag if you want to upload another version."
     exit 1
 fi


### PR DESCRIPTION
Broke when we upgraded the docker images in our release pipeline


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
