### PR TITLE
event-stream headers and protocol messages

### DIFF
--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -12,7 +12,7 @@ import awscrt.exceptions
 from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
 from collections.abc import ByteString
 from concurrent.futures import Future
-from enum import IntEnum, IntFlag
+from enum import IntEnum
 from functools import partial
 from typing import Any, Optional, Sequence
 from uuid import UUID
@@ -245,7 +245,12 @@ class EventStreamRpcMessageType(IntEnum):
         return str(self)
 
 
-class EventStreamRpcMessageFlag(IntFlag):
+class EventStreamRpcMessageFlag:
+    """Flags for an event-stream RPC messages."""
+    # TODO: when python 3.5 is dropped this class should inherit from IntFlag.
+    # When doing this, be sure to update type-hints and callbacks to pass
+    # EventStreamRpcMessageFlag instead of plain int.
+
     NONE = 0
     CONNECTION_ACCEPTED = 0x1
     TERMINATE_STREAM = 0x2
@@ -298,7 +303,7 @@ class EventStreamRpcClientConnectionHandler(ABC):
             headers: Sequence[EventStreamHeader],
             payload: bytes,
             message_type: EventStreamRpcMessageType,
-            flags: EventStreamRpcMessageFlag,
+            flags: int,
             **kwargs) -> None:
         pass
 
@@ -414,7 +419,6 @@ class EventStreamRpcClientConnection(NativeResource):
             # transform from simple types to actual classes
             headers = [EventStreamHeader._from_binding_tuple(i) for i in headers]
             message_type = EventStreamRpcMessageType(message_type)
-            flags = EventStreamRpcMessageFlag(flags)
             handler.on_protocol_message(
                 headers=headers,
                 payload=payload,
@@ -450,7 +454,7 @@ class EventStreamRpcClientConnection(NativeResource):
             message_type: EventStreamRpcMessageType,
             headers: Optional[Sequence[EventStreamHeader]] = [],
             payload: Optional[ByteString] = b'',
-            flags: EventStreamRpcMessageFlag = EventStreamRpcMessageFlag.NONE) -> Future:
+            flags: int = EventStreamRpcMessageFlag.NONE) -> Future:
 
         future = Future()
 

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -231,14 +231,34 @@ class EventStreamHeader:
 
 
 class EventStreamRpcMessageType(IntEnum):
+    """Types of event-stream RPC messages.
+
+    Different message types expect specific headers and flags, consult documentation."""
+    # TODO: flesh out these docs
+
     APPLICATION_MESSAGE = 0
+    """Application message"""
+
     APPLICATION_ERROR = 1
+    """Application error"""
+
     PING = 2
+    """Ping"""
+
     PING_RESPONSE = 3
+    """Ping response"""
+
     CONNECT = 4
+    """Connect"""
+
     CONNECT_ACK = 5
+    """Connect acknowledgement"""
+
     PROTOCOL_ERROR = 6
+    """Protocol error"""
+
     INTERNAL_ERROR = 7
+    """Internal error"""
 
     def __format__(self, format_spec):
         # override so formatted string doesn't simply look like an int
@@ -246,14 +266,27 @@ class EventStreamRpcMessageType(IntEnum):
 
 
 class EventStreamRpcMessageFlag:
-    """Flags for an event-stream RPC messages."""
+    """Flags for event-stream RPC messages.
+
+    Flags may be XORed together.
+    Not all flags can be used with all messages types, consult documentation.
+    """
+    # TODO: flesh out these docs
+
     # TODO: when python 3.5 is dropped this class should inherit from IntFlag.
     # When doing this, be sure to update type-hints and callbacks to pass
     # EventStreamRpcMessageFlag instead of plain int.
 
     NONE = 0
+    """No flags"""
+
     CONNECTION_ACCEPTED = 0x1
+    """Connection accepted
+
+    If this flag is absent from a CONNECT_ACK, the connection has been rejected."""
+
     TERMINATE_STREAM = 0x2
+    """Terminate stream"""
 
     def __format__(self, format_spec):
         # override so formatted string doesn't simply look like an int
