### PR TITLE
don't need to import from __future__ anymore

### DIFF
--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -5,7 +5,6 @@ AWS client-side authentication: standard credentials providers and signing.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 import _awscrt
 from awscrt import NativeResource
 import awscrt.exceptions

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -7,7 +7,6 @@ All network operations in `awscrt.http` are asynchronous.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 import _awscrt
 from concurrent.futures import Future
 from awscrt import NativeResource

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -8,7 +8,6 @@ Long-running event-loop threads are used for concurrency.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 import _awscrt
 from awscrt import NativeResource
 from enum import IntEnum

--- a/elasticurl.py
+++ b/elasticurl.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
-from __future__ import print_function
 import argparse
 import sys
 import os

--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import print_function
-
 import argparse
 from awscrt import io, mqtt
 from awscrt.io import LogLevel

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import print_function
 import distutils.ccompiler
 import glob
 import os

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import print_function
 from awscrt import NativeResource
 import gc
 import inspect

--- a/test/appexit_http.py
+++ b/test/appexit_http.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import, print_function
 import awscrt.http
 import awscrt.io
 import enum

--- a/test/test_appexit.py
+++ b/test/test_appexit.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import, print_function
 import subprocess
 import sys
 import unittest

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 import awscrt.auth
 import awscrt.io
 import datetime

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 import awscrt.exceptions
 from awscrt.http import HttpClientConnection, HttpClientStream, HttpHeaders, HttpProxyOptions, HttpRequest, HttpVersion
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, InputStream, TlsConnectionOptions, TlsContextOptions
 from test import NativeResourceTest, TIMEOUT
 import io

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
 from awscrt import awsiot_mqtt_connection_builder
 from awscrt.auth import AwsCredentialsProvider
 from awscrt.http import HttpProxyOptions


### PR DESCRIPTION
These were needed to support Python 2, but we don't support Python 2 anymore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
