### PR TITLE
event-stream RPC connection

### DIFF
--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -29,12 +29,12 @@ class EventStreamRpcClientConnectionHandler:
     resources finish shutting down.
 
     Attributes:
-        connection: Initially None. Will be set to the actual connection
-            before any events are invoked.
+        connection (Optional[EventStreamRpcClientConnection]): Initially None.
+            Will be set to the actual connection before any events are invoked.
     """
 
     def __init__(self):
-        self.connection: Optional[EventStreamRpcClientConnection] = None
+        self.connection = None
 
     def on_connection_setup(self, **kwargs) -> None:
         """Invoked when connection has been successfully established.
@@ -66,7 +66,7 @@ class EventStreamRpcClientConnection(NativeResource):
 
         port (int): Remote port.
 
-        shutdown_future (concurrent.futures.Future): Completes when this
+        shutdown_future (concurrent.futures.Future[None]): Completes when this
             connection has finished shutting down. Future will contain a
             result of None, or an exception indicating why shutdown occurred.
             Note that the connection may have been garbage-collected before
@@ -78,9 +78,9 @@ class EventStreamRpcClientConnection(NativeResource):
     def __init__(self, host_name, port):
         # Do no instantiate directly, use static connect method
         super().__init__()
-        self.host_name: str = host_name
-        self.port: int = port
-        self.shutdown_future: Future[None] = Future()
+        self.host_name = host_name
+        self.port = port
+        self.shutdown_future = Future()
 
     @classmethod
     def connect(

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -183,4 +183,10 @@ class EventStreamRpcClientConnection(NativeResource):
         return self.shutdown_future
 
     def is_open(self):
+        """
+        Returns:
+            bool: True if this connection is open and usable, False otherwise.
+            Check :attr:`shutdown_future` to know when the connection is completely
+            finished shutting down.
+        """
         return _awscrt.event_stream_connection_is_open(self._binding)

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -1,0 +1,186 @@
+"""
+event-stream library for `awscrt`.
+"""
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+import _awscrt
+from awscrt import NativeResource
+import awscrt.exceptions
+from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
+from concurrent.futures import Future
+from functools import partial
+from typing import Callable, Optional
+import weakref
+
+
+class EventStreamRpcClientConnectionHandler:
+    """Base class for handling connection events.
+
+    Inherit from this class and override functions to handle connection events.
+    All events for this connection will be invoked on the same thread,
+    and `on_connection_setup()` will always be the first event invoked.
+    The `connection` property will be set before any events are invoked.
+    If the connect attempt is unsuccessful, no events will be invoked.
+
+    Note that the `on_connection_shutdown()` event will not be invoked
+    if the handler is garbage-collected before the connection's internal
+    resources finish shutting down.
+
+    Attributes:
+        connection: Initially None. Will be set to the actual connection
+            before any events are invoked.
+    """
+
+    def __init__(self):
+        self.connection: Optional[EventStreamRpcClientConnection] = None
+
+    def on_connection_setup(self, **kwargs) -> None:
+        """Invoked when connection has been successfully established.
+
+        This will always be the first callback invoked on the handler.
+        """
+        pass
+
+    def on_protocol_message(self, **kwargs) -> None:
+        # TODO define signature
+        pass
+
+    def on_connection_shutdown(self, reason: Optional[Exception], **kwargs) -> None:
+        """Invoked when the connection finishes shutting down.
+
+        Note that this event will not be invoked if the handler is
+        garbage-collected before the shutdown process completes"""
+        pass
+
+
+class EventStreamRpcClientConnection(NativeResource):
+    """A client connection for the event-stream RPC protocol.
+
+    Use :meth:`EventStreamRpcClientConnection.connect()` to establish a new
+    connection.
+
+    Attributes:
+        host_name (str): Remote host name.
+
+        port (int): Remote port.
+
+        shutdown_future (concurrent.futures.Future): Completes when this
+            connection has finished shutting down. Future will contain a
+            result of None, or an exception indicating why shutdown occurred.
+            Note that the connection may have been garbage-collected before
+            this future completes.
+    """
+
+    __slots__ = ['host_name', 'port', 'shutdown_future']
+
+    def __init__(self, host_name, port):
+        # Do no instantiate directly, use static connect method
+        self.host_name: str = host_name
+        self.port: int = port
+        self.shutdown_future: Future[None] = Future()
+
+    @classmethod
+    def connect(
+            cls,
+            *,
+            handler: EventStreamRpcClientConnectionHandler,
+            host_name: str,
+            port: int,
+            bootstrap: ClientBootstrap,
+            socket_options: Optional[SocketOptions] = None,
+            tls_connection_options: Optional[TlsConnectionOptions] = None) -> Future:
+        """Asynchronously establish a new EventStreamRpcClientConnection.
+
+        Args:
+            TODO (int): fill this out
+        Returns:
+            concurrent.futures.Future: A Future which completes when the connection succeeds or fails.
+            If successful, the Future will contain None.
+            Otherwise it will contain an exception.
+            If the connection is successful, it is accessible via `handler.connection`.
+        """
+
+        if not socket_options:
+            socket_options = SocketOptions()
+
+        future = Future()
+
+        # Connection is not made available to user until on_setup has fired
+        connection = cls(host_name, port)
+
+        # We must be careful to avoid circular references that prevent the connection from getting GC'd.
+        # Only the internal _on_setup callback binds strong references to the connection and handler.
+        # This is ok because it fires exactly once, and references to it are cleared afterwards.
+        # All other callbacks must bind weak references to the handler,
+        # or references to futures within the connection rather than the connection itself.
+        handler_weakref = weakref.ref(handler)
+
+        connection._binding = _awscrt.event_stream_rpc_client_connection_connect(
+            host_name,
+            port,
+            bootstrap,
+            socket_options,
+            tls_connection_options,
+            partial(cls._on_setup, future, handler, connection),
+            partial(cls._on_shutdown, connection.shutdown_future, handler_weakref),
+            partial(cls._on_protocol_message, handler_weakref))
+
+        return future
+
+    @staticmethod
+    def _on_setup(bound_future, bound_handler, bound_connection, error_code):
+        try:
+            if error_code:
+                e = awscrt.exceptions.from_code(error_code)
+                bound_future.set_exception(e)
+            else:
+                bound_handler.connection = bound_connection
+                bound_handler.on_setup()
+                bound_future.set_result(None)
+        except Exception as e:
+            # user callback had unhandled exception, set future as failed
+            bound_future.set_exception(e)
+            raise
+
+    @staticmethod
+    def _on_shutdown(bound_future, bound_weak_handler, error_code):
+        reason = awscrt.exceptions.from_code(error_code) if error_code else None
+        try:
+            handler = bound_weak_handler()
+            if handler:
+                handler.on_shutdown(reason)
+        finally:
+            # user callback had unhandled exception, use finally to ensure future gets set
+            if reason:
+                bound_future.set_exception(reason)
+            else:
+                bound_future.set_result(None)
+
+    @staticmethod
+    def _on_protocol_message(bound_weak_header, headers, payload, message_type, flags):
+        handler = bound_weak_handler()
+        if handler:
+            handler.on_protocol_message(
+                headers=headers,
+                payload=payload,
+                message_type=message_type,
+                flags=flags)
+
+    def close(self):
+        """Close the connection.
+
+        Shutdown is asynchronous. This call has no effect if the connection is already
+        closing.
+
+        Returns:
+            concurrent.futures.Future: This connection's :attr:`shutdown_future`,
+            which completes when shutdown has finished.
+        """
+        # TODO: let user pass their own exception/error-code/reason for closing
+        _awscrt.event_stream_connection_close(self._binding)
+        return self.shutdown_future
+
+    def is_open(self):
+        return _awscrt.event_stream_connection_is_open(self._binding)

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -11,7 +11,7 @@ import awscrt.exceptions
 from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
 from concurrent.futures import Future
 from functools import partial
-from typing import Callable, Optional
+from typing import Optional
 import weakref
 
 
@@ -77,6 +77,7 @@ class EventStreamRpcClientConnection(NativeResource):
 
     def __init__(self, host_name, port):
         # Do no instantiate directly, use static connect method
+        super().__init__()
         self.host_name: str = host_name
         self.port: int = port
         self.shutdown_future: Future[None] = Future()

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -43,15 +43,15 @@ class EventStreamRpcClientConnectionHandler:
         """
         pass
 
-    def on_protocol_message(self, **kwargs) -> None:
-        # TODO define signature
-        pass
-
     def on_connection_shutdown(self, reason: Optional[Exception], **kwargs) -> None:
         """Invoked when the connection finishes shutting down.
 
         Note that this event will not be invoked if the handler is
         garbage-collected before the shutdown process completes"""
+        pass
+
+    def on_protocol_message(self, **kwargs) -> None:
+        # TODO define signature
         pass
 
 

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -6,6 +6,7 @@ event-stream library for `awscrt`.
 # SPDX-License-Identifier: Apache-2.0.
 
 import _awscrt
+from abc import ABC, abstractmethod
 from awscrt import NativeResource
 import awscrt.exceptions
 from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
@@ -15,7 +16,7 @@ from typing import Optional
 import weakref
 
 
-class EventStreamRpcClientConnectionHandler:
+class EventStreamRpcClientConnectionHandler(ABC):
     """Base class for handling connection events.
 
     Inherit from this class and override functions to handle connection events.
@@ -36,6 +37,7 @@ class EventStreamRpcClientConnectionHandler:
     def __init__(self):
         self.connection = None
 
+    @abstractmethod
     def on_connection_setup(self, **kwargs) -> None:
         """Invoked when connection has been successfully established.
 
@@ -43,6 +45,7 @@ class EventStreamRpcClientConnectionHandler:
         """
         pass
 
+    @abstractmethod
     def on_connection_shutdown(self, reason: Optional[Exception], **kwargs) -> None:
         """Invoked when the connection finishes shutting down.
 
@@ -50,6 +53,7 @@ class EventStreamRpcClientConnectionHandler:
         garbage-collected before the shutdown process completes"""
         pass
 
+    @abstractmethod
     def on_protocol_message(self, **kwargs) -> None:
         # TODO define signature
         pass
@@ -108,7 +112,7 @@ class EventStreamRpcClientConnection(NativeResource):
 
         future = Future()
 
-        # Connection is not made available to user until on_setup has fired
+        # Connection is not made available to user until setup callback fires
         connection = cls(host_name, port)
 
         # We must be careful to avoid circular references that prevent the connection from getting GC'd.
@@ -124,21 +128,21 @@ class EventStreamRpcClientConnection(NativeResource):
             bootstrap,
             socket_options,
             tls_connection_options,
-            partial(cls._on_setup, future, handler, connection),
-            partial(cls._on_shutdown, connection.shutdown_future, handler_weakref),
+            partial(cls._on_connection_setup, future, handler, connection),
+            partial(cls._on_connection_shutdown, connection.shutdown_future, handler_weakref),
             partial(cls._on_protocol_message, handler_weakref))
 
         return future
 
     @staticmethod
