### PR TITLE
Eventstream stream/continuation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - '*'
-      - '!master'
+      - '!main'
 
 env:
   BUILDER_VERSION: v0.6.17

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional 
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
 documentation, we greatly value feedback and contributions from our community.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary 
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
 
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/awslabs/aws-crt-python/issues), or [recently closed](https://github.com/awslabs/aws-crt-python/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
+When filing an issue, please check [existing open](https://github.com/awslabs/aws-crt-python/issues), or [recently closed](https://github.com/awslabs/aws-crt-python/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -36,17 +36,17 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/aws-crt-python/labels/help%20wanted) issues is a great place to start. 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/aws-crt-python/labels/help%20wanted) issues is a great place to start.
 
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). 
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact 
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/aws-crt-python/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/awslabs/aws-crt-python/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -472,7 +472,6 @@ class EventStreamRpcClientConnection(NativeResource):
             else:
                 bound_future.set_result(None)
 
-
     @staticmethod
     def _on_connection_shutdown(bound_future, bound_weak_handler, error_code):
         reason = awscrt.exceptions.from_code(error_code) if error_code else None

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -441,7 +441,7 @@ class EventStreamRpcClientConnection(NativeResource):
         # or references to futures within the connection rather than the connection itself.
         handler_weakref = weakref.ref(handler)
 
-        connection._binding = _awscrt.event_stream_rpc_client_connection_connect(
+        _awscrt.event_stream_rpc_client_connection_connect(
             host_name,
             port,
             bootstrap,
@@ -454,12 +454,13 @@ class EventStreamRpcClientConnection(NativeResource):
         return future
 
     @staticmethod
-    def _on_connection_setup(bound_future, bound_handler, bound_connection, error_code):
+    def _on_connection_setup(bound_future, bound_handler, bound_connection, binding, error_code):
         if error_code:
             connection = None
             error = awscrt.exceptions.from_code(error_code)
         else:
             connection = bound_connection
+            connection._binding = binding
             error = None
 
         try:

--- a/awscrt/eventstream.py
+++ b/awscrt/eventstream.py
@@ -550,7 +550,7 @@ class EventStreamRpcClientConnection(NativeResource):
         try:
             bound_handler.on_connection_setup(connection=connection, error=error)
         finally:
-            # user callback had unhandled exception, use finally to ensure future gets set
+            # ensure future completes, even if user callback had unhandled exception
             if error:
                 bound_future.set_exception(error)
             else:
@@ -564,7 +564,7 @@ class EventStreamRpcClientConnection(NativeResource):
             if handler:
                 handler.on_connection_shutdown(reason=reason)
         finally:
-            # user callback had unhandled exception, use finally to ensure future gets set
+            # ensure future completes, even if user callback had unhandled exception
             if reason:
                 bound_future.set_exception(reason)
             else:
@@ -577,7 +577,7 @@ class EventStreamRpcClientConnection(NativeResource):
             if handler:
                 handler.on_continuation_closed()
         finally:
-            # user callback had unhandled exception, use finally to ensure future gets set
+            # ensure future completes, even if user callback had unhandled exception
             bound_future.set_result(None)
 
     @staticmethod
@@ -614,7 +614,7 @@ class EventStreamRpcClientConnection(NativeResource):
             if bound_callback:
                 bound_callback(error=e)
         finally:
-            # user callback had unhandled exception, use finally to ensure future gets set
+            # ensure future completes, even if user callback had unhandled exception
             if error_code:
                 bound_future.set_exception(e)
             else:

--- a/awscrt/eventstream/__init__.py
+++ b/awscrt/eventstream/__init__.py
@@ -1,0 +1,284 @@
+"""
+event-stream library for `awscrt`.
+"""
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+from collections.abc import ByteString
+from enum import IntEnum
+from typing import Any
+from uuid import UUID
+
+__all__ = ['HeaderType', 'Header']
+
+
+_BYTE_MIN = -2**7
+_BYTE_MAX = 2**7 - 1
+_INT16_MIN = -2**15
+_INT16_MAX = 2**15 - 1
+_INT32_MIN = -2**31
+_INT32_MAX = 2**31 - 1
+_INT64_MIN = -2**63
+_INT64_MAX = 2**63 - 1
+
+
+class HeaderType(IntEnum):
+    """Supported types for the value within a Header"""
+
+    BOOL_TRUE = 0
+    """Value is True.
+
+    No actual value is transmitted on the wire."""
+
+    BOOL_FALSE = 1
+    """Value is False.
+
+    No actual value is transmitted on the wire."""
+
+    BYTE = 2
+    """Value is signed 8-bit int."""
+
+    INT16 = 3
+    """Value is signed 16-bit int."""
+
+    INT32 = 4
+    """Value is signed 32-bit int."""
+
+    INT64 = 5
+    """Value is signed 64-bit int."""
+
+    BYTE_BUF = 6
+    """Value is raw bytes."""
+
+    STRING = 7
+    """Value is a str.
+
+    Transmitted on the wire as utf-8"""
+
+    TIMESTAMP = 8
+    """Value is a posix timestamp (seconds since Unix epoch).
+
+    Transmitted on the wire as a 64-bit int"""
+
+    UUID = 9
+    """Value is a UUID.
+
+    Transmitted on the wire as 16 bytes"""
+
+    def __format__(self, format_spec):
+        # override so formatted string doesn't simply look like an int
+        return str(self)
+
+
+class Header:
+    """A header in an event-stream message.
+
+    Each header has a name, value, and type.
+    :class:`HeaderType` enumerates the supported value types.
+
+    Create a header with one of the Header.from_X() functions.
+    """
+
+    def __init__(self, name: str, value: Any, header_type: HeaderType):
+        # do not call directly, use Header.from_xyz() methods.
+        self._name = name
+        self._value = value
+        self._type = header_type
+
+    @classmethod
+    def from_bool(cls, name: str, value: bool) -> 'Header':
+        """Create a Header of type BOOL_TRUE or BOOL_FALSE"""
+        if value:
+            return cls(name, True, HeaderType.BOOL_TRUE)
+        else:
+            return cls(name, False, HeaderType.BOOL_FALSE)
+
+    @classmethod
+    def from_byte(cls, name: str, value: int) -> 'Header':
+        """Create a Header of type BYTE
+
+        The value must fit in an 8-bit signed int"""
+        value = int(value)
+        if value < _BYTE_MIN or value > _BYTE_MAX:
+            raise ValueError("Value {} cannot fit in signed 8-bit byte".format(value))
+        return cls(name, value, HeaderType.BYTE)
+
+    @classmethod
+    def from_int16(cls, name: str, value: int) -> 'Header':
+        """Create a Header of type INT16
+
+        The value must fit in an 16-bit signed int"""
+        value = int(value)
+        if value < _INT16_MIN or value > _INT16_MAX:
+            raise ValueError("Value {} cannot fit in signed 16-bit int".format(value))
+        return cls(name, value, HeaderType.INT16)
+
+    @classmethod
+    def from_int32(cls, name: str, value: int) -> 'Header':
+        """Create a Header of type INT32
+
+        The value must fit in an 32-bit signed int"""
+        value = int(value)
+        if value < _INT32_MIN or value > _INT32_MAX:
+            raise ValueError("Value {} cannot fit in signed 32-bit int".format(value))
+        return cls(name, value, HeaderType.INT32)
+
+    @classmethod
+    def from_int64(cls, name: str, value: int) -> 'Header':
+        """Create a Header of type INT64
+
+        The value must fit in an 64-bit signed int"""
+        value = int(value)
+        if value < _INT64_MIN or value > _INT64_MAX:
+            raise ValueError("Value {} cannot fit in signed 64-bit int".format(value))
+        return cls(name, value, HeaderType.INT64)
+
+    @classmethod
+    def from_byte_buf(cls, name: str, value: ByteString) -> 'Header':
+        """Create a Header of type BYTES
+
+        The value must be a bytes-like object"""
+        return cls(name, value, HeaderType.BYTE_BUF)
+
+    @classmethod
+    def from_string(cls, name: str, value: str) -> 'Header':
+        """Create a Header of type STRING"""
+        value = str(value)
+        return cls(name, value, HeaderType.STRING)
+
+    @classmethod
+    def from_timestamp(cls, name: str, value: int) -> 'Header':
+        """Create a Header of type TIMESTAMP
+
+        Value must be a posix timestamp (seconds since Unix epoch)"""
+
+        value = int(value)
+        if value < _INT64_MIN or value > _INT64_MAX:
+            raise ValueError("Value {} exceeds timestamp limits".format(value))
+        return cls(name, value, HeaderType.TIMESTAMP)
+
+    @classmethod
+    def from_uuid(cls, name: str, value: UUID) -> 'Header':
+        """Create a Header of type UUID
+
+        The value must be a UUID"""
+
+        if not isinstance(value, UUID):
+            raise TypeError("Value must be UUID, not {}".format(type(value)))
+        return cls(name, value, HeaderType.UUID)
+
+    @classmethod
+    def _from_binding_tuple(cls, binding_tuple):
+        # native code deals with a simplified tuple, rather than full class
+        name, value, header_type = binding_tuple
+        header_type = HeaderType(header_type)
+        if header_type == HeaderType.UUID:
+            value = UUID(bytes=value)
+        return cls(name, value, header_type)
+
+    def _as_binding_tuple(self):
+        # native code deals with a simplified tuple, rather than full class
+        if self._type == HeaderType.UUID:
+            value = self._value.bytes
+        else:
+            value = self._value
+        return (self._name, value, self._type)
+
+    @property
+    def name(self) -> str:
+        """Header name"""
+        return self._name
+
+    @property
+    def type(self) -> HeaderType:
+        """Header type"""
+        return self._type
+
+    @property
+    def value(self) -> Any:
+        """Header value
+
+        The header's type determines the value's type.
+        Use the value_as_X() methods for type-checked queries."""
+        return self._value
+
+    def _value_as(self, header_type: HeaderType) -> Any:
+        if self._type != header_type:
+            raise TypeError("Header type is {}, not {}".format(self._type, header_type))
+        return self._value
+
+    def value_as_bool(self) -> bool:
+        """Return bool value
+
+        Raises an exception if type is not BOOL_TRUE or BOOL_FALSE"""
+        if self._type == HeaderType.BOOL_TRUE:
+            return True
+        if self._type == HeaderType.BOOL_FALSE:
+            return False
+        raise TypeError(
+            "Header type is {}, not {} or {}".format(
+                self._type,
+                HeaderType.BOOL_TRUE,
+                HeaderType.BOOL_FALSE))
+
+    def value_as_byte(self) -> int:
+        """Return value of 8-bit signed int
+
+        Raises an exception if type is not INT8"""
+        return self._value_as(HeaderType.BYTE)
+
+    def value_as_int16(self) -> int:
+        """Return value of 16-bit signed int
+
+        Raises an exception if type is not INT16"""
+        return self._value_as(HeaderType.INT16)
+
+    def value_as_int32(self) -> int:
+        """Return value of 32-bit signed int
+
+        Raises an exception if type is not INT32"""
+        return self._value_as(HeaderType.INT32)
+
+    def value_as_int64(self) -> int:
+        """Return value of 64-bit signed int
+
+        Raises an exception if type is not INT64"""
+        return self._value_as(HeaderType.INT64)
+
+    def value_as_byte_buf(self) -> ByteString:
+        """Return value of bytes
+
+        Raises an exception if type is not BYTE_BUF"""
+        return self._value_as(HeaderType.BYTE_BUF)
+
+    def value_as_string(self) -> str:
+        """Return value of string
+
+        Raises an exception if type is not STRING"""
+        return self._value_as(HeaderType.STRING)
+
+    def value_as_timestamp(self) -> int:
+        """Return value of timestamp (seconds since Unix epoch)
+
+        Raises an exception if type is not TIMESTAMP"""
+        return self._value_as(HeaderType.TIMESTAMP)
+
+    def value_as_uuid(self) -> UUID:
+        """Return value of UUID
+
+        Raises an exception if type is not UUID"""
+        return self._value_as(HeaderType.UUID)
+
+    def __str__(self):
+        return "{}: {} <{}>".format(
+            self._name,
+            repr(self._value),
+            self._type.name)
+
+    def __repr__(self):
+        return "{}({}, {}, {})".format(
+            self.__class__.__name__,
+            repr(self._name),
+            repr(self._value),
+            repr(self._type))

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -9,13 +9,13 @@ import _awscrt
 from abc import ABC, abstractmethod
 from awscrt import NativeResource
 import awscrt.exceptions
-from awscrt.eventstream import Header, HeaderType
+from awscrt.eventstream import Header
 from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
 from collections.abc import ByteString, Callable
 from concurrent.futures import Future
 from enum import IntEnum
 from functools import partial
-from typing import Any, Optional, Sequence
+from typing import Optional, Sequence
 import weakref
 
 __all__ = [

--- a/source/event_stream.h
+++ b/source/event_stream.h
@@ -13,6 +13,10 @@ PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyOb
 PyObject *aws_py_event_stream_rpc_client_connection_close(PyObject *self, PyObject *args);
 PyObject *aws_py_event_stream_rpc_client_connection_is_open(PyObject *self, PyObject *args);
 PyObject *aws_py_event_stream_rpc_client_connection_send_protocol_message(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_connection_new_stream(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_continuation_activate(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_continuation_send_message(PyObject *self, PyObject *args);
+PyObject *aws_py_event_stream_rpc_client_continuation_is_closed(PyObject *self, PyObject *args);
 
 /**
  * Given a python list of EventStreamHeaders, init an aws_array_list of aws_event_stream_header_value_pairs.
@@ -29,5 +33,17 @@ bool aws_py_event_stream_native_headers_init(struct aws_array_list *native_heade
 PyObject *aws_py_event_stream_python_headers_create(
     struct aws_event_stream_header_value_pair *native_headers,
     size_t count);
+
+/**
+ * Common callback used by both connection and continuation messages.
+ * user_data should be a python callable that takes an error_code and returns nothing. */
+void aws_py_event_stream_rpc_client_on_message_flush(int error_code, void *user_data);
+
+/* Given a python object, return a pointer to its underlying native type.
+ * If NULL is returned, a python error has been set */
+
+struct aws_event_stream_rpc_client_connection *aws_py_get_event_stream_rpc_client_connection(PyObject *connection);
+struct aws_event_stream_rpc_client_continuation_token *aws_py_get_event_stream_rpc_client_continuation(
+    PyObject *continuation);
 
 #endif /* AWS_CRT_PYTHON_EVENT_STREAM_H */

--- a/source/event_stream.h
+++ b/source/event_stream.h
@@ -19,7 +19,7 @@ PyObject *aws_py_event_stream_rpc_client_continuation_send_message(PyObject *sel
 PyObject *aws_py_event_stream_rpc_client_continuation_is_closed(PyObject *self, PyObject *args);
 
 /**
- * Given a python list of EventStreamHeaders, init an aws_array_list of aws_event_stream_header_value_pairs.
+ * Given a python list of Headers, init an aws_array_list of aws_event_stream_header_value_pairs.
  * All variable-length values are copied (owned) by the new headers.
  * Returns false and sets python exception if error occurred.
  */

--- a/source/event_stream_headers.c
+++ b/source/event_stream_headers.c
@@ -23,7 +23,7 @@ static bool s_add_native_header(struct aws_array_list *native_headers, PyObject 
 
     const size_t name_len_max = sizeof(((struct aws_event_stream_header_value_pair *)0)->header_name) - 1;
     if (name_len > name_len_max) {
-        PyErr_SetString(PyExc_ValueError, "EventStreamHeader.name exceeds max length");
+        PyErr_SetString(PyExc_ValueError, "Header.name exceeds max length");
         goto done;
     }
 
@@ -106,7 +106,7 @@ static bool s_add_native_header(struct aws_array_list *native_headers, PyObject 
                 goto done;
             }
             if (value_len > UINT16_MAX) {
-                PyErr_SetString(PyExc_ValueError, "EventStreamHeader STRING value exceeds max length");
+                PyErr_SetString(PyExc_ValueError, "Header STRING value exceeds max length");
                 goto done;
             }
             if (aws_event_stream_add_string_header(
@@ -143,7 +143,7 @@ static bool s_add_native_header(struct aws_array_list *native_headers, PyObject 
         } break;
 
         default: {
-            PyErr_SetString(PyExc_ValueError, "EventStreamHeader.type has invalid value");
+            PyErr_SetString(PyExc_ValueError, "Header.type has invalid value");
             goto done;
         } break;
     }
@@ -166,7 +166,7 @@ bool aws_py_event_stream_native_headers_init(struct aws_array_list *native_heade
     bool success = false;
     PyObject *sequence_py = NULL;
 
-    sequence_py = PySequence_Fast(headers_py, "Expected sequence of EventStreamHeaders"); /* New reference */
+    sequence_py = PySequence_Fast(headers_py, "Expected sequence of Headers"); /* New reference */
     if (!sequence_py) {
         goto done;
     }

--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -42,7 +42,7 @@ struct connection_binding {
 };
 
 struct aws_event_stream_rpc_client_connection *aws_py_get_event_stream_rpc_client_connection(PyObject *connection) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(connection, s_capsule_name, "EventStreamRpcClientConnection", connection_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(connection, s_capsule_name, "ClientConnection", connection_binding);
 }
 
 PyObject *aws_py_event_stream_rpc_client_connection_connect(PyObject *self, PyObject *args) {

--- a/source/event_stream_rpc_client_continuation.c
+++ b/source/event_stream_rpc_client_continuation.c
@@ -1,0 +1,357 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include "event_stream.h"
+
+#include <aws/event-stream/event_stream_rpc_client.h>
+
+struct continuation_binding;
+static void s_continuation_capsule_destructor(PyObject *capsule);
+static void s_continuation_destroy_if_ready(struct continuation_binding *continuation);
+static void s_on_continuation_closed(struct aws_event_stream_rpc_client_continuation_token *native, void *user_data);
+static void s_on_continuation_message(
+    struct aws_event_stream_rpc_client_continuation_token *native,
+    const struct aws_event_stream_rpc_message_args *message_args,
+    void *user_data);
+
+static const char *s_capsule_name = "aws_event_stream_rpc_client_continuation_token";
+
+struct continuation_binding {
+    struct aws_event_stream_rpc_client_continuation_token *native;
+
+    /* Binding cannot be destroyed until:
+     * capsule has been destroyed AND
+     * ((continuation was activated AND closed) OR (never activated at all)) */
+    bool capsule_destroyed;
+    bool has_activated;
+    bool has_closed;
+
+    PyObject *on_message;
+    PyObject *on_closed;
+};
+
+struct aws_event_stream_rpc_client_continuation_token *aws_py_get_event_stream_rpc_client_continuation(
+    PyObject *continuation) {
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(
+        continuation, s_capsule_name, "EventStreamRpcClientContinuation", continuation_binding);
+}
+
+PyObject *aws_py_event_stream_rpc_client_connection_new_stream(PyObject *self, PyObject *args) {
+    (void)self;
+
+    PyObject *connection_py;
+    PyObject *on_message_py;
+    PyObject *on_closed_py;
+    if (!PyArg_ParseTuple(args, "OOO", &connection_py, &on_message_py, &on_closed_py)) {
+        return NULL;
+    }
+
+    struct aws_event_stream_rpc_client_connection *native_connection =
+        aws_py_get_event_stream_rpc_client_connection(connection_py);
+    if (!native_connection) {
+        return NULL;
+    }
+
+    struct continuation_binding *continuation =
+        aws_mem_calloc(aws_py_get_allocator(), 1, sizeof(struct continuation_binding));
+    PyObject *capsule = PyCapsule_New(continuation, s_capsule_name, s_continuation_capsule_destructor);
+    if (!capsule) {
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur */
+
+    continuation->on_message = on_message_py;
+    Py_INCREF(continuation->on_message);
+    continuation->on_closed = on_closed_py;
+    Py_INCREF(continuation->on_closed);
+
+    struct aws_event_stream_rpc_client_stream_continuation_options options = {
+        .on_continuation = s_on_continuation_message,
+        .on_continuation_closed = s_on_continuation_closed,
+        .user_data = continuation,
+    };
+    continuation->native = aws_event_stream_rpc_client_connection_new_stream(native_connection, &options);
+    if (!continuation->native) {
+        PyErr_SetAwsLastError();
+        goto error;
+    }
+
+    return capsule;
+error:
+    /* capsule's destructor will clean up anything inside of it */
+    Py_DECREF(capsule);
+    return NULL;
+}
+
+static void s_on_continuation_closed(struct aws_event_stream_rpc_client_continuation_token *native, void *user_data) {
+    (void)native;
+    struct continuation_binding *continuation = user_data;
+
+    AWS_FATAL_ASSERT(
+        continuation->has_activated && "Illegal for on_continuation_close to fire without having activated");
+    AWS_FATAL_ASSERT(!continuation->has_closed && "Illegal for on_continuation_close to fire twice");
+    continuation->has_closed = true;
+
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
+
+    PyObject *result = PyObject_CallFunction(continuation->on_closed, "()");
+    if (result) {
+        Py_DECREF(result);
+    } else {
+        /* Callback might fail during application shutdown */
+        PyErr_WriteUnraisable(PyErr_Occurred());
+    }
+
+    s_continuation_destroy_if_ready(continuation);
+    PyGILState_Release(state);
+}
+
+static void s_continuation_capsule_destructor(PyObject *capsule) {
+    struct continuation_binding *continuation = PyCapsule_GetPointer(capsule, s_capsule_name);
+    continuation->capsule_destroyed = true;
+    s_continuation_destroy_if_ready(continuation);
+}
+
+static void s_continuation_destroy_if_ready(struct continuation_binding *continuation) {
+    bool destroy;
+    if (continuation->native) {
+        if (continuation->capsule_destroyed) {
+            if (continuation->has_activated) {
+                if (continuation->has_closed) {
+                    /* python class has been GC'd and continuation is complete */
+                    destroy = true;
+                } else {
+                    /* python class been GC'd but continuation hasn't finished */
+                    destroy = false;
+                }
+            } else {
+                /* capsule has been GC'd and continuation was never activated */
+                destroy = true;
+            }
+        } else {
+            /* capsule still alive */
+            destroy = false;
+        }
+    } else {
+        /* native continuation creation failed */
+        destroy = true;
+    }
+
+    if (destroy) {
+        aws_event_stream_rpc_client_continuation_release(continuation->native);
+        Py_XDECREF(continuation->on_message);
+        Py_XDECREF(continuation->on_closed);
+        aws_mem_release(aws_py_get_allocator(), continuation);
+    }
+}
+
+static void s_on_continuation_message(
+    struct aws_event_stream_rpc_client_continuation_token *native,
+    const struct aws_event_stream_rpc_message_args *message_args,
+    void *user_data) {
+
+    (void)native;
+    struct continuation_binding *continuation = user_data;
+
+    PyGILState_STATE state;
+    if (aws_py_gilstate_ensure(&state)) {
+        return; /* Python has shut down. Nothing matters anymore, but don't crash */
+    }
+
+    /* We always want to deliver bytes to python user, even if the length is 0.
+     * But PyObject_CallFunction() with "y#" will convert a NULL ptr to None instead of 0-length bytes.
+     * Therefore, if message_args->payload_buffer is NULL, pass some other valid ptr instead. */
+    const char *payload_ptr = (void *)message_args->payload->buffer;
+    if (payload_ptr == NULL) {
+        payload_ptr = "";
+    }
+
+    PyObject *result = PyObject_CallFunction(
+        continuation->on_message,
+        "(Oy#iI)",
+        /* NOTE: if headers_create() returns NULL, then PyObject_CallFunction() fails too, which is convenient */
+        aws_py_event_stream_python_headers_create(message_args->headers, message_args->headers_count),
+        payload_ptr,
+        message_args->payload->len,
+        message_args->message_type,
+        message_args->message_flags);
+    if (result) {
+        Py_DECREF(result);
+    } else {
+        /* Callback might fail during application shutdown */
+        PyErr_WriteUnraisable(PyErr_Occurred());
+
+        /* TODO: Should we close the stream on an unhandled exception?
+         * If so, do we differentiate between internal failure and failure stemming from the user's callback? */
+    }
+
+    PyGILState_Release(state);
+}
+
+PyObject *aws_py_event_stream_rpc_client_continuation_activate(PyObject *self, PyObject *args) {
+    (void)self;
+
+    PyObject *capsule_py;
+    const char *operation_name;
+    Py_ssize_t operation_name_len;
+    PyObject *headers_py;
+    Py_buffer payload_buf; /* Py_buffers must be released after successful PyArg_ParseTuple() calls */
+    int message_type;
+    uint32_t message_flags;
+    PyObject *on_flush_py;
+    if (!PyArg_ParseTuple(
+            args,
+            "Os#Os*iIO",
+            &capsule_py,
+            &operation_name,
+            &operation_name_len,
+            &headers_py,
+            &payload_buf,
+            &message_type,
+            &message_flags,
+            &on_flush_py)) {
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur */
+
+    bool success = false;
+    struct aws_array_list headers;
+    AWS_ZERO_STRUCT(headers);
+    bool has_activated_prev_value = false;
+    Py_INCREF(on_flush_py); /* Keep completion callback alive until it fires */
+
+    struct continuation_binding *continuation = PyCapsule_GetPointer(capsule_py, s_capsule_name);
+    if (!continuation) {
+        goto done;
+    }
+
+    has_activated_prev_value = continuation->has_activated;
+    continuation->has_activated = true;
+
+    if (!aws_py_event_stream_native_headers_init(&headers, headers_py)) {
+        goto done;
+    }
+
+    struct aws_byte_buf payload = aws_byte_buf_from_array(payload_buf.buf, payload_buf.len);
+    struct aws_event_stream_rpc_message_args msg_args = {
+        .headers = headers.data,
+        .headers_count = aws_array_list_length(&headers),
+        .payload = &payload,
+        .message_type = message_type,
+        .message_flags = message_flags,
+    };
+    if (aws_event_stream_rpc_client_continuation_activate(
+            continuation->native,
+            aws_byte_cursor_from_array(operation_name, (size_t)operation_name_len),
+            &msg_args,
+            aws_py_event_stream_rpc_client_on_message_flush,
+            on_flush_py)) {
+        PyErr_SetAwsLastError();
+        goto done;
+    }
+
+    success = true;
+
+done:
+    PyBuffer_Release(&payload_buf);
+    if (aws_array_list_is_valid(&headers)) {
+        aws_event_stream_headers_list_cleanup(&headers);
+    }
+
+    if (success) {
+        Py_RETURN_NONE;
+    }
+
+    /* failed */
+    Py_DECREF(on_flush_py);
+    if (continuation) {
+        continuation->has_activated = has_activated_prev_value;
+    }
+    return NULL;
+}
+
+PyObject *aws_py_event_stream_rpc_client_continuation_send_message(PyObject *self, PyObject *args) {
+    (void)self;
+
+    PyObject *capsule_py;
+    PyObject *headers_py;
+    Py_buffer payload_buf; /* Py_buffers must be released after successful PyArg_ParseTuple() calls */
+    int message_type;
+    uint32_t message_flags;
+    PyObject *on_flush_py;
+    if (!PyArg_ParseTuple(
+            args, "OOs*iIO", &capsule_py, &headers_py, &payload_buf, &message_type, &message_flags, &on_flush_py)) {
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur */
+
+    bool success = false;
+    struct aws_array_list headers;
+    AWS_ZERO_STRUCT(headers);
+
+    /* Keep completion callback alive until it fires */
+    Py_INCREF(on_flush_py);
+
+    struct continuation_binding *continuation = PyCapsule_GetPointer(capsule_py, s_capsule_name);
+    if (!continuation) {
+        goto done;
+    }
+
+    if (!aws_py_event_stream_native_headers_init(&headers, headers_py)) {
+        goto done;
+    }
+
+    struct aws_byte_buf payload = aws_byte_buf_from_array(payload_buf.buf, payload_buf.len);
+    struct aws_event_stream_rpc_message_args msg_args = {
+        .headers = headers.data,
+        .headers_count = aws_array_list_length(&headers),
+        .payload = &payload,
+        .message_type = message_type,
+        .message_flags = message_flags,
+    };
+    if (aws_event_stream_rpc_client_continuation_send_message(
+            continuation->native, &msg_args, aws_py_event_stream_rpc_client_on_message_flush, on_flush_py)) {
+        PyErr_SetAwsLastError();
+        goto done;
+    }
+
+    success = true;
+
+done:
+    PyBuffer_Release(&payload_buf);
+    if (aws_array_list_is_valid(&headers)) {
+        aws_event_stream_headers_list_cleanup(&headers);
+    }
+
+    if (success) {
+        Py_RETURN_NONE;
+    }
+
+    Py_DECREF(on_flush_py);
+    return NULL;
+}
+
+PyObject *aws_py_event_stream_rpc_client_continuation_is_closed(PyObject *self, PyObject *args) {
+    (void)self;
+    PyObject *capsule;
+    if (!PyArg_ParseTuple(args, "O", &capsule)) {
+        return NULL;
+    }
+
+    struct continuation_binding *continuation = PyCapsule_GetPointer(capsule, s_capsule_name);
+    if (!continuation) {
+        return NULL;
+    }
+
+    if (aws_event_stream_rpc_client_continuation_is_closed(continuation->native)) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}

--- a/source/event_stream_rpc_client_continuation.c
+++ b/source/event_stream_rpc_client_continuation.c
@@ -33,8 +33,7 @@ struct continuation_binding {
 
 struct aws_event_stream_rpc_client_continuation_token *aws_py_get_event_stream_rpc_client_continuation(
     PyObject *continuation) {
-    AWS_PY_RETURN_NATIVE_FROM_BINDING(
-        continuation, s_capsule_name, "EventStreamRpcClientContinuation", continuation_binding);
+    AWS_PY_RETURN_NATIVE_FROM_BINDING(continuation, s_capsule_name, "ClientContinuation", continuation_binding);
 }
 
 PyObject *aws_py_event_stream_rpc_client_connection_new_stream(PyObject *self, PyObject *args) {

--- a/source/module.c
+++ b/source/module.c
@@ -550,6 +550,10 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_close, METH_VARARGS),
     AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_is_open, METH_VARARGS),
     AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_send_protocol_message, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_connection_new_stream, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_continuation_activate, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_continuation_send_message, METH_VARARGS),
+    AWS_PY_METHOD_DEF(event_stream_rpc_client_continuation_is_closed, METH_VARARGS),
 
     {NULL, NULL, 0, NULL},
 };

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -6,7 +6,11 @@ from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 from queue import Queue
 from test import NativeResourceTest, TIMEOUT
 import time
+from unittest import skipUnless
 from uuid import UUID, uuid4
+
+# TODO: setup permanent online echo server we can hit from tests
+RUN_LOCALHOST_TESTS = True
 
 
 class TestHeaders(NativeResourceTest):
@@ -137,38 +141,80 @@ class EventRecord:
         self.failure = None
 
 
-class SimpleHandler(EventStreamRpcClientConnectionHandler):
-    def __init__(self):
-        super().__init__()
+class ConnectionHandler(EventStreamRpcClientConnectionHandler):
+    def __init__(self, fail_test_fn):
         self.record = EventRecord()
+        self.fail_test = fail_test_fn
+        self.connection = None
 
-    def on_connection_setup(self, **kwargs):
+    def on_connection_setup(self, connection, error, **kwargs):
         if self.record.setup_call is not None:
-            self.record.failure = "setup can only fire once"
-        self.record.setup_call = {}
+            self.fail_test("setup can only fire once")
+        self.record.setup_call = {'connection': connection, 'error': error}
+        self.connection = connection
 
     def on_connection_shutdown(self, reason, **kwargs):
         if self.record.setup_call is None:
-            self.record.failure = "if setup doesn't fire, shutdown shouldn't fire"
+            self.fail_test("if setup doesn't fire, shutdown shouldn't fire")
+        if self.record.setup_call['error'] is not None:
+            self.fail_test("shutdown shouldn't fire if setup had an error")
         if self.record.shutdown_call is not None:
-            self.record.failure = "shutdown can only fire once"
+            self.fail_test("shutdown can only fire once")
         self.record.shutdown_call = {'reason': reason}
 
     def on_protocol_message(self, headers, payload, message_type, flags, **kwargs):
         if self.record.setup_call is None:
-            self.record.failure = "setup must fire before messages"
+            self.fail_test("setup must fire before messages")
         if self.record.shutdown_call is not None:
-            self.record.failure = "messages cannot fire after shutdown"
+            self.fail_test("messages cannot fire after shutdown")
         self.record.message_calls.put(
             {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
 
 
+class ContinuationRecord:
+    def __init__(self):
+        self.message_calls = Queue()
+        self.close_call = None
+        self.failure = None
+
+
+class ContinuationHandler(EventStreamRpcClientContinuationHandler):
+    def __init__(self, fail_test_fn):
+        self.record = ContinuationRecord()
+        self.fail_test = fail_test_fn
+
+    def on_continuation_message(
+            self,
+            headers,
+            payload,
+            message_type,
+            flags,
+            **kwargs):
+        if self.record.close_call:
+            self.fail_test("messages should not fire after close")
+        self.record.message_calls.put(
+            {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
+
+    def on_continuation_closed(self, **kwargs):
+        if self.record.close_call:
+            self.fail_test("shutdown can only fire once")
+        self.record.close_call = {}
+
+
 class TestClient(NativeResourceTest):
+
+    def _fail_test_from_callback(self, msg):
+        print("ERROR FROM CALLBACK", msg)
+        self._failure_from_callback = msg
+
+    def _assertNoFailuresFromCallbacks(self):
+        self.assertIsNone(getattr(self, '_failure_from_callback', None))
+
     def test_connect_failure(self):
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
-        handler = SimpleHandler()
+        handler = ConnectionHandler(self._fail_test_from_callback)
         future = EventStreamRpcClientConnection.connect(
             handler=handler,
             host_name="fake",
@@ -177,16 +223,18 @@ class TestClient(NativeResourceTest):
 
         failure = future.exception(TIMEOUT)
         self.assertTrue(isinstance(failure, Exception))
-        self.assertIsNone(handler.record.setup_call)
+        self.assertIsNotNone(handler.record.setup_call)
+        self.assertIsNone(handler.record.setup_call['connection'])
+        self.assertTrue(isinstance(handler.record.setup_call['error'], Exception))
         self.assertIsNone(handler.record.shutdown_call)
-        self.assertIsNone(handler.record.failure)
+        self._assertNoFailuresFromCallbacks()
 
+    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
     def test_connect_success(self):
-        self.skipTest("Skipping until we have permanent echo server")
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
-        handler = SimpleHandler()
+        handler = ConnectionHandler(self._fail_test_from_callback)
         future = EventStreamRpcClientConnection.connect(
             handler=handler,
             host_name="127.0.0.1",
@@ -195,6 +243,8 @@ class TestClient(NativeResourceTest):
 
         self.assertIsNone(future.exception(TIMEOUT))
         self.assertIsNotNone(handler.record.setup_call)
+        self.assertTrue(isinstance(handler.record.setup_call['connection'], EventStreamRpcClientConnection))
+        self.assertIsNone(handler.record.setup_call['error'])
         self.assertTrue(handler.connection.is_open())
         self.assertIsNone(handler.record.shutdown_call)
 
@@ -204,14 +254,14 @@ class TestClient(NativeResourceTest):
         self.assertIsNotNone(handler.record.shutdown_call)
         self.assertIsNone(handler.record.shutdown_call['reason'])
 
-        self.assertIsNone(handler.record.failure)
+        self._assertNoFailuresFromCallbacks()
 
+    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
     def test_closes_on_zero_refcount(self):
-        self.skipTest("Skipping until we have permanent echo server")
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
-        handler = SimpleHandler()
+        handler = ConnectionHandler(self._fail_test_from_callback)
         future = EventStreamRpcClientConnection.connect(
             handler=handler,
             host_name="127.0.0.1",
@@ -229,19 +279,20 @@ class TestClient(NativeResourceTest):
         # the shutdown_future should complete, but the handler's shutdown
         # callback should not fire in this test because the handler has been deleted.
         del handler
+        del record.setup_call # we were storing another reference to connection here
         self.assertIsNone(shutdown_future.exception(TIMEOUT))
         self.assertIsNone(
             record.shutdown_call,
             "on_connection_shutdown shouldn't fire if handler is garbage collected before connection finishes shutdown")
 
-        self.assertIsNone(record.failure)
+        self._assertNoFailuresFromCallbacks()
 
+    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
     def test_echo(self):
-        self.skipTest("Skipping until we have permanent echo server")
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
-        handler = SimpleHandler()
+        handler = ConnectionHandler(self._fail_test_from_callback)
         connect_future = EventStreamRpcClientConnection.connect(
             handler=handler,
             host_name="127.0.0.1",
@@ -274,6 +325,8 @@ class TestClient(NativeResourceTest):
             EventStreamHeader.from_int64('echo-int64', 999999999999),
             EventStreamHeader.from_byte_buf('echo-byte-buf', b'\x00\xff\x0f\xf0'),
             EventStreamHeader.from_string('echo-string', 'noodles'),
+            # utf-8 breaks echo test. don't get response.
+            #EventStreamHeader.from_string('echo-string-utf8', '--\u1234--'),
             EventStreamHeader.from_timestamp('echo-timestamp', time.time()),
             EventStreamHeader.from_uuid('echo-uuid', UUID('01234567-89ab-cdef-0123-456789abcdef')),
         ]
@@ -294,4 +347,60 @@ class TestClient(NativeResourceTest):
             self.assertEqual(sent_header.value, recv_header.value)
         self.assertEqual(echo_payload, msg['payload'])
 
-        self.assertIsNone(handler.record.failure)
+        # use a stream to execute the "EchoMessage" operation,
+        # which takes 1 message and responds with 1 message
+        stream_handler = ContinuationHandler(self._fail_test_from_callback)
+        stream_handler.continuation = handler.connection.new_stream(stream_handler)
+        msg_future = stream_handler.continuation.activate(
+            operation='awstest#EchoMessage',
+            headers=[],
+            payload=b'{}',
+            message_type=EventStreamRpcMessageType.APPLICATION_MESSAGE,
+            flags=EventStreamRpcMessageFlag.NONE)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to receive response, which should end the stream
+        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertEqual(EventStreamRpcMessageType.APPLICATION_MESSAGE, msg['message_type'])
+        self.assertTrue(EventStreamRpcMessageFlag.TERMINATE_STREAM & msg['flags'])
+        self.assertIsNone(stream_handler.continuation.closed_future.exception(TIMEOUT))
+
+        # use a stream to execute the "EchoStreamMessages" operation,
+        # which has an empty initial request/response, but then allows further messages
+        stream_handler = ContinuationHandler(self._fail_test_from_callback)
+        stream_handler.continuation = handler.connection.new_stream(stream_handler)
+        msg_future = stream_handler.continuation.activate(
+            operation='awstest#EchoStreamMessages',
+            headers=[],
+            payload=b'{}',
+            message_type=EventStreamRpcMessageType.APPLICATION_MESSAGE,
+            flags=EventStreamRpcMessageFlag.NONE)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to initial response, which should end the stream
+        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertEqual(EventStreamRpcMessageType.APPLICATION_MESSAGE, msg['message_type'])
+        self.assertFalse(EventStreamRpcMessageFlag.TERMINATE_STREAM & msg['flags'])
+
+        # send a 2nd message on the stream
+        msg_future = stream_handler.continuation.send_message(
+            headers=[],
+            payload=b'{}',
+            message_type=EventStreamRpcMessageType.APPLICATION_MESSAGE,
+            flags=EventStreamRpcMessageFlag.NONE)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait for 2nd response
+        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertEqual(EventStreamRpcMessageType.APPLICATION_MESSAGE, msg['message_type'])
+        self.assertFalse(EventStreamRpcMessageFlag.TERMINATE_STREAM & msg['flags'])
+
+        # close connection
+        handler.connection.close()
+        self.assertIsNone(handler.connection.shutdown_future.exception(TIMEOUT))
+        self.assertIsNone(stream_handler.continuation.closed_future.exception(TIMEOUT))
+
+        self._assertNoFailuresFromCallbacks()

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -2,23 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from awscrt.eventstream import *
-from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
-from queue import Queue
-from test import NativeResourceTest, TIMEOUT
+from test import NativeResourceTest
 import time
-from unittest import skipUnless
 from uuid import UUID, uuid4
-
-# TODO: setup permanent online echo server we can hit from tests
-RUN_LOCALHOST_TESTS = False
 
 
 class TestHeaders(NativeResourceTest):
     def test_bool_true(self):
         name = 'truthy'
         value = True
-        h = EventStreamHeader.from_bool(name, value)
-        self.assertIs(EventStreamHeaderType.BOOL_TRUE, h.type)
+        h = Header.from_bool(name, value)
+        self.assertIs(HeaderType.BOOL_TRUE, h.type)
         self.assertEqual(value, h.value_as_bool())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
@@ -26,8 +20,8 @@ class TestHeaders(NativeResourceTest):
     def test_bool_false(self):
         name = 'falsey'
         value = False
-        h = EventStreamHeader.from_bool(name, value)
-        self.assertIs(EventStreamHeaderType.BOOL_FALSE, h.type)
+        h = Header.from_bool(name, value)
+        self.assertIs(HeaderType.BOOL_FALSE, h.type)
         self.assertEqual(value, h.value_as_bool())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
@@ -35,56 +29,56 @@ class TestHeaders(NativeResourceTest):
     def test_byte(self):
         name = 'bytey'
         value = 127
-        h = EventStreamHeader.from_byte(name, value)
-        self.assertIs(EventStreamHeaderType.BYTE, h.type)
+        h = Header.from_byte(name, value)
+        self.assertIs(HeaderType.BYTE, h.type)
         self.assertEqual(value, h.value_as_byte())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_byte, 'too-big', 128)
-        self.assertRaises(ValueError, EventStreamHeader.from_byte, 'too-small', -129)
+        self.assertRaises(ValueError, Header.from_byte, 'too-big', 128)
+        self.assertRaises(ValueError, Header.from_byte, 'too-small', -129)
 
     def test_int16(self):
         name = 'sweet16'
         value = 32000
-        h = EventStreamHeader.from_int16(name, value)
-        self.assertIs(EventStreamHeaderType.INT16, h.type)
+        h = Header.from_int16(name, value)
+        self.assertIs(HeaderType.INT16, h.type)
         self.assertEqual(value, h.value_as_int16())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-big', 64000)
-        self.assertRaises(ValueError, EventStreamHeader.from_int16, 'too-small', -64000)
+        self.assertRaises(ValueError, Header.from_int16, 'too-big', 64000)
+        self.assertRaises(ValueError, Header.from_int16, 'too-small', -64000)
 
     def test_int32(self):
         name = 'win32'
         value = 2000000000
-        h = EventStreamHeader.from_int32(name, value)
-        self.assertIs(EventStreamHeaderType.INT32, h.type)
+        h = Header.from_int32(name, value)
+        self.assertIs(HeaderType.INT32, h.type)
         self.assertEqual(value, h.value_as_int32())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 4000000000)
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -4000000000)
+        self.assertRaises(ValueError, Header.from_int32, 'too-big', 4000000000)
+        self.assertRaises(ValueError, Header.from_int32, 'too-small', -4000000000)
 
     def test_int64(self):
         name = 'N64'
         value = 9223372036854775807
-        h = EventStreamHeader.from_int64(name, value)
-        self.assertIs(EventStreamHeaderType.INT64, h.type)
+        h = Header.from_int64(name, value)
+        self.assertIs(HeaderType.INT64, h.type)
         self.assertEqual(value, h.value_as_int64())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-big', 18000000000000000000)
-        self.assertRaises(ValueError, EventStreamHeader.from_int32, 'too-small', -18000000000000000000)
+        self.assertRaises(ValueError, Header.from_int32, 'too-big', 18000000000000000000)
+        self.assertRaises(ValueError, Header.from_int32, 'too-small', -18000000000000000000)
 
     def test_byte_buf(self):
         name = 'buffy'
         value = bytes(range(0, 256)) * 100
-        h = EventStreamHeader.from_byte_buf(name, value)
-        self.assertIs(EventStreamHeaderType.BYTE_BUF, h.type)
+        h = Header.from_byte_buf(name, value)
+        self.assertIs(HeaderType.BYTE_BUF, h.type)
         self.assertEqual(value, h.value_as_byte_buf())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
@@ -92,8 +86,8 @@ class TestHeaders(NativeResourceTest):
     def test_string(self):
         name = 'stringy'
         value = 'abcdefghijklmnopqrstuvwxyz' * 100
-        h = EventStreamHeader.from_string(name, value)
-        self.assertIs(EventStreamHeaderType.STRING, h.type)
+        h = Header.from_string(name, value)
+        self.assertIs(HeaderType.STRING, h.type)
         self.assertEqual(value, h.value_as_string())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
@@ -101,8 +95,8 @@ class TestHeaders(NativeResourceTest):
     def test_timestamp(self):
         name = 'timeywimey'
         value = time.time()
-        h = EventStreamHeader.from_timestamp(name, value)
-        self.assertIs(EventStreamHeaderType.TIMESTAMP, h.type)
+        h = Header.from_timestamp(name, value)
+        self.assertIs(HeaderType.TIMESTAMP, h.type)
         # compare with delta, since protocol uses int instead of float
         self.assertAlmostEqual(value, h.value_as_timestamp(), delta=1.0)
         self.assertAlmostEqual(value, h.value, delta=1.0)
@@ -111,14 +105,14 @@ class TestHeaders(NativeResourceTest):
     def test_uuid(self):
         name = 'davuuid'
         value = UUID('01234567-89ab-cdef-0123-456789abcdef')
-        h = EventStreamHeader.from_uuid(name, value)
-        self.assertIs(EventStreamHeaderType.UUID, h.type)
+        h = Header.from_uuid(name, value)
+        self.assertIs(HeaderType.UUID, h.type)
         self.assertEqual(value, h.value_as_uuid())
         self.assertEqual(value, h.value)
         self.assertEqual(name, h.name)
 
     def test_wrong_type(self):
-        h = EventStreamHeader.from_bool('truthy', True)
+        h = Header.from_bool('truthy', True)
         self.assertRaises(TypeError, h.value_as_byte)
         self.assertRaises(TypeError, h.value_as_int16)
         self.assertRaises(TypeError, h.value_as_int32)
@@ -128,279 +122,6 @@ class TestHeaders(NativeResourceTest):
         self.assertRaises(TypeError, h.value_as_timestamp)
         self.assertRaises(TypeError, h.value_as_uuid)
 
-        h = EventStreamHeader.from_int32('32', 32)
+        h = Header.from_int32('32', 32)
         self.assertRaises(TypeError, h.value_as_bool)
         self.assertRaises(TypeError, h.value_as_int64)
-
-
-class EventRecord:
-    def __init__(self):
-        self.setup_call = None
-        self.shutdown_call = None
-        self.message_calls = Queue()
-        self.failure = None
-
-
-class ConnectionHandler(EventStreamRpcClientConnectionHandler):
-    def __init__(self, fail_test_fn):
-        self.record = EventRecord()
-        self.fail_test = fail_test_fn
-        self.connection = None
-
-    def on_connection_setup(self, connection, error, **kwargs):
-        if self.record.setup_call is not None:
-            self.fail_test("setup can only fire once")
-        self.record.setup_call = {'connection': connection, 'error': error}
-        self.connection = connection
-
-    def on_connection_shutdown(self, reason, **kwargs):
-        if self.record.setup_call is None:
-            self.fail_test("if setup doesn't fire, shutdown shouldn't fire")
-        if self.record.setup_call['error'] is not None:
-            self.fail_test("shutdown shouldn't fire if setup had an error")
-        if self.record.shutdown_call is not None:
-            self.fail_test("shutdown can only fire once")
-        self.record.shutdown_call = {'reason': reason}
-
-    def on_protocol_message(self, headers, payload, message_type, flags, **kwargs):
-        if self.record.setup_call is None:
-            self.fail_test("setup must fire before messages")
-        if self.record.shutdown_call is not None:
-            self.fail_test("messages cannot fire after shutdown")
-        self.record.message_calls.put(
-            {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
-
-
-class ContinuationRecord:
-    def __init__(self):
-        self.message_calls = Queue()
-        self.close_call = None
-        self.failure = None
-
-
-class ContinuationHandler(EventStreamRpcClientContinuationHandler):
-    def __init__(self, fail_test_fn):
-        self.record = ContinuationRecord()
-        self.fail_test = fail_test_fn
-
-    def on_continuation_message(
-            self,
-            headers,
-            payload,
-            message_type,
-            flags,
-            **kwargs):
-        if self.record.close_call:
-            self.fail_test("messages should not fire after close")
-        self.record.message_calls.put(
-            {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
-
-    def on_continuation_closed(self, **kwargs):
-        if self.record.close_call:
-            self.fail_test("shutdown can only fire once")
-        self.record.close_call = {}
-
-
-class TestClient(NativeResourceTest):
-
-    def _fail_test_from_callback(self, msg):
-        print("ERROR FROM CALLBACK", msg)
-        self._failure_from_callback = msg
-
-    def _assertNoFailuresFromCallbacks(self):
-        self.assertIsNone(getattr(self, '_failure_from_callback', None))
-
-    def test_connect_failure(self):
-        elg = EventLoopGroup()
-        resolver = DefaultHostResolver(elg)
-        bootstrap = ClientBootstrap(elg, resolver)
-        handler = ConnectionHandler(self._fail_test_from_callback)
-        future = EventStreamRpcClientConnection.connect(
-            handler=handler,
-            host_name="fake",
-            port=99,
-            bootstrap=bootstrap)
-
-        failure = future.exception(TIMEOUT)
-        self.assertTrue(isinstance(failure, Exception))
-        self.assertIsNotNone(handler.record.setup_call)
-        self.assertIsNone(handler.record.setup_call['connection'])
-        self.assertTrue(isinstance(handler.record.setup_call['error'], Exception))
-        self.assertIsNone(handler.record.shutdown_call)
-        self._assertNoFailuresFromCallbacks()
-
-    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
-    def test_connect_success(self):
-        elg = EventLoopGroup()
-        resolver = DefaultHostResolver(elg)
-        bootstrap = ClientBootstrap(elg, resolver)
-        handler = ConnectionHandler(self._fail_test_from_callback)
-        future = EventStreamRpcClientConnection.connect(
-            handler=handler,
-            host_name="127.0.0.1",
-            port=8033,
-            bootstrap=bootstrap)
-
-        self.assertIsNone(future.exception(TIMEOUT))
-        self.assertIsNotNone(handler.record.setup_call)
-        self.assertTrue(isinstance(handler.record.setup_call['connection'], EventStreamRpcClientConnection))
-        self.assertIsNone(handler.record.setup_call['error'])
-        self.assertTrue(handler.connection.is_open())
-        self.assertIsNone(handler.record.shutdown_call)
-
-        # close
-        shutdown_future = handler.connection.close()
-        self.assertIsNone(shutdown_future.exception(TIMEOUT))
-        self.assertIsNotNone(handler.record.shutdown_call)
-        self.assertIsNone(handler.record.shutdown_call['reason'])
-
-        self._assertNoFailuresFromCallbacks()
-
-    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
-    def test_closes_on_zero_refcount(self):
-        elg = EventLoopGroup()
-        resolver = DefaultHostResolver(elg)
-        bootstrap = ClientBootstrap(elg, resolver)
-        handler = ConnectionHandler(self._fail_test_from_callback)
-        future = EventStreamRpcClientConnection.connect(
-            handler=handler,
-            host_name="127.0.0.1",
-            port=8033,
-            bootstrap=bootstrap)
-
-        # connection should succeed
-        self.assertIsNone(future.exception(TIMEOUT))
-
-        # grab pointers to stuff that will tell us about how shutdown went,
-        record = handler.record
-        shutdown_future = handler.connection.shutdown_future
-
-        # connection should shut itself down when all references are released.
-        # the shutdown_future should complete, but the handler's shutdown
-        # callback should not fire in this test because the handler has been deleted.
-        del handler
-        del record.setup_call  # we were storing another reference to connection here
-        self.assertIsNone(shutdown_future.exception(TIMEOUT))
-        self.assertIsNone(
-            record.shutdown_call,
-            "on_connection_shutdown shouldn't fire if handler is garbage collected before connection finishes shutdown")
-
-        self._assertNoFailuresFromCallbacks()
-
-    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
-    def test_echo(self):
-        elg = EventLoopGroup()
-        resolver = DefaultHostResolver(elg)
-        bootstrap = ClientBootstrap(elg, resolver)
-        handler = ConnectionHandler(self._fail_test_from_callback)
-        connect_future = EventStreamRpcClientConnection.connect(
-            handler=handler,
-            host_name="127.0.0.1",
-            port=8033,
-            bootstrap=bootstrap)
-
-        self.assertIsNone(connect_future.exception(TIMEOUT))
-
-        # send CONNECT msg
-        msg_future = handler.connection.send_protocol_message(
-            message_type=EventStreamRpcMessageType.CONNECT,
-            headers=[EventStreamHeader.from_string(':version', '0.1.0'),
-                     EventStreamHeader.from_string('client-name', 'accepted.testy_mc_testerson')])
-
-        self.assertIsNone(msg_future.exception(TIMEOUT))
-
-        # wait to receive CONNECT_ACK
-        msg = handler.record.message_calls.get(timeout=TIMEOUT)
-        self.assertIs(EventStreamRpcMessageType.CONNECT_ACK, msg['message_type'])
-        self.assertTrue(EventStreamRpcMessageFlag.CONNECTION_ACCEPTED & msg['flags'])
-
-        # send PING msg, server will echo back its headers and payload in the PING_RESPONSE.
-        # test every single header type
-        echo_headers = [
-            EventStreamHeader.from_bool('echo-true', True),
-            EventStreamHeader.from_bool('echo-false', False),
-            EventStreamHeader.from_byte('echo-byte', 127),
-            EventStreamHeader.from_int16('echo-int16', 32000),
-            EventStreamHeader.from_int32('echo-int32', 2000000000),
-            EventStreamHeader.from_int64('echo-int64', 999999999999),
-            EventStreamHeader.from_byte_buf('echo-byte-buf', b'\x00\xff\x0f\xf0'),
-            EventStreamHeader.from_string('echo-string', 'noodles'),
-            # utf-8 breaks echo test. don't get response.
-            #EventStreamHeader.from_string('echo-string-utf8', '--\u1234--'),
-            EventStreamHeader.from_timestamp('echo-timestamp', time.time()),
-            EventStreamHeader.from_uuid('echo-uuid', UUID('01234567-89ab-cdef-0123-456789abcdef')),
-        ]
-        echo_payload = b'\x00\xDE\xAD\xBE\xEF'
-        msg_future = handler.connection.send_protocol_message(
-            message_type=EventStreamRpcMessageType.PING,
-            headers=echo_headers,
-            payload=echo_payload)
-
-        self.assertIsNone(msg_future.exception(TIMEOUT))
-
-        # wait to receive PING_RESPONSE, which should echo what we sent
-        msg = handler.record.message_calls.get(timeout=TIMEOUT)
-        self.assertIs(EventStreamRpcMessageType.PING_RESPONSE, msg['message_type'])
-        for sent_header in echo_headers:
-            recv_header = next(x for x in msg['headers'] if x.name.lower() == sent_header.name.lower())
-            self.assertEqual(sent_header.type, recv_header.type)
-            self.assertEqual(sent_header.value, recv_header.value)
-        self.assertEqual(echo_payload, msg['payload'])
-
-        # use a stream to execute the "EchoMessage" operation,
-        # which takes 1 message and responds with 1 message
-        stream_handler = ContinuationHandler(self._fail_test_from_callback)
-        stream_handler.continuation = handler.connection.new_stream(stream_handler)
-        msg_future = stream_handler.continuation.activate(
-            operation='awstest#EchoMessage',
-            headers=[],
-            payload=b'{}',
-            message_type=EventStreamRpcMessageType.APPLICATION_MESSAGE,
-            flags=EventStreamRpcMessageFlag.NONE)
-
-        self.assertIsNone(msg_future.exception(TIMEOUT))
-
-        # wait to receive response, which should end the stream
-        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
-        self.assertEqual(EventStreamRpcMessageType.APPLICATION_MESSAGE, msg['message_type'])
-        self.assertTrue(EventStreamRpcMessageFlag.TERMINATE_STREAM & msg['flags'])
-        self.assertIsNone(stream_handler.continuation.closed_future.exception(TIMEOUT))
-
-        # use a stream to execute the "EchoStreamMessages" operation,
-        # which has an empty initial request/response, but then allows further messages
-        stream_handler = ContinuationHandler(self._fail_test_from_callback)
-        stream_handler.continuation = handler.connection.new_stream(stream_handler)
-        msg_future = stream_handler.continuation.activate(
-            operation='awstest#EchoStreamMessages',
-            headers=[],
-            payload=b'{}',
-            message_type=EventStreamRpcMessageType.APPLICATION_MESSAGE,
-            flags=EventStreamRpcMessageFlag.NONE)
-
-        self.assertIsNone(msg_future.exception(TIMEOUT))
-
-        # wait to initial response, which should end the stream
-        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
-        self.assertEqual(EventStreamRpcMessageType.APPLICATION_MESSAGE, msg['message_type'])
-        self.assertFalse(EventStreamRpcMessageFlag.TERMINATE_STREAM & msg['flags'])
-
-        # send a 2nd message on the stream
-        msg_future = stream_handler.continuation.send_message(
-            headers=[],
-            payload=b'{}',
-            message_type=EventStreamRpcMessageType.APPLICATION_MESSAGE,
-            flags=EventStreamRpcMessageFlag.NONE)
-
-        self.assertIsNone(msg_future.exception(TIMEOUT))
-
-        # wait for 2nd response
-        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
-        self.assertEqual(EventStreamRpcMessageType.APPLICATION_MESSAGE, msg['message_type'])
-        self.assertFalse(EventStreamRpcMessageFlag.TERMINATE_STREAM & msg['flags'])
-
-        # close connection
-        handler.connection.close()
-        self.assertIsNone(handler.connection.shutdown_future.exception(TIMEOUT))
-        self.assertIsNone(stream_handler.continuation.closed_future.exception(TIMEOUT))
-
-        self._assertNoFailuresFromCallbacks()

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -10,7 +10,7 @@ from unittest import skipUnless
 from uuid import UUID, uuid4
 
 # TODO: setup permanent online echo server we can hit from tests
-RUN_LOCALHOST_TESTS = True
+RUN_LOCALHOST_TESTS = False
 
 
 class TestHeaders(NativeResourceTest):

--- a/test/test_eventstream.py
+++ b/test/test_eventstream.py
@@ -279,7 +279,7 @@ class TestClient(NativeResourceTest):
         # the shutdown_future should complete, but the handler's shutdown
         # callback should not fire in this test because the handler has been deleted.
         del handler
-        del record.setup_call # we were storing another reference to connection here
+        del record.setup_call  # we were storing another reference to connection here
         self.assertIsNone(shutdown_future.exception(TIMEOUT))
         self.assertIsNone(
             record.shutdown_call,

--- a/test/test_eventstream_rpc.py
+++ b/test/test_eventstream_rpc.py
@@ -1,0 +1,287 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+from awscrt.eventstream import *
+from awscrt.eventstream.rpc import *
+from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
+from queue import Queue
+from test import NativeResourceTest, TIMEOUT
+import time
+from unittest import skipUnless
+from uuid import UUID, uuid4
+
+# TODO: setup permanent online echo server we can hit from tests
+RUN_LOCALHOST_TESTS = False
+
+
+class EventRecord:
+    def __init__(self):
+        self.setup_call = None
+        self.shutdown_call = None
+        self.message_calls = Queue()
+        self.failure = None
+
+
+class ConnectionHandler(ClientConnectionHandler):
+    def __init__(self, fail_test_fn):
+        self.record = EventRecord()
+        self.fail_test = fail_test_fn
+        self.connection = None
+
+    def on_connection_setup(self, connection, error, **kwargs):
+        if self.record.setup_call is not None:
+            self.fail_test("setup can only fire once")
+        self.record.setup_call = {'connection': connection, 'error': error}
+        self.connection = connection
+
+    def on_connection_shutdown(self, reason, **kwargs):
+        if self.record.setup_call is None:
+            self.fail_test("if setup doesn't fire, shutdown shouldn't fire")
+        if self.record.setup_call['error'] is not None:
+            self.fail_test("shutdown shouldn't fire if setup had an error")
+        if self.record.shutdown_call is not None:
+            self.fail_test("shutdown can only fire once")
+        self.record.shutdown_call = {'reason': reason}
+
+    def on_protocol_message(self, headers, payload, message_type, flags, **kwargs):
+        if self.record.setup_call is None:
+            self.fail_test("setup must fire before messages")
+        if self.record.shutdown_call is not None:
+            self.fail_test("messages cannot fire after shutdown")
+        self.record.message_calls.put(
+            {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
+
+
+class ContinuationRecord:
+    def __init__(self):
+        self.message_calls = Queue()
+        self.close_call = None
+        self.failure = None
+
+
+class ContinuationHandler(ClientContinuationHandler):
+    def __init__(self, fail_test_fn):
+        self.record = ContinuationRecord()
+        self.fail_test = fail_test_fn
+
+    def on_continuation_message(
+            self,
+            headers,
+            payload,
+            message_type,
+            flags,
+            **kwargs):
+        if self.record.close_call:
+            self.fail_test("messages should not fire after close")
+        self.record.message_calls.put(
+            {'headers': headers, 'payload': payload, 'message_type': message_type, 'flags': flags})
+
+    def on_continuation_closed(self, **kwargs):
+        if self.record.close_call:
+            self.fail_test("shutdown can only fire once")
+        self.record.close_call = {}
+
+
+class TestClient(NativeResourceTest):
+
+    def _fail_test_from_callback(self, msg):
+        print("ERROR FROM CALLBACK", msg)
+        self._failure_from_callback = msg
+
+    def _assertNoFailuresFromCallbacks(self):
+        self.assertIsNone(getattr(self, '_failure_from_callback', None))
+
+    def test_connect_failure(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = ConnectionHandler(self._fail_test_from_callback)
+        future = ClientConnection.connect(
+            handler=handler,
+            host_name="fake",
+            port=99,
+            bootstrap=bootstrap)
+
+        failure = future.exception(TIMEOUT)
+        self.assertTrue(isinstance(failure, Exception))
+        self.assertIsNotNone(handler.record.setup_call)
+        self.assertIsNone(handler.record.setup_call['connection'])
+        self.assertTrue(isinstance(handler.record.setup_call['error'], Exception))
+        self.assertIsNone(handler.record.shutdown_call)
+        self._assertNoFailuresFromCallbacks()
+
+    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
+    def test_connect_success(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = ConnectionHandler(self._fail_test_from_callback)
+        future = ClientConnection.connect(
+            handler=handler,
+            host_name="127.0.0.1",
+            port=8033,
+            bootstrap=bootstrap)
+
+        self.assertIsNone(future.exception(TIMEOUT))
+        self.assertIsNotNone(handler.record.setup_call)
+        self.assertTrue(isinstance(handler.record.setup_call['connection'], ClientConnection))
+        self.assertIsNone(handler.record.setup_call['error'])
+        self.assertTrue(handler.connection.is_open())
+        self.assertIsNone(handler.record.shutdown_call)
+
+        # close
+        shutdown_future = handler.connection.close()
+        self.assertIsNone(shutdown_future.exception(TIMEOUT))
+        self.assertIsNotNone(handler.record.shutdown_call)
+        self.assertIsNone(handler.record.shutdown_call['reason'])
+
+        self._assertNoFailuresFromCallbacks()
+
+    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
+    def test_closes_on_zero_refcount(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = ConnectionHandler(self._fail_test_from_callback)
+        future = ClientConnection.connect(
+            handler=handler,
+            host_name="127.0.0.1",
+            port=8033,
+            bootstrap=bootstrap)
+
+        # connection should succeed
+        self.assertIsNone(future.exception(TIMEOUT))
+
+        # grab pointers to stuff that will tell us about how shutdown went,
+        record = handler.record
+        shutdown_future = handler.connection.shutdown_future
+
+        # connection should shut itself down when all references are released.
+        # the shutdown_future should complete, but the handler's shutdown
+        # callback should not fire in this test because the handler has been deleted.
+        del handler
+        del record.setup_call  # we were storing another reference to connection here
+        self.assertIsNone(shutdown_future.exception(TIMEOUT))
+        self.assertIsNone(
+            record.shutdown_call,
+            "on_connection_shutdown shouldn't fire if handler is garbage collected before connection finishes shutdown")
+
+        self._assertNoFailuresFromCallbacks()
+
+    @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
+    def test_echo(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        handler = ConnectionHandler(self._fail_test_from_callback)
+        connect_future = ClientConnection.connect(
+            handler=handler,
+            host_name="127.0.0.1",
+            port=8033,
+            bootstrap=bootstrap)
+
+        self.assertIsNone(connect_future.exception(TIMEOUT))
+
+        # send CONNECT msg
+        msg_future = handler.connection.send_protocol_message(
+            message_type=MessageType.CONNECT,
+            headers=[Header.from_string(':version', '0.1.0'),
+                     Header.from_string('client-name', 'accepted.testy_mc_testerson')])
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to receive CONNECT_ACK
+        msg = handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertIs(MessageType.CONNECT_ACK, msg['message_type'])
+        self.assertTrue(MessageFlag.CONNECTION_ACCEPTED & msg['flags'])
+
+        # send PING msg, server will echo back its headers and payload in the PING_RESPONSE.
+        # test every single header type
+        echo_headers = [
+            Header.from_bool('echo-true', True),
+            Header.from_bool('echo-false', False),
+            Header.from_byte('echo-byte', 127),
+            Header.from_int16('echo-int16', 32000),
+            Header.from_int32('echo-int32', 2000000000),
+            Header.from_int64('echo-int64', 999999999999),
+            Header.from_byte_buf('echo-byte-buf', b'\x00\xff\x0f\xf0'),
+            Header.from_string('echo-string', 'noodles'),
+            # utf-8 breaks echo test. don't get response.
+            #Header.from_string('echo-string-utf8', '--\u1234--'),
+            Header.from_timestamp('echo-timestamp', time.time()),
+            Header.from_uuid('echo-uuid', UUID('01234567-89ab-cdef-0123-456789abcdef')),
+        ]
+        echo_payload = b'\x00\xDE\xAD\xBE\xEF'
+        msg_future = handler.connection.send_protocol_message(
+            message_type=MessageType.PING,
+            headers=echo_headers,
+            payload=echo_payload)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to receive PING_RESPONSE, which should echo what we sent
+        msg = handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertIs(MessageType.PING_RESPONSE, msg['message_type'])
+        for sent_header in echo_headers:
+            recv_header = next(x for x in msg['headers'] if x.name.lower() == sent_header.name.lower())
+            self.assertEqual(sent_header.type, recv_header.type)
+            self.assertEqual(sent_header.value, recv_header.value)
+        self.assertEqual(echo_payload, msg['payload'])
+
+        # use a stream to execute the "EchoMessage" operation,
+        # which takes 1 message and responds with 1 message
+        stream_handler = ContinuationHandler(self._fail_test_from_callback)
+        stream_handler.continuation = handler.connection.new_stream(stream_handler)
+        msg_future = stream_handler.continuation.activate(
+            operation='awstest#EchoMessage',
+            headers=[],
+            payload=b'{}',
+            message_type=MessageType.APPLICATION_MESSAGE,
+            flags=MessageFlag.NONE)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to receive response, which should end the stream
+        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertEqual(MessageType.APPLICATION_MESSAGE, msg['message_type'])
+        self.assertTrue(MessageFlag.TERMINATE_STREAM & msg['flags'])
+        self.assertIsNone(stream_handler.continuation.closed_future.exception(TIMEOUT))
+
+        # use a stream to execute the "EchoStreamMessages" operation,
+        # which has an empty initial request/response, but then allows further messages
+        stream_handler = ContinuationHandler(self._fail_test_from_callback)
+        stream_handler.continuation = handler.connection.new_stream(stream_handler)
+        msg_future = stream_handler.continuation.activate(
+            operation='awstest#EchoStreamMessages',
+            headers=[],
+            payload=b'{}',
+            message_type=MessageType.APPLICATION_MESSAGE,
+            flags=MessageFlag.NONE)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait to initial response, which should end the stream
+        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertEqual(MessageType.APPLICATION_MESSAGE, msg['message_type'])
+        self.assertFalse(MessageFlag.TERMINATE_STREAM & msg['flags'])
+
+        # send a 2nd message on the stream
+        msg_future = stream_handler.continuation.send_message(
+            headers=[],
+            payload=b'{}',
+            message_type=MessageType.APPLICATION_MESSAGE,
+            flags=MessageFlag.NONE)
+
+        self.assertIsNone(msg_future.exception(TIMEOUT))
+
+        # wait for 2nd response
+        msg = stream_handler.record.message_calls.get(timeout=TIMEOUT)
+        self.assertEqual(MessageType.APPLICATION_MESSAGE, msg['message_type'])
+        self.assertFalse(MessageFlag.TERMINATE_STREAM & msg['flags'])
+
+        # close connection
+        handler.connection.close()
+        self.assertIsNone(handler.connection.shutdown_future.exception(TIMEOUT))
+        self.assertIsNone(stream_handler.continuation.closed_future.exception(TIMEOUT))
+
+        self._assertNoFailuresFromCallbacks()


### PR DESCRIPTION
Also, some changes to the connection:
- Connection handler is now a pure abstract base class, user must store reference to connection themselves. It was weird to use the abstract-base-class stuff, but not be purely abstract
- set connection._binding from on_setup callback (instead of `connection._binding = connect()`) to avoid race condition where on_setup fires before thread calling connect() can store the binding.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
