### PR TITLE
Increase timeout for test downloading 14MB file

### DIFF
--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -350,8 +350,8 @@ class TestClient(NativeResourceTest):
         stream = connection.request(request, response.on_response, response.on_body)
         stream.activate()
 
-        # wait for stream to complete
-        stream_completion_result = stream.completion_future.result(self.timeout)
+        # wait for stream to complete (use long timeout, it's a big file)
+        stream_completion_result = stream.completion_future.result(60)
 
         # check result
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
This test was failing pretty often.
Turns out there's a simple reason for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
