### PR TITLE
attempt to fix manylinux2014 job

### DIFF
--- a/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
@@ -8,8 +8,9 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
-docker run \
+docker run --rm -it \
     --mount type=bind,source=`pwd`,target=/aws-crt-python \
     --workdir /aws-crt-python \
-    --entrypoint /aws-crt-python/continuous-delivery/build-wheels-manylinux2014-aarch64.sh \
-    $DOCKER_IMAGE
+    --entrypoint /bin/bash \
+    $DOCKER_IMAGE \
+    continuous-delivery/build-wheels-manylinux2014-aarch64.sh

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
@@ -8,8 +8,9 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
-docker run \
+docker run --rm -it \
     --mount type=bind,source=`pwd`,target=/aws-crt-python \
     --workdir /aws-crt-python \
-    --entrypoint /aws-crt-python/continuous-delivery/build-wheels-manylinux2014-x86_64.sh \
-    $DOCKER_IMAGE
+    --entrypoint /bin/bash \
+    $DOCKER_IMAGE \
+    continuous-delivery/build-wheels-manylinux2014-x86_64.sh


### PR DESCRIPTION
Error on Jenkins was:
> Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/aws-crt-python/continuous-delivery/build-wheels-manylinux2014-x86_64.sh\": permission denied": unknown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
