### PR TITLE
doc: Highlight that the retain option is not supported by AWS IoT

### DIFF
--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -110,12 +110,14 @@ class Will:
         qos (QoS): QoS used when publishing the Will message.
         payload (bytes): Content of Will message.
         retain (bool): Whether the Will message is to be retained when it is published.
+            This is not supported by AWS IoT. See https://docs.aws.amazon.com/iot/latest/developerguide/mqtt.html
 
     Attributes:
         topic (str): Topic to publish Will message on.
         qos (QoS): QoS used when publishing the Will message.
         payload (bytes): Content of Will message.
         retain (bool): Whether the Will message is to be retained when it is published.
+            This is not supported by AWS IoT. See https://docs.aws.amazon.com/iot/latest/developerguide/mqtt.html
     """
     __slots__ = ('topic', 'qos', 'payload', 'retain')
 


### PR DESCRIPTION
* Add a link to the AWS IoT documentation specifying that the retain flag will cause a disconnection
* https://github.com/aws/aws-iot-device-sdk-python-v2/issues/113\#issuecomment-697995436

*Issue #, if available:*

*Description of changes:*

Add a link to reference documentation highlighting the the `retain` flag is not supported by AWS IoT

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
