### PR TITLE
More support for sloppy shutdowns.

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -570,19 +570,6 @@ PyDoc_STRVAR(s_module_doc, "C extension for binding AWS implementations of MQTT,
  * Module Init
  ******************************************************************************/
 
-static void s_module_free(void) {
-    if (s_logger_init) {
-        aws_logger_clean_up(&s_logger);
-    }
-
-    aws_hash_table_clean_up(&s_py_to_aws_error_map);
-    aws_hash_table_clean_up(&s_aws_to_py_error_map);
-
-    aws_mqtt_library_clean_up();
-    aws_auth_library_clean_up();
-    aws_http_library_clean_up();
-}
-
 static void s_module_init(void) {
     s_install_crash_handler();
 
@@ -599,11 +586,6 @@ static void s_module_init(void) {
 
 #if PY_MAJOR_VERSION == 3
 
-static void s_py3_module_free(void *userdata) {
-    (void)userdata;
-    s_module_free();
-}
-
 PyMODINIT_FUNC PyInit__awscrt(void) {
     static struct PyModuleDef s_module_def = {
         PyModuleDef_HEAD_INIT,
@@ -611,10 +593,10 @@ PyMODINIT_FUNC PyInit__awscrt(void) {
         s_module_doc,
         -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
         s_module_methods,
-        NULL,              /* slots for multi-phase initialization */
-        NULL,              /* traversal fn to call during GC traversal */
-        NULL,              /* clear fn to call during GC clear */
-        s_py3_module_free, /* fn to call during deallocation of the module object */
+        NULL, /* slots for multi-phase initialization */
+        NULL, /* traversal fn to call during GC traversal */
+        NULL, /* clear fn to call during GC clear */
+        NULL, /* fn to call during deallocation of the module object */
     };
 
     PyObject *m = PyModule_Create(&s_module_def);
@@ -631,11 +613,6 @@ PyMODINIT_FUNC PyInit__awscrt(void) {
 PyMODINIT_FUNC init_awscrt(void) {
     if (!Py_InitModule3(s_module_name, s_module_methods, s_module_doc)) {
         AWS_FATAL_ASSERT(0 && "Failed to initialize _awscrt");
-    }
-
-    /* Python 2 doesn't let us pass a module-free fn to the module-create fn, so register a global at-exit fn. */
-    if (Py_AtExit(s_module_free) == -1) {
-        AWS_FATAL_ASSERT(0 && "Failed to register atexit function for _awscrt");
     }
 
     s_module_init();


### PR DESCRIPTION
We were seeing occasional crashes in the logger code when a program exited while native objects were still alive. The global static logger was cleaned up during module unload, so if another thread is logging in the middle of that ... crash. Attempt to fix by NOT cleaning up global statics during module unload.

It's not clear to me whether C modules can be reloaded, so this seems like an acceptable solution. If someone can show me where the reload process is documented, and has a use case, we can try harder to support it. Maybe track the number of living native objects, and clean up global statics if the count is 0.

For history's sake, here's a link where were first started supporting "sloppy shutdown" https://github.com/awslabs/aws-crt-python/pull/116

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
