### PR TITLE
Accept duck typed python streams.

### DIFF
--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -179,7 +179,7 @@ class HttpClientConnection(HttpConnectionBase):
     def request(self, request, on_response=None, on_body=None):
         """Create :class:`HttpClientStream` to carry out the request/response exchange.
 
-        NOTE: The stream sends no data until :meth:`HttpClientStream.activate()`
+        NOTE: The HTTP stream sends no data until :meth:`HttpClientStream.activate()`
         is called. Call activate() when you're ready for callbacks and events to fire.
 
         Args:
@@ -188,7 +188,7 @@ class HttpClientConnection(HttpConnectionBase):
             on_response: Optional callback invoked once main response headers are received.
                 The function should take the following arguments and return nothing:
 
-                *   `http_stream` (:class:`HttpClientStream`): Stream carrying
+                *   `http_stream` (:class:`HttpClientStream`): HTTP stream carrying
                     out this request/response exchange.
 
                 *   `status_code` (int): Response status code.
@@ -198,13 +198,13 @@ class HttpClientConnection(HttpConnectionBase):
 
                 *   `**kwargs` (dict): Forward compatibility kwargs.
 
-                An exception raise by this function will cause the stream to end in error.
+                An exception raise by this function will cause the HTTP stream to end in error.
                 This callback is always invoked on the connection's event-loop thread.
 
             on_body: Optional callback invoked 0+ times as response body data is received.
                 The function should take the following arguments and return nothing:
 
-                *   `http_stream` (:class:`HttpClientStream`): Stream carrying
+                *   `http_stream` (:class:`HttpClientStream`): HTTP stream carrying
                     out this request/response exchange.
 
                 *   `chunk` (buffer): Response body data (not necessarily
@@ -212,7 +212,7 @@ class HttpClientConnection(HttpConnectionBase):
 
                 *   `**kwargs` (dict): Forward-compatibility kwargs.
 
-                An exception raise by this function will cause the stream to end in error.
+                An exception raise by this function will cause the HTTP stream to end in error.
                 This callback is always invoked on the connection's event-loop thread.
 
         Returns:
@@ -245,11 +245,11 @@ class HttpStreamBase(NativeResource):
 
 
 class HttpClientStream(HttpStreamBase):
-    """Stream that sends a request and receives a response.
+    """HTTP stream that sends a request and receives a response.
 
     Create an HttpClientStream with :meth:`HttpClientConnection.request()`.
 
-    NOTE: The stream sends no data until :meth:`HttpClientStream.activate()`
+    NOTE: The HTTP stream sends no data until :meth:`HttpClientStream.activate()`
     is called. Call activate() when you're ready for callbacks and events to fire.
 
     Attributes:
@@ -288,7 +288,7 @@ class HttpClientStream(HttpStreamBase):
     def activate(self):
         """Begin sending the request.
 
-        The stream does nothing until this is called. Call activate() when you
+        The HTTP stream does nothing until this is called. Call activate() when you
         are ready for its callbacks and events to fire.
         """
         _awscrt.http_client_stream_activate(self)
@@ -332,7 +332,7 @@ class HttpMessageBase(NativeResource):
 
     @property
     def body_stream(self):
-        """InputStream: Stream of outgoing body."""
+        """InputStream: Binary stream of outgoing body."""
         return _awscrt.http_message_get_body_stream(self._binding)
 
     @body_stream.setter
@@ -352,7 +352,7 @@ class HttpRequest(HttpMessageBase):
         path (str): HTTP path-and-query value. Default value is "/".
         headers (Optional[HttpHeaders]): Optional headers. If None specified,
             an empty :class:`HttpHeaders` is created.
-        body_string(Optional[Union[InputStream, io.IOBase]]): Optional body as stream.
+        body_stream(Optional[Union[InputStream, io.IOBase]]): Optional body as binary stream.
     """
 
     __slots__ = ()

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import
 import _awscrt
 from awscrt import NativeResource
 from enum import IntEnum
-import io
 import threading
 
 

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -490,20 +490,47 @@ def is_alpn_available():
 
 
 class InputStream(NativeResource):
-    """InputStream allows `awscrt` native code to read from Python I/O classes.
+    """InputStream allows `awscrt` native code to read from Python binary I/O classes.
 
     Args:
-        stream (io.IOBase): Python I/O stream to wrap.
+        stream (io.IOBase): Python binary I/O stream to wrap.
     """
-    __slots__ = ()
+    __slots__ = ('_stream')
     # TODO: Implement IOBase interface so Python can read from this class as well.
 
     def __init__(self, stream):
-        assert isinstance(stream, io.IOBase)
+        # duck-type instead of checking inheritance from IOBase.
+        # At the least, stream must have read()
+        if not callable(getattr(stream, 'read', None)):
+            raise TypeError('I/O stream type expected')
         assert not isinstance(stream, InputStream)
 
         super().__init__()
-        self._binding = _awscrt.input_stream_new(stream)
+        self._stream = stream
+        self._binding = _awscrt.input_stream_new(self)
+
+    def _read_into_memoryview(self, m):
+        # Read into memoryview m.
+        # Return number of bytes read, or None if no data available.
+        try:
+            # prefer the most efficient read methods,
+            if hasattr(self._stream, 'readinto1'):
+                return self._stream.readinto1(m)
+            if hasattr(self._stream, 'readinto'):
+                return self._stream.readinto(m)
+
+            if hasattr(self._stream, 'read1'):
+                data = self._stream.read1(len(m))
+            else:
+                data = self._stream.read(len(m))
+            n = len(data)
+            m[:n] = data
+            return n
+        except BlockingIOError:
+            return None
+
+    def _seek(self, offset, whence):
+        return self._stream.seek(offset, whence)
 
     @classmethod
     def wrap(cls, stream, allow_none=False):
@@ -511,7 +538,7 @@ class InputStream(NativeResource):
         Given some stream type, returns an :class:`InputStream`.
 
         Args:
-            stream (Union[io.IOBase, InputStream, None]): I/O stream to wrap.
+            stream (Union[io.IOBase, InputStream, None]): Binary I/O stream to wrap.
             allow_none (bool): Whether to allow `stream` to be None.
                 If False (default), and `stream` is None, an exception is raised.
 
@@ -520,10 +547,8 @@ class InputStream(NativeResource):
             Otherwise, an :class:`InputStream` which wraps the `stream` is returned.
             If `allow_none` is True, and `stream` is None, then None is returned.
         """
-        if isinstance(stream, InputStream):
-            return stream
-        if isinstance(stream, io.IOBase):
-            return cls(stream)
         if stream is None and allow_none:
             return None
-        raise TypeError('I/O stream type expected')
+        if isinstance(stream, InputStream):
+            return stream
+        return cls(stream)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from __future__ import absolute_import
-from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
+from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, InputStream, TlsConnectionOptions, TlsContextOptions
 from test import NativeResourceTest, TIMEOUT
+import io
 import unittest
 
 
@@ -82,6 +83,62 @@ class TlsConnectionOptionsTest(NativeResourceTest):
         ctx = ClientTlsContext(opt)
         conn_opt = TlsConnectionOptions(ctx)
         conn_opt.set_server_name('localhost')
+
+
+class MockPythonStream:
+    """For testing duck-typed stream classes.
+    Doesn't inherit from io.IOBase. Doesn't implement readinto()"""
+
+    def __init__(self, src_data):
+        self.data = bytes(src_data)
+        self.len = len(src_data)
+        self.pos = 0
+
+    def seek(self, where):
+        self.pos = where
+
+    def tell(self):
+        return self.pos
+
+    def read(self, amount=None):
+        if amount is None:
+            amount = self.len - self.pos
+        else:
+            amount = min(amount, self.len - self.pos)
+        prev_pos = self.pos
+        self.pos += amount
+        return self.data[prev_pos: self.pos]
+
+
+class InputStreamTest(NativeResourceTest):
+    def _test(self, python_stream, expected):
+        input_stream = InputStream(python_stream)
+        result = bytearray()
+        fixed_mv_len = 4
+        fixed_mv = memoryview(bytearray(fixed_mv_len))
+        while True:
+            read_len = input_stream._read_into_memoryview(fixed_mv)
+            if read_len is None:
+                continue
+            if read_len == 0:
+                break
+            if read_len > 0:
+                self.assertLessEqual(read_len, fixed_mv_len)
+                result += fixed_mv[0:read_len]
+
+        self.assertEqual(expected, result)
+
+    def test_read_official_io(self):
+        # Read from a class defined in the io module
+        src_data = b'a long string here'
+        python_stream = io.BytesIO(src_data)
+        self._test(python_stream, src_data)
+
+    def test_read_duck_typed_io(self):
+        # Read from a class defined in the io module
+        src_data = b'a man a can a planal canada'
+        python_stream = MockPythonStream(src_data)
+        self._test(python_stream, src_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
AWS CLI has a custom stream class with no base that only implements read()

* Don't require python stream to inherit from `io.IOBase`
* Accept python streams that only implement `read()` (previously required `readinto()`).
* C callbacks now invoke private methods on python self, instead of public methods on other python stream. Easier to debug, and keeps complex logic out of C
* Tweak docs to clarify "binary stream" and "HTTP stream"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