-    def _on_setup(bound_future, bound_handler, bound_connection, error_code):
+    def _on_connection_setup(bound_future, bound_handler, bound_connection, error_code):
         try:
             if error_code:
                 e = awscrt.exceptions.from_code(error_code)
                 bound_future.set_exception(e)
             else:
                 bound_handler.connection = bound_connection
-                bound_handler.on_setup()
+                bound_handler.on_connection_setup()
                 bound_future.set_result(None)
         except Exception as e:
             # user callback had unhandled exception, set future as failed
@@ -146,12 +150,12 @@ class EventStreamRpcClientConnection(NativeResource):
             raise
 
     @staticmethod
-    def _on_shutdown(bound_future, bound_weak_handler, error_code):
+    def _on_connection_shutdown(bound_future, bound_weak_handler, error_code):
         reason = awscrt.exceptions.from_code(error_code) if error_code else None
         try:
             handler = bound_weak_handler()
             if handler:
-                handler.on_shutdown(reason)
+                handler.on_connection_shutdown(reason=reason)
         finally:
             # user callback had unhandled exception, use finally to ensure future gets set
             if reason:
@@ -180,7 +184,7 @@ class EventStreamRpcClientConnection(NativeResource):
             which completes when shutdown has finished.
         """
         # TODO: let user pass their own exception/error-code/reason for closing
-        _awscrt.event_stream_connection_close(self._binding)
+        _awscrt.event_stream_rpc_client_connection_close(self._binding)
         return self.shutdown_future
 
     def is_open(self):
@@ -190,4 +194,4 @@ class EventStreamRpcClientConnection(NativeResource):
             Check :attr:`shutdown_future` to know when the connection is completely
             finished shutting down.
         """
