### PR TITLE
OSX TLS ReadMe Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API documentation: https://awslabs.github.io/aws-crt-python/
 
 This library is licensed under the Apache 2.0 License.
 
-## OSX Only TLS Behavior
+## OSX-Only TLS Behavior
 
 Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ API documentation: https://awslabs.github.io/aws-crt-python/
 
 This library is licensed under the Apache 2.0 License.
 
-## OSX-Only TLS Behavior
+## Mac-Only TLS Behavior
 
-Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This library is licensed under the Apache 2.0 License.
 
 ## Mac-Only TLS Behavior
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ API documentation: https://awslabs.github.io/aws-crt-python/
 
 This library is licensed under the Apache 2.0 License.
 
+## OSX-Only TLS Behavior
+
+Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+
 ## Installation
 
 To install from pip:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API documentation: https://awslabs.github.io/aws-crt-python/
 
 This library is licensed under the Apache 2.0 License.
 
-## OSX-Only TLS Behavior
+## OSX Only TLS Behavior
 
 Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@ API documentation: https://awslabs.github.io/aws-crt-python/
 
 This library is licensed under the Apache 2.0 License.
 
-## Mac-Only TLS Behavior
-
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
-
-```
-static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
-```
-
 ## Installation
 
 To install from pip:
@@ -32,3 +24,11 @@ python -m pip install .
 ````
 
 To use from your Python application, declare `awscrt` as a dependency in your `setup.py` file.
+
+## Mac-Only TLS Behavior
+
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v0.6.2, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
+```


### PR DESCRIPTION
*Description of changes:*
Adding OSX TLS Keychain information to README.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
