### PR TITLE
Fix bug in binding of aws_input_stream_seek()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ def awscrt_ext():
 
 setuptools.setup(
     name="awscrt",
-    version="0.5.13",
+    version="0.5.14",
     author="Amazon Web Services, Inc",
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",

--- a/source/io.c
+++ b/source/io.c
@@ -655,7 +655,7 @@ static int s_aws_input_stream_py_seek(
         return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
     }
 
-    method_result = PyObject_CallMethod(impl->io, "seek", "(li)", &offset, &basis);
+    method_result = PyObject_CallMethod(impl->io, "seek", "(li)", offset, basis);
     if (!method_result) {
         aws_result = aws_py_raise_error();
         goto done;

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -286,4 +286,10 @@ class TestSigner(NativeResourceTest):
 
         self.assertIs(http_request, signing_result)  # should be same object
 
-        self.assertEqual(0, body_stream.tell())  # stream's position should be at beginning
+        # don't have canonical headers to test against
+        # so just assert that these expected headers are present
+        self.assertIsNotNone(signing_result.headers.get('x-amz-content-sha256'))
+        self.assertIsNotNone(signing_result.headers.get('Authorization'))
+
+        # stream should be seeked back to initial position
+        self.assertEqual(0, body_stream.tell())

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -286,9 +286,8 @@ class TestSigner(NativeResourceTest):
 
         self.assertIs(http_request, signing_result)  # should be same object
 
-        # don't have canonical headers to test against
-        # so just assert that these expected headers are present
-        self.assertIsNotNone(signing_result.headers.get('x-amz-content-sha256'))
+        self.assertEqual('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+                         signing_result.headers.get('x-amz-content-sha256'))
         self.assertIsNotNone(signing_result.headers.get('Authorization'))
 
         # stream should be seeked back to initial position

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -288,7 +288,9 @@ class TestSigner(NativeResourceTest):
 
         self.assertEqual('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
                          signing_result.headers.get('x-amz-content-sha256'))
-        self.assertIsNotNone(signing_result.headers.get('Authorization'))
+        self.assertEqual(
+            'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=8e17c5b22b7bb28da47f44b08691c087a0993d0965bfab053376360790d44d6c',
+            signing_result.headers.get('Authorization'))
 
         # stream should be seeked back to initial position
         self.assertEqual(0, body_stream.tell())


### PR DESCRIPTION
Testing this bug via an auth test, rather than a test direcly on `awscrt.io.InputStream` because we haven't added read()/seek() functions that are accessible from python. But we know that auth will seek after signing the body

Don't have a canonical Sigv4 results to check the signed request against, so this new test just checks that we don't raise an exception. Can anyone hook me up with expected signed values?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