-        return _awscrt.event_stream_connection_is_open(self._binding)
+        return _awscrt.event_stream_rpc_client_connection_is_open(self._binding)

--- a/source/event_stream.h
+++ b/source/event_stream.h
@@ -1,0 +1,13 @@
+#ifndef AWS_CRT_PYTHON_EVENT_STREAM_H
+#define AWS_CRT_PYTHON_EVENT_STREAM_H
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include "module.h"
+
+PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_connection_close(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_connection_is_open(PyObject *self, PyObject *args);
+
+#endif /* AWS_CRT_PYTHON_EVENT_STREAM_H */

--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -96,8 +96,8 @@ PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyOb
     Py_INCREF(connection->on_setup);
     connection->on_shutdown = on_shutdown_py;
     Py_INCREF(connection->on_shutdown);
-    connection->on_setup = on_setup_py;
-    Py_INCREF(connection->on_setup);
+    connection->on_protocol_message = on_message_py;
+    Py_INCREF(connection->on_protocol_message);
 
     struct aws_event_stream_rpc_client_connection_options conn_options = {
         .host_name = host_name,

--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -115,7 +115,7 @@ PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyOb
         goto error;
     }
 
-    Py_RETURN_NONE;
+    return capsule;
 
 error:
     /* capsule's destructor will clean up anything inside of it */

--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -1,0 +1,292 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include "event_stream.h"
+
+#include "io.h"
+
+#include <aws/event-stream/event_stream_rpc_client.h>
+#include <aws/io/socket.h>
+
+struct connection_binding;
+static void s_capsule_destructor(PyObject *capsule);
+static void s_connection_destroy_if_ready(struct connection_binding *connection);
+static int s_on_connection_setup(
+    struct aws_event_stream_rpc_client_connection *native,
+    int error_code,
+    void *user_data);
+static void s_on_connection_shutdown(
+    struct aws_event_stream_rpc_client_connection *native,
+    int error_code,
+    void *user_data);
+static void s_on_protocol_message(
+    struct aws_event_stream_rpc_client_connection *native,
+    const struct aws_event_stream_rpc_message_args *message_args,
+    void *user_data);
+
+static const char *s_capsule_name = "aws_event_stream_rpc_client_connection";
+
+struct connection_binding {
+    struct aws_event_stream_rpc_client_connection *native;
+    bool shutdown_complete;
+    bool capsule_destroyed;
+
+    PyObject *on_setup;
+    PyObject *on_shutdown;
+    PyObject *on_protocol_message;
+};
+
+PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyObject *args) {
+    (void)self;
+
+    struct aws_allocator *alloc = aws_py_get_allocator();
+
+    const char *host_name;
+    uint16_t port;
+    PyObject *bootstrap_py;
+    PyObject *socket_options_py;
+    PyObject *tls_options_py;
+    PyObject *on_setup_py;
+    PyObject *on_shutdown_py;
+    PyObject *on_message_py;
+    if (!PyArg_ParseTuple(
+            args,
+            "sHOOOOOO",
+            &host_name,
+            &port,
+            &bootstrap_py,
+            &socket_options_py,
+            &tls_options_py,
+            &on_setup_py,
+            &on_shutdown_py,
+            &on_message_py)) {
+        return NULL;
+    }
+
+    struct aws_client_bootstrap *bootstrap = aws_py_get_client_bootstrap(bootstrap_py);
+    if (!bootstrap) {
+        return NULL;
+    }
+
+    struct aws_socket_options socket_options;
+    if (!aws_py_socket_options_init(&socket_options, socket_options_py)) {
+        return NULL;
+    }
+
+    /* TLS options are optional */
+    struct aws_tls_connection_options *tls_options = NULL;
+    if (tls_options_py != Py_None) {
+        tls_options = aws_py_get_tls_connection_options(tls_options_py);
+        if (!tls_options) {
+            return NULL;
+        }
+    }
+
+    struct connection_binding *connection = aws_mem_calloc(alloc, 1, sizeof(struct connection_binding));
+    PyObject *capsule = PyCapsule_New(connection, s_capsule_name, s_capsule_destructor);
+    if (!capsule) {
+        aws_mem_release(alloc, connection);
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur */
+
+    connection->on_setup = on_setup_py;
+    Py_INCREF(connection->on_setup);
+    connection->on_shutdown = on_shutdown_py;
+    Py_INCREF(connection->on_shutdown);
+    connection->on_setup = on_setup_py;
+    Py_INCREF(connection->on_setup);
+
+    struct aws_event_stream_rpc_client_connection_options conn_options = {
+        .host_name = host_name,
+        .port = port,
+        .socket_options = &socket_options,
+        .tls_options = tls_options,
+        .bootstrap = bootstrap,
+        .on_connection_setup = s_on_connection_setup,
+        .on_connection_shutdown = s_on_connection_shutdown,
+        .on_connection_protocol_message = s_on_protocol_message,
+        .user_data = connection,
+    };
+
+    if (aws_event_stream_rpc_client_connection_connect(alloc, &conn_options)) {
+        goto error;
+    }
+
+    Py_RETURN_NONE;
+
+error:
+    /* capsule's destructor will clean up anything inside of it */
+    Py_DECREF(capsule);
+    return NULL;
+}
+
+static int s_on_connection_setup(
+    struct aws_event_stream_rpc_client_connection *native,
+    int error_code,
+    void *user_data) {
+
+    struct connection_binding *connection = user_data;
+    connection->native = native;
+
+    AWS_FATAL_ASSERT(!(native && error_code) && "illegal for event-stream connection to both succeed and fail");
+    AWS_FATAL_ASSERT(connection->on_setup && "illegal for event-stream connection setup to fire twice");
+
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
+
+    PyObject *result = PyObject_CallFunction(connection->on_setup, "(i)", error_code);
+    if (result) {
+        Py_DECREF(result);
+    } else {
+        /* Callback might fail during application shutdown */
+        PyErr_WriteUnraisable(PyErr_Occurred());
+    }
+
+    /* on_setup callback has a captured reference to python connection object.
+     * Need to clear it so that its refcount can ever reach zero */
+    Py_CLEAR(connection->on_setup);
+    PyGILState_Release(state);
+
+    return AWS_OP_SUCCESS; /* Calling code never actually checks this, so always returning SUCCESS */
+}
+
+static void s_on_connection_shutdown(
+    struct aws_event_stream_rpc_client_connection *native,
+    int error_code,
+    void *user_data) {
+
+    (void)native;
+    struct connection_binding *connection = user_data;
+
+    AWS_FATAL_ASSERT(!connection->shutdown_complete && "illegal for event-stream connection shutdown to fire twice");
+
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
+
+    PyObject *result = PyObject_CallFunction(connection->on_shutdown, "(i)", error_code);
+    if (result) {
+        Py_DECREF(result);
+    } else {
+        /* Callback might fail during application shutdown */
+        PyErr_WriteUnraisable(PyErr_Occurred());
+    }
+
+    connection->shutdown_complete = true;
+    s_connection_destroy_if_ready(connection);
+    PyGILState_Release(state);
+}
+
+static void s_capsule_destructor(PyObject *capsule) {
+    struct connection_binding *connection = PyCapsule_GetPointer(capsule, s_capsule_name);
+    connection->capsule_destroyed = true;
+    s_connection_destroy_if_ready(connection);
+}
+
+static void s_connection_destroy_if_ready(struct connection_binding *connection) {
+    bool destroy;
+
+    if (connection->native) {
+        if (connection->capsule_destroyed) {
+            if (connection->shutdown_complete) {
+                /* python class has been GC'd and native connection has finished shutdown */
+                destroy = true;
+            } else {
+                /* python class has been GC'd but native connection still neeeds to shut down */
+                aws_event_stream_rpc_client_connection_close(connection->native, AWS_ERROR_SUCCESS);
+                destroy = false;
+            }
+        } else {
+            /* native connection has shut down, but python class still exists */
+            destroy = false;
+        }
+    } else {
+        /* native connection setup failed */
+        destroy = true;
+    }
+
+    if (destroy) {
+        Py_XDECREF(connection->on_setup);
+        Py_XDECREF(connection->on_shutdown);
+        Py_XDECREF(connection->on_protocol_message);
+        aws_event_stream_rpc_client_connection_release(connection->native);
+        aws_mem_release(aws_py_get_allocator(), connection);
+    }
+}
+
+static void s_on_protocol_message(
+    struct aws_event_stream_rpc_client_connection *native,
+    const struct aws_event_stream_rpc_message_args *message_args,
+    void *user_data) {
+
+    (void)native;
+    struct connection_binding *connection = user_data;
+
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
+
+    /* TODO: create Python headers from C headers */
+    PyObject *headers_py = Py_None;
+    Py_INCREF(headers_py);
+
+    PyObject *result = PyObject_CallFunction(
+        connection->on_protocol_message,
+        "(Oy#iI)",
+        headers_py,
+        message_args->payload->buffer,
+        message_args->payload->len,
+        message_args->message_type,
+        message_args->message_flags);
+    if (result) {
+        Py_DECREF(result);
+    } else {
+        /* Callback might fail during application shutdown */
+        PyErr_WriteUnraisable(PyErr_Occurred());
+    }
+
+    Py_DECREF(headers_py);
+
+    PyGILState_Release(state);
+}
+
+PyObject *aws_py_event_stream_rpc_client_connection_close(PyObject *self, PyObject *args) {
+    (void)self;
+    PyObject *capsule;
+    if (!PyArg_ParseTuple(args, "O", &capsule)) {
+        return NULL;
+    }
+
+    struct connection_binding *connection = PyCapsule_GetPointer(capsule, s_capsule_name);
+    if (!connection) {
+        return NULL;
+    }
+
+    aws_event_stream_rpc_client_connection_close(connection->native, AWS_OP_SUCCESS);
+    Py_RETURN_NONE;
+}
+
+PyObject *aws_py_event_stream_rpc_client_connection_is_open(PyObject *self, PyObject *args) {
+    (void)self;
+    PyObject *capsule;
+    if (!PyArg_ParseTuple(args, "O", &capsule)) {
+        return NULL;
+    }
+
+    struct connection_binding *connection = PyCapsule_GetPointer(capsule, s_capsule_name);
+    if (!connection) {
+        return NULL;
+    }
+
+    if (aws_event_stream_rpc_client_connection_is_closed(connection->native)) {
+        Py_RETURN_FALSE;
+    }
+    Py_RETURN_TRUE;
+}

--- a/source/module.c
+++ b/source/module.c
@@ -6,6 +6,7 @@
 
 #include "auth.h"
 #include "crypto.h"
+#include "event_stream.h"
 #include "http.h"
 #include "io.h"
 #include "mqtt_client.h"
@@ -14,6 +15,7 @@
 #include <aws/auth/auth.h>
 #include <aws/common/byte_buf.h>
 #include <aws/common/system_info.h>
+#include <aws/event-stream/event_stream.h>
 #include <aws/http/http.h>
 #include <aws/io/io.h>
 #include <aws/io/logging.h>
@@ -543,6 +545,11 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(signing_config_get_omit_session_token, METH_VARARGS),
     AWS_PY_METHOD_DEF(sign_request_aws, METH_VARARGS),
 
+    /* Event Stream */
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_connect, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_close, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_is_open, METH_VARARGS),
+
     {NULL, NULL, 0, NULL},
 };
 