@@ -451,10 +484,29 @@ class EventStreamRpcClientConnection(NativeResource):
     def send_protocol_message(
             self,
             *,
-            message_type: EventStreamRpcMessageType,
             headers: Optional[Sequence[EventStreamHeader]] = [],
             payload: Optional[ByteString] = b'',
+            message_type: EventStreamRpcMessageType,
             flags: int = EventStreamRpcMessageFlag.NONE) -> Future:
+        """Send a protocol message.
+
+        Protocol messages use stream 0.
+
+        Keyword Args:
+            headers: Message headers.
+            payload: Binary message payload.
+            message_type: Message type.
+            flags: Message flags. Values from EventStreamRpcMessageFlag may be
+                XORed together. Not all flags can be used with all messages
+                types, consult documentation.
+        Returns:
+            A future which completes with a result of None if the the message
+            successfully written to the wire. This is still no guarantee
+            that the peer received or processed the message.
+            The future will complete with an exception if the connection
+            is closed before the message can be sent.
+
+        """
 
         future = Future()
 

--- a/source/event_stream.h
+++ b/source/event_stream.h
@@ -6,8 +6,28 @@
  */
 #include "module.h"
 
+struct aws_array_list;
+struct aws_event_stream_header_value_pair;
+
 PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyObject *args);
 PyObject *aws_py_event_stream_rpc_client_connection_close(PyObject *self, PyObject *args);
 PyObject *aws_py_event_stream_rpc_client_connection_is_open(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_connection_send_protocol_message(PyObject *self, PyObject *args);
+
+/**
+ * Given a python list of EventStreamHeaders, init an aws_array_list of aws_event_stream_header_value_pairs.
+ * All variable-length values are copied (owned) by the new headers.
+ * Returns false and sets python exception if error occurred.
+ */
+bool aws_py_event_stream_headers_list_init(struct aws_array_list *headers, PyObject *headers_py);
+
+/**
+ * Given an array of aws_event_stream_header_value_pair, create a python list containing (name, type, value) tuples.
+ * Returns a new reference if successful.
+ * Returns NULL and sets a python exception if error occurs.
+ */
+PyObject *aws_py_event_stream_headers_create_python_list(
+    struct aws_event_stream_header_value_pair *headers,
+    size_t count);
 
 #endif /* AWS_CRT_PYTHON_EVENT_STREAM_H */

--- a/source/event_stream.h
+++ b/source/event_stream.h
@@ -19,15 +19,15 @@ PyObject *aws_py_event_stream_rpc_client_connection_send_protocol_message(PyObje
  * All variable-length values are copied (owned) by the new headers.
  * Returns false and sets python exception if error occurred.
  */
-bool aws_py_event_stream_headers_list_init(struct aws_array_list *headers, PyObject *headers_py);
+bool aws_py_event_stream_native_headers_init(struct aws_array_list *native_headers, PyObject *headers_py);
 
 /**
- * Given an array of aws_event_stream_header_value_pair, create a python list containing (name, type, value) tuples.
+ * Given an array of aws_event_stream_header_value_pair, create a python list containing (name, value, type) tuples.
  * Returns a new reference if successful.
  * Returns NULL and sets a python exception if error occurs.
  */
-PyObject *aws_py_event_stream_headers_create_python_list(
-    struct aws_event_stream_header_value_pair *headers,
+PyObject *aws_py_event_stream_python_headers_create(
+    struct aws_event_stream_header_value_pair *native_headers,
     size_t count);
 
 #endif /* AWS_CRT_PYTHON_EVENT_STREAM_H */

--- a/source/event_stream_headers.c
+++ b/source/event_stream_headers.c
@@ -1,0 +1,310 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include "event_stream.h"
+
+#include <aws/event-stream/event_stream.h>
+
+/* Add new header to aws_array_list, based on python header */
+static bool s_add_header(struct aws_array_list *headers, PyObject *header_py) {
+    bool success = false;
+
+    /* Here's every new reference we may create. These need to be decref'd at end of function */
+    PyObject *name_py = NULL;               /* EventStreamHeaders.name */
+    PyObject *type_py = NULL;               /* EventStreamHeaders.type */
+    PyObject *type_value_py = NULL;         /* EventStreamHeaders.type.value */
+    PyObject *value_py = NULL;              /* EventStreamHeaders.value */
+    PyObject *value_extra_py = NULL;        /* EventStreamHeaders.value.some_extra_property  */
+    Py_buffer value_buf_py = {.obj = NULL}; /* For reading bytes-like values */
+
+    name_py = PyObject_GetAttrString(header_py, "name"); /* New reference */
+    if (!name_py) {
+        goto done;
+    }
+
+    size_t name_len;
+    const char *name = PyUnicode_AsUTF8AndSize(name_py, (Py_ssize_t *)&name_len);
+    if (!name) {
+        goto done;
+    }
+
+    const size_t name_len_max = sizeof(((struct aws_event_stream_header_value_pair *)0)->header_name) - 1;
+    if (name_len > name_len_max) {
+        PyErr_SetString(PyExc_ValueError, "EventStreamHeader.name exceeds max length");
+        goto done;
+    }
+
+    type_py = PyObject_GetAttrString(header_py, "type"); /* New reference */
+    if (!type_py) {
+        goto done;
+    }
+
+    type_value_py = PyObject_GetAttrString(type_py, "value"); /* New reference */
+    if (!type_value_py) {
+        goto done;
+    }
+
+    int type = PyLong_AsLong(type_value_py);
+    if (PyErr_Occurred()) {
+        goto done;
+    }
+
+    value_py = PyObject_GetAttrString(header_py, "value"); /* New reference */
+    if (!value_py) {
+        goto done;
+    }
+
+    switch (type) {
+        case AWS_EVENT_STREAM_HEADER_BOOL_TRUE: {
+            if (aws_event_stream_add_bool_header(headers, name, name_len, true)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_BOOL_FALSE: {
+            if (aws_event_stream_add_bool_header(headers, name, name_len, false)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_BYTE: {
+            int32_t value = PyLong_AsLong(value_py);
+            if (PyErr_Occurred()) {
+                goto done;
+            }
+            /* simply casting to 8 bits, we already checked bounds when setting value in python */
+            if (aws_event_stream_add_byte_header(headers, name, name_len, (int8_t)value)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_INT16: {
+            int32_t value = PyLong_AsLong(value_py);
+            if (PyErr_Occurred()) {
+                goto done;
+            }
+            /* simply casting to 16 bits, we already checked bounds when setting value in python */
+            if (aws_event_stream_add_int16_header(headers, name, name_len, (int16_t)value)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_INT32: {
+            int32_t value = PyLong_AsLong(value_py);
+            if (PyErr_Occurred()) {
+                goto done;
+            }
+            if (aws_event_stream_add_int32_header(headers, name, name_len, value)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_INT64: {
+            int64_t value = PyLong_AsLongLong(value_py);
+            if (PyErr_Occurred()) {
+                goto done;
+            }
+            if (aws_event_stream_add_int64_header(headers, name, name_len, value)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_BYTE_BUF: {
+            if (PyObject_GetBuffer(value_py, &value_buf_py, PyBUF_SIMPLE) == -1) { /* New reference */
+                goto done;
+            }
+            if (aws_event_stream_add_bytebuf_header(
+                    headers, name, name_len, value_buf_py.buf, value_buf_py.len, true /*copy*/)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_STRING: {
+            size_t value_len;
+            const char *value = PyUnicode_AsUTF8AndSize(value_py, (Py_ssize_t *)&value_len);
+            if (!value) {
+                goto done;
+            }
+            if (value_len > UINT16_MAX) {
+                PyErr_SetString(PyExc_ValueError, "EventStreamHeader STRING value exceeds max length");
+                goto done;
+            }
+            if (aws_event_stream_add_string_header(
+                    headers, name, name_len, value, (uint16_t)value_len, true /*copy*/)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_TIMESTAMP: {
+            int64_t value = PyLong_AsLongLong(value_py);
+            if (PyErr_Occurred()) {
+                goto done;
+            }
+            if (aws_event_stream_add_timestamp_header(headers, name, name_len, value)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        case AWS_EVENT_STREAM_HEADER_UUID: {
+            value_extra_py = PyObject_GetAttrString(value_py, "bytes"); /* New reference */
+            if (!value_extra_py) {
+                goto done;
+            }
+            if (PyObject_GetBuffer(value_extra_py, &value_buf_py, PyBUF_SIMPLE) == -1) { /* New reference */
+                goto done;
+            }
+            if (value_buf_py.len != 16) {
+                PyErr_SetString(PyExc_ValueError, "UUID.bytes must be length 16");
+                goto done;
+            }
+            if (aws_event_stream_add_uuid_header(headers, name, name_len, (const uint8_t *)value_buf_py.buf)) {
+                PyErr_SetAwsLastError();
+                goto done;
+            }
+        } break;
+
+        default: {
+            PyErr_SetString(PyExc_ValueError, "EventStreamHeader.type has invalid value");
+            goto done;
+        } break;
+    }
+
+    success = true;
+done:
+    Py_XDECREF(name_py);
+    Py_XDECREF(type_py);
+    Py_XDECREF(type_value_py);
+    Py_XDECREF(value_py);
+    Py_XDECREF(value_extra_py);
+    if (value_buf_py.obj) {
+        PyBuffer_Release(&value_buf_py);
+    }
+    return success;
+}
+
+bool aws_py_event_stream_headers_list_init(struct aws_array_list *headers, PyObject *headers_py) {
+    if (aws_event_stream_headers_list_init(headers, aws_py_get_allocator())) {
+        PyErr_SetAwsLastError();
+        return false;
+    }
+
+    /* From hereon, need to clean up if anything goes wrong */
+    bool success = false;
+    PyObject *sequence_py = NULL;
+
+    sequence_py = PySequence_Fast(headers_py, "Expected sequence of EventStreamHeaders");
+    if (!sequence_py) {
+        goto done;
+    }
+
+    const Py_ssize_t count = PySequence_Fast_GET_SIZE(sequence_py);
+    for (Py_ssize_t i = 0; i < count; ++i) {
+        /* Borrowed reference, don't need to decref */
+        PyObject *header_py = PySequence_Fast_GET_ITEM(sequence_py, i);
+
+        if (!s_add_header(headers, header_py)) {
+            goto done;
+        }
+    }
+
+    success = true;
+done:
+    Py_XDECREF(sequence_py);
+
+    if (success) {
+        return true;
+    }
+
+    aws_event_stream_headers_list_cleanup(headers);
+    return false;
+}
+
+/* Create python value from header value */
+static PyObject *s_create_value(struct aws_event_stream_header_value_pair *header) {
+    switch (header->header_value_type) {
+        case AWS_EVENT_STREAM_HEADER_BOOL_TRUE:
+            Py_INCREF(Py_True);
+            return Py_True;
+
+        case AWS_EVENT_STREAM_HEADER_BOOL_FALSE:
+            Py_INCREF(Py_False);
+            return Py_False;
+
+        case AWS_EVENT_STREAM_HEADER_BYTE:
+            return PyLong_FromLong(aws_event_stream_header_value_as_byte(header));
+
+        case AWS_EVENT_STREAM_HEADER_INT16:
+            return PyLong_FromLong(aws_event_stream_header_value_as_int16(header));
+
+        case AWS_EVENT_STREAM_HEADER_INT32:
+            return PyLong_FromLong(aws_event_stream_header_value_as_int32(header));
+
+        case AWS_EVENT_STREAM_HEADER_INT64:
+            return PyLong_FromLong(aws_event_stream_header_value_as_int64(header));
+
+        case AWS_EVENT_STREAM_HEADER_BYTE_BUF: {
+            struct aws_byte_buf tmp_buf = aws_event_stream_header_value_as_bytebuf(header);
+            return PyBytes_FromStringAndSize((const char *)tmp_buf.buffer, tmp_buf.len);
+        }
+
+        case AWS_EVENT_STREAM_HEADER_STRING: {
+            struct aws_byte_buf tmp_buf = aws_event_stream_header_value_as_string(header);
+            return PyUnicode_FromStringAndSize((const char *)tmp_buf.buffer, tmp_buf.len);
+        }
+
+        case AWS_EVENT_STREAM_HEADER_TIMESTAMP:
+            return PyLong_FromLong(aws_event_stream_header_value_as_timestamp(header));
+
+        case AWS_EVENT_STREAM_HEADER_UUID: {
+            /* It's tricky to create a python UUID with the c-api.
+             * Instead, create python bytes and transform that into an actual UUID out in python */
+            struct aws_byte_buf tmp_buf = aws_event_stream_header_value_as_uuid(header);
+            return PyBytes_FromStringAndSize((const char *)tmp_buf.buffer, tmp_buf.len);
+        }
+    }
+
+    PyErr_SetString(PyExc_ValueError, "Invalid aws_event_stream_header_value_type");
+    return NULL;
+}
+
+PyObject *aws_py_event_stream_headers_create_python_list(
+    struct aws_event_stream_header_value_pair *headers,
+    size_t count) {
+
+    PyObject *list_py = PyList_New(count);
+    if (!list_py) {
+        return NULL;
+    }
+
+    /* From hereon, need to clean up if anything goes wrong */
+
+    for (size_t i = 0; i < count; ++i) {
+        struct aws_event_stream_header_value_pair *header = &headers[i];
+
+        /* NOTE: Py_BuildValue() will fail if it gets NULL from s_create_value().
+         * This is a cool feature, don't need to worry about cleaning up tmp value if something goes wrong. */
+
+        PyObject *tuple = Py_BuildValue(
+            "(s#iO)", header->header_name, header->header_name_len, header->header_value_type, s_create_value(header));
+        if (!tuple) {
+            goto error;
+        }
+
+        PyList_SET_ITEM(list_py, i, tuple); /* steals reference to tuple */
+    }
+
+    return list_py;
+error:
+    Py_DECREF(list_py);
+    return NULL;
+}

--- a/source/module.c
+++ b/source/module.c
@@ -549,6 +549,7 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_connect, METH_VARARGS),
     AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_close, METH_VARARGS),
     AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_is_open, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_send_protocol_message, METH_VARARGS),
 
     {NULL, NULL, 0, NULL},
 };

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -1,16 +1,139 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from awscrt.eventstream import EventStreamRpcClientConnection, EventStreamRpcClientConnectionHandler
+from awscrt.eventstream import *
 from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
+from queue import Queue
 from test import NativeResourceTest, TIMEOUT
+import time
+from uuid import UUID, uuid4
+
+
+class TestHeaders(NativeResourceTest):
+    def test_bool_true(self):
+        name = 'truthy'
+        value = True
+        h = EventStreamHeader.from_bool(name, value)
+        self.assertIs(EventStreamHeaderType.BOOL_TRUE, h.type)
+        self.assertEqual(value, h.value_as_bool())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+    def test_bool_false(self):
+        name = 'falsey'
+        value = False
+        h = EventStreamHeader.from_bool(name, value)
+        self.assertIs(EventStreamHeaderType.BOOL_FALSE, h.type)
+        self.assertEqual(value, h.value_as_bool())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+    def test_byte(self):
+        name = 'bytey'
+        value = 127
+        h = EventStreamHeader.from_byte(name, value)
+        self.assertIs(EventStreamHeaderType.BYTE, h.type)
+        self.assertEqual(value, h.value_as_byte())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+        self.assertRaises(ValueError, EventStreamHeader.from_byte, 'too-big', 128)
+        self.assertRaises(ValueError, EventStreamHeader.from_byte, 'too-small', -129)
+
+    def test_int16(self):
+        name = 'sweet16'
+        value = 32_000
+        h = EventStreamHeader.from_int16(name, value)
+        self.assertIs(EventStreamHeaderType.INT16, h.type)
+        self.assertEqual(value, h.value_as_int16())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-big', 64_000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-small', -64_000)
+
+    def test_int32(self):
+        name = 'win32'
+        value = 2_000_000_000
+        h = EventStreamHeader.from_int32(name, value)
+        self.assertIs(EventStreamHeaderType.INT32, h.type)
+        self.assertEqual(value, h.value_as_int32())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 4_000_000_000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -4_000_000_000)
+
+    def test_int64(self):
+        name = 'N64'
+        value = 9_223_372_036_854_775_807
+        h = EventStreamHeader.from_int64(name, value)
+        self.assertIs(EventStreamHeaderType.INT64, h.type)
+        self.assertEqual(value, h.value_as_int64())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 18_000_000_000_000_000_000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -18_000_000_000_000_000_000)
+
+    def test_byte_buf(self):
+        name = 'buffy'
+        value = bytes(range(0, 256)) * 100
+        h = EventStreamHeader.from_byte_buf(name, value)
+        self.assertIs(EventStreamHeaderType.BYTE_BUF, h.type)
+        self.assertEqual(value, h.value_as_byte_buf())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+    def test_string(self):
+        name = 'stringy'
+        value = 'abcdefghijklmnopqrstuvwxyz' * 100
+        h = EventStreamHeader.from_string(name, value)
+        self.assertIs(EventStreamHeaderType.STRING, h.type)
+        self.assertEqual(value, h.value_as_string())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+    def test_timestamp(self):
+        name = 'timeywimey'
+        value = time.time()
+        h = EventStreamHeader.from_timestamp(name, value)
+        self.assertIs(EventStreamHeaderType.TIMESTAMP, h.type)
+        # compare with delta, since protocol uses int instead of float
+        self.assertAlmostEqual(value, h.value_as_timestamp(), delta=1.0)
+        self.assertAlmostEqual(value, h.value, delta=1.0)
+        self.assertEqual(name, h.name)
+
+    def test_uuid(self):
+        name = 'davuuid'
+        value = UUID('01234567-89ab-cdef-0123-456789abcdef')
+        h = EventStreamHeader.from_uuid(name, value)
+        self.assertIs(EventStreamHeaderType.UUID, h.type)
+        self.assertEqual(value, h.value_as_uuid())
+        self.assertEqual(value, h.value)
+        self.assertEqual(name, h.name)
+
+    def test_wrong_type(self):
+        h = EventStreamHeader.from_bool('truthy', True)
+        self.assertRaises(TypeError, h.value_as_byte)
+        self.assertRaises(TypeError, h.value_as_int16)
+        self.assertRaises(TypeError, h.value_as_int32)
+        self.assertRaises(TypeError, h.value_as_int64)
+        self.assertRaises(TypeError, h.value_as_byte_buf)
+        self.assertRaises(TypeError, h.value_as_string)
+        self.assertRaises(TypeError, h.value_as_timestamp)
+        self.assertRaises(TypeError, h.value_as_uuid)
+
+        h = EventStreamHeader.from_int32('32', 32)
+        self.assertRaises(TypeError, h.value_as_bool)
+        self.assertRaises(TypeError, h.value_as_int64)
 
 
 class EventRecord:
     def __init__(self):
-        self.setup_calls = []
-        self.shutdown_calls = []
-        self.message_calls = []
+        self.setup_call = None
+        self.shutdown_call = None
+        self.message_calls = Queue()
         self.failure = None
 
 
@@ -20,23 +143,24 @@ class SimpleHandler(EventStreamRpcClientConnectionHandler):
         self.record = EventRecord()
 
     def on_connection_setup(self, **kwargs):
-        if len(self.record.setup_calls) > 0:
+        if self.record.setup_call is not None:
             self.record.failure = "setup can only fire once"
-        self.record.setup_calls.append({})
+        self.record.setup_call = {}
 
     def on_connection_shutdown(self, reason, **kwargs):
-        if len(self.record.setup_calls) == 0:
+        if self.record.setup_call is None:
             self.record.failure = "if setup doesn't fire, shutdown shouldn't fire"
-        if len(self.record.shutdown_calls) > 0:
+        if self.record.shutdown_call is not None:
             self.record.failure = "shutdown can only fire once"
-        self.record.shutdown_calls.append({'reason': reason})
+        self.record.shutdown_call = {'reason': reason}
 
-    def on_protocol_message(self, **kwargs):
-        if len(self.record.setup_calls) == 0:
+    def on_protocol_message(self, headers, payload, message_type, flags, **kwargs):
+        if self.record.setup_call is None:
             self.record.failure = "setup must fire before messages"
-        if len(self.record.shutdown_calls) > 0:
+        if self.record.shutdown_call is not None:
             self.record.failure = "messages cannot fire after shutdown"
-        self.record.message_calls.append(kwargs)
+        self.record.message_calls.put(
+            {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
 
 
 class TestClient(NativeResourceTest):
@@ -53,8 +177,8 @@ class TestClient(NativeResourceTest):
 
         failure = future.exception(TIMEOUT)
         self.assertTrue(isinstance(failure, Exception))
-        self.assertEqual(0, len(handler.record.setup_calls))
-        self.assertEqual(0, len(handler.record.shutdown_calls))
+        self.assertIsNone(handler.record.setup_call)
+        self.assertIsNone(handler.record.shutdown_call)
         self.assertIsNone(handler.record.failure)
 
     def test_connect_success(self):
@@ -70,15 +194,15 @@ class TestClient(NativeResourceTest):
             bootstrap=bootstrap)
 
         self.assertIsNone(future.exception(TIMEOUT))
-        self.assertEqual(1, len(handler.record.setup_calls))
+        self.assertIsNotNone(handler.record.setup_call)
         self.assertTrue(handler.connection.is_open())
-        self.assertEqual(0, len(handler.record.shutdown_calls))
+        self.assertIsNone(handler.record.shutdown_call)
 
         # close
         shutdown_future = handler.connection.close()
         self.assertIsNone(shutdown_future.exception(TIMEOUT))
-        self.assertEqual(1, len(handler.record.shutdown_calls))
-        self.assertIsNone(handler.record.shutdown_calls[0]['reason'])
+        self.assertIsNotNone(handler.record.shutdown_call)
+        self.assertIsNone(handler.record.shutdown_call['reason'])
 
         self.assertIsNone(handler.record.failure)
 
@@ -106,9 +230,67 @@ class TestClient(NativeResourceTest):
         # callback should not fire in this test because the handler has been deleted.
         del handler
         self.assertIsNone(shutdown_future.exception(TIMEOUT))
-        self.assertEqual(
-            0,
-            len(record.shutdown_calls),
+        self.assertIsNone(
+            record.shutdown_call,
             "on_connection_shutdown shouldn't fire if handler is garbage collected before connection finishes shutdown")
 
         self.assertIsNone(record.failure)
+
+    def test_echo(self):
+        # self.skipTest("Skipping until we have permanent echo server")
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = SimpleHandler()
+        connect_future = EventStreamRpcClientConnection.connect(
+            handler=handler,
+            host_name="127.0.0.1",
+            port=8033,
+            bootstrap=bootstrap)
+
+        self.assertIsNone(connect_future.exception(TIMEOUT))
+
+        # send CONNECT msg
+        msg_future = handler.connection.send_protocol_message(
+            message_type=EventStreamRpcMessageType.CONNECT,
+            headers=[EventStreamHeader.from_string(':version', '0.1.0'),
+                     EventStreamHeader.from_string('client-name', 'accepted.testy_mc_testerson')])
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to receive CONNECT_ACK
+        msg = handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertIs(EventStreamRpcMessageType.CONNECT_ACK, msg['message_type'])
+        self.assertTrue(EventStreamRpcMessageFlag.CONNECTION_ACCEPTED & msg['flags'])
+
+        # send PING msg, server will echo back its headers and payload in the PING_RESPONSE
+        echo_headers = [
+            EventStreamHeader.from_bool('echo-true', True),
+            EventStreamHeader.from_bool('echo-false', False),
+            EventStreamHeader.from_byte('echo-byte', 127),
+            EventStreamHeader.from_int16('echo-int16', 32_000),
+            EventStreamHeader.from_int32('echo-int32', 2_000_000_000),
+            EventStreamHeader.from_int64('echo-int64', 999_999_999_999),
+            EventStreamHeader.from_byte_buf('echo-byte-buf', b'\x00\xff\x0f\xf0'),
+            EventStreamHeader.from_string('echo-string', 'noodles'),
+            EventStreamHeader.from_timestamp('echo-timestamp', time.time()),
+            EventStreamHeader.from_uuid('echo-uuid', UUID('01234567-89ab-cdef-0123-456789abcdef')),
+        ]
+        echo_payload = b'\x00\xDE\xAD\xBE\xEF'
+        msg_future = handler.connection.send_protocol_message(
+            message_type=EventStreamRpcMessageType.PING,
+            headers=echo_headers,
+            payload=echo_payload)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to receive PING_RESPONSE, which should echo what we sent
+        msg = handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertIs(EventStreamRpcMessageType.PING_RESPONSE, msg['message_type'])
+        for sent_header in echo_headers:
+            recv_header = next(x for x in msg['headers'] if x.name == sent_header.name)
+            self.assertEqual(sent_header.type, recv_header.type)
+            self.assertEqual(sent_header.value, recv_header.value)
+        self.assertEqual(echo_payload, msg['payload'])
+
+        self.assertIsNone(handler.record.failure)

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -42,39 +42,39 @@ class TestHeaders(NativeResourceTest):
 
     def test_int16(self):
         name = 'sweet16'
-        value = 32_000
+        value = 32000
         h = EventStreamHeader.from_int16(name, value)
         self.assertIs(EventStreamHeaderType.INT16, h.type)
         self.assertEqual(value, h.value_as_int16())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-big', 64_000)
-        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-small', -64_000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-big', 64000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-small', -64000)
 
     def test_int32(self):
         name = 'win32'
-        value = 2_000_000_000
+        value = 2000000000
         h = EventStreamHeader.from_int32(name, value)
         self.assertIs(EventStreamHeaderType.INT32, h.type)
         self.assertEqual(value, h.value_as_int32())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 4_000_000_000)
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -4_000_000_000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 4000000000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -4000000000)
 
     def test_int64(self):
         name = 'N64'
-        value = 9_223_372_036_854_775_807
+        value = 9223372036854775807
         h = EventStreamHeader.from_int64(name, value)
         self.assertIs(EventStreamHeaderType.INT64, h.type)
         self.assertEqual(value, h.value_as_int64())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 18_000_000_000_000_000_000)
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -18_000_000_000_000_000_000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 18000000000000000000)
+        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -18000000000000000000)
 
     def test_byte_buf(self):
         name = 'buffy'
@@ -237,7 +237,7 @@ class TestClient(NativeResourceTest):
         self.assertIsNone(record.failure)
 
     def test_echo(self):
-        # self.skipTest("Skipping until we have permanent echo server")
+        self.skipTest("Skipping until we have permanent echo server")
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
@@ -263,14 +263,15 @@ class TestClient(NativeResourceTest):
         self.assertIs(EventStreamRpcMessageType.CONNECT_ACK, msg['message_type'])
         self.assertTrue(EventStreamRpcMessageFlag.CONNECTION_ACCEPTED & msg['flags'])
 
-        # send PING msg, server will echo back its headers and payload in the PING_RESPONSE
+        # send PING msg, server will echo back its headers and payload in the PING_RESPONSE.
+        # test every single header type
         echo_headers = [
             EventStreamHeader.from_bool('echo-true', True),
             EventStreamHeader.from_bool('echo-false', False),
             EventStreamHeader.from_byte('echo-byte', 127),
-            EventStreamHeader.from_int16('echo-int16', 32_000),
-            EventStreamHeader.from_int32('echo-int32', 2_000_000_000),
-            EventStreamHeader.from_int64('echo-int64', 999_999_999_999),
+            EventStreamHeader.from_int16('echo-int16', 32000),
+            EventStreamHeader.from_int32('echo-int32', 2000000000),
+            EventStreamHeader.from_int64('echo-int64', 999999999999),
             EventStreamHeader.from_byte_buf('echo-byte-buf', b'\x00\xff\x0f\xf0'),
             EventStreamHeader.from_string('echo-string', 'noodles'),
             EventStreamHeader.from_timestamp('echo-timestamp', time.time()),
@@ -288,7 +289,7 @@ class TestClient(NativeResourceTest):
         msg = handler.record.message_calls.get(timeout=TIMEOUT)
         self.assertIs(EventStreamRpcMessageType.PING_RESPONSE, msg['message_type'])
         for sent_header in echo_headers:
-            recv_header = next(x for x in msg['headers'] if x.name == sent_header.name)
+            recv_header = next(x for x in msg['headers'] if x.name.lower() == sent_header.name.lower())
             self.assertEqual(sent_header.type, recv_header.type)
             self.assertEqual(sent_header.value, recv_header.value)
         self.assertEqual(echo_payload, msg['payload'])


### PR DESCRIPTION
Define headers, enums, flags, etc necessary for sending and receiving protocol messages.

2 choices made for simplicity over efficiency:
1) Rather the pass complex `EventStreamHeader` class back and forth between python and C, I always pass a simple `(name, value, type)` tuple. Transforming back and forth between them is less efficient than dealing directly with the `EventStreamHeader` class in C, but it makes the C code much simpler and less likely to leak references. We can always come back and make this more efficient in the future without affecting the public API.
2) Deep-copying contents of python headers to C headers. We could get away with non-owning references to the header names and values, but the code would be more complex. Again, we can change this under the hood without affecting the public API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
