### PR TITLE
jenkins is not a tty

### DIFF
--- a/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
@@ -8,7 +8,7 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
-docker run --rm -it \
+docker run --rm \
     --mount type=bind,source=`pwd`,target=/aws-crt-python \
     --workdir /aws-crt-python \
     --entrypoint /bin/bash \

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
@@ -8,7 +8,7 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
-docker run --rm -it \
+docker run --rm \
     --mount type=bind,source=`pwd`,target=/aws-crt-python \
     --workdir /aws-crt-python \
     --entrypoint /bin/bash \


### PR DESCRIPTION
Error on Jenkins was:
> the input device is not a TTY



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