@@ -576,6 +583,7 @@ PyMODINIT_FUNC PyInit__awscrt(void) {
     aws_http_library_init(aws_py_get_allocator());
     aws_auth_library_init(aws_py_get_allocator());
     aws_mqtt_library_init(aws_py_get_allocator());
+    aws_event_stream_library_init(aws_py_get_allocator());
 
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9
     if (!PyEval_ThreadsInitialized()) {

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+from awscrt.eventstream import EventStreamRpcClientConnection, EventStreamRpcClientConnectionHandler
+from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
+from test import NativeResourceTest, TIMEOUT
+
+
+class SimpleHandler(EventStreamRpcClientConnectionHandler):
+    def __init__(self):
+        self.is_setup = False
+        self.is_shutdown = False
+        self.shutdown_reason = None
+        self.protocol_messages = []
+
+    def on_setup(self, **kwargs):
+        self.is_setup = True
+
+    def on_shutdown(self, reason, **kwargs):
+        self.is_shutdown = True
+        self.shutdown_reason = reason
+
+    def on_protocol_message(self, **kwargs):
+        self.protocol_messages.append("TODO")
+
+
+class TestClient(NativeResourceTest):
+    def test_failed_connect(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = SimpleHandler()
+        future = EventStreamRpcClientConnection.connect(
+            handler=handler,
+            host_name="fake",
+            port=99,
+            bootstrap=bootstrap)
+
+        failure = future.exception(TIMEOUT)
+        self.assertTrue(isinstance(failure, Exception))
+        self.assertFalse(handler.is_setup)
+        self.assertFalse(handler.is_shutdown)

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -6,27 +6,41 @@ from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 from test import NativeResourceTest, TIMEOUT
 
 
+class EventRecord:
+    def __init__(self):
+        self.setup_calls = []
+        self.shutdown_calls = []
+        self.message_calls = []
+        self.failure = None
+
+
 class SimpleHandler(EventStreamRpcClientConnectionHandler):
     def __init__(self):
         super().__init__()
-        self.is_setup = False
-        self.is_shutdown = False
-        self.shutdown_reason = None
-        self.protocol_messages = []
+        self.record = EventRecord()
 
-    def on_setup(self, **kwargs):
-        self.is_setup = True
+    def on_connection_setup(self, **kwargs):
+        if len(self.record.setup_calls) > 0:
+            self.record.failure = "setup can only fire once"
+        self.record.setup_calls.append({})
 
-    def on_shutdown(self, reason, **kwargs):
-        self.is_shutdown = True
-        self.shutdown_reason = reason
+    def on_connection_shutdown(self, reason, **kwargs):
+        if len(self.record.setup_calls) == 0:
+            self.record.failure = "if setup doesn't fire, shutdown shouldn't fire"
+        if len(self.record.shutdown_calls) > 0:
+            self.record.failure = "shutdown can only fire once"
+        self.record.shutdown_calls.append({'reason': reason})
 
     def on_protocol_message(self, **kwargs):
-        self.protocol_messages.append("TODO")
+        if len(self.record.setup_calls) == 0:
+            self.record.failure = "setup must fire before messages"
+        if len(self.record.shutdown_calls) > 0:
+            self.record.failure = "messages cannot fire after shutdown"
+        self.record.message_calls.append(kwargs)
 
 
 class TestClient(NativeResourceTest):
-    def test_failed_connect(self):
+    def test_connect_failure(self):
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
@@ -39,5 +53,62 @@ class TestClient(NativeResourceTest):
 
         failure = future.exception(TIMEOUT)
         self.assertTrue(isinstance(failure, Exception))
-        self.assertFalse(handler.is_setup)
-        self.assertFalse(handler.is_shutdown)
+        self.assertEqual(0, len(handler.record.setup_calls))
+        self.assertEqual(0, len(handler.record.shutdown_calls))
+        self.assertIsNone(handler.record.failure)
+
+    def test_connect_success(self):
+        self.skipTest("Skipping until we have permanent echo server")
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = SimpleHandler()
+        future = EventStreamRpcClientConnection.connect(
+            handler=handler,
+            host_name="127.0.0.1",
+            port=8033,
+            bootstrap=bootstrap)
+
+        self.assertIsNone(future.exception(TIMEOUT))
+        self.assertEqual(1, len(handler.record.setup_calls))
+        self.assertTrue(handler.connection.is_open())
+        self.assertEqual(0, len(handler.record.shutdown_calls))
+
+        # close
+        shutdown_future = handler.connection.close()
+        self.assertIsNone(shutdown_future.exception(TIMEOUT))
+        self.assertEqual(1, len(handler.record.shutdown_calls))
+        self.assertIsNone(handler.record.shutdown_calls[0]['reason'])
+
+        self.assertIsNone(handler.record.failure)
+
+    def test_closes_on_zero_refcount(self):
+        self.skipTest("Skipping until we have permanent echo server")
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = SimpleHandler()
+        future = EventStreamRpcClientConnection.connect(
+            handler=handler,
+            host_name="127.0.0.1",
+            port=8033,
+            bootstrap=bootstrap)
+
+        # connection should succeed
+        self.assertIsNone(future.exception(TIMEOUT))
+
+        # grab pointers to stuff that will tell us about how shutdown went,
+        record = handler.record
+        shutdown_future = handler.connection.shutdown_future
+
+        # connection should shut itself down when all references are released.
+        # the shutdown_future should complete, but the handler's shutdown
+        # callback should not fire in this test because the handler has been deleted.
+        del handler
+        self.assertIsNone(shutdown_future.exception(TIMEOUT))
+        self.assertEqual(
+            0,
+            len(record.shutdown_calls),
+            "on_connection_shutdown shouldn't fire if handler is garbage collected before connection finishes shutdown")
+
+        self.assertIsNone(record.failure)

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -8,6 +8,7 @@ from test import NativeResourceTest, TIMEOUT
 
 class SimpleHandler(EventStreamRpcClientConnectionHandler):
     def __init__(self):
+        super().__init__()
         self.is_setup = False
         self.is_shutdown = False
         self.shutdown_reason = None


### PR DESCRIPTION
implemented connect() and close() so far. Chose to use a handler, instead of individual callbacks, so that it's harder to create circular references that would prevent the connection from ever cleaning up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
