### PR TITLE
eventstream fixes

### DIFF
--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -185,7 +185,7 @@ class ClientConnectionHandler(ABC):
         pass
 
 
-def _msg_args_for_bindings(headers, payload, message_type, flags):
+def _to_binding_msg_args(headers, payload, message_type, flags):
     """
     Transform args that a python send-msg function would take,
     into args that a native send-msg function would take.
@@ -202,7 +202,7 @@ def _msg_args_for_bindings(headers, payload, message_type, flags):
     return (headers, payload, message_type, flags)
 
 
-def _msg_args_from_bindings(headers, payload, message_type, flags):
+def _from_binding_msg_args(headers, payload, message_type, flags):
     """
     Transform msg-received args that came from native,
     into msg-received args presented to python users.
@@ -352,7 +352,7 @@ class ClientConnection(NativeResource):
         handler = bound_weak_handler()
         if handler:
             # transform from simple types to actual classes
-            headers, payload, message_type, flags = _msg_args_from_bindings(headers, payload, message_type, flags)
+            headers, payload, message_type, flags = _from_binding_msg_args(headers, payload, message_type, flags)
             handler.on_protocol_message(
                 headers=headers,
                 payload=payload,
@@ -364,7 +364,7 @@ class ClientConnection(NativeResource):
         handler = bound_weak_handler()
         if handler:
             # transform from simple types to actual classes
-            headers, payload, message_type, flags = _msg_args_from_bindings(headers, payload, message_type, flags)
+            headers, payload, message_type, flags = _from_binding_msg_args(headers, payload, message_type, flags)
             handler.on_continuation_message(
                 headers=headers,
                 payload=payload,
@@ -455,7 +455,7 @@ class ClientConnection(NativeResource):
         future = Future()
 
         # native code deals with simplified types
-        headers, payload, message_type, flags = _msg_args_for_bindings(headers, payload, message_type, flags)
+        headers, payload, message_type, flags = _to_binding_msg_args(headers, payload, message_type, flags)
 
         _awscrt.event_stream_rpc_client_connection_send_protocol_message(
             self._binding,
@@ -564,7 +564,7 @@ class ClientContinuation(NativeResource):
         flush_future = Future()
 
         # native code deals with simplified types
-        headers, payload, message_type, flags = _msg_args_for_bindings(headers, payload, message_type, flags)
+        headers, payload, message_type, flags = _to_binding_msg_args(headers, payload, message_type, flags)
 
         _awscrt.event_stream_rpc_client_continuation_activate(
             self._binding,
@@ -627,7 +627,7 @@ class ClientContinuation(NativeResource):
         """
         future = Future()
         # native code deals with simplified types
-        headers, payload, message_type, flags = _msg_args_for_bindings(headers, payload, message_type, flags)
+        headers, payload, message_type, flags = _to_binding_msg_args(headers, payload, message_type, flags)
 
         _awscrt.event_stream_rpc_client_continuation_send_message(
             self._binding,

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -358,7 +358,7 @@ class ClientConnection(NativeResource):
             else:
                 bound_future.set_result(None)
 
-    def close(self, reason=None):
+    def close(self):
         """Close the connection.
 
         Shutdown is asynchronous. This call has no effect if the connection is already

--- a/setup.py
+++ b/setup.py
@@ -304,7 +304,8 @@ setuptools.setup(
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",
     url="https://github.com/awslabs/aws-crt-python",
-    packages=setuptools.find_packages(),
+    # Note: find_packages() without extra args will end up installing test/
+    packages=setuptools.find_packages(include=['awscrt*']),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -304,7 +304,7 @@ setuptools.setup(
     author_email="aws-sdk-common-runtime@amazon.com",
     description="A common runtime for AWS Python projects",
     url="https://github.com/awslabs/aws-crt-python",
-    packages=['awscrt'],
+    packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/source/event_stream_rpc_client_continuation.c
+++ b/source/event_stream_rpc_client_continuation.c
@@ -162,20 +162,12 @@ static void s_on_continuation_message(
         return; /* Python has shut down. Nothing matters anymore, but don't crash */
     }
 
-    /* We always want to deliver bytes to python user, even if the length is 0.
-     * But PyObject_CallFunction() with "y#" will convert a NULL ptr to None instead of 0-length bytes.
-     * Therefore, if message_args->payload_buffer is NULL, pass some other valid ptr instead. */
-    const char *payload_ptr = (void *)message_args->payload->buffer;
-    if (payload_ptr == NULL) {
-        payload_ptr = "";
-    }
-
     PyObject *result = PyObject_CallFunction(
         continuation->on_message,
         "(Oy#iI)",
         /* NOTE: if headers_create() returns NULL, then PyObject_CallFunction() fails too, which is convenient */
         aws_py_event_stream_python_headers_create(message_args->headers, message_args->headers_count),
-        payload_ptr,
+        message_args->payload->buffer,
         message_args->payload->len,
         message_args->message_type,
         message_args->message_flags);


### PR DESCRIPTION
- fix `setup.py` so that eventstream modules get installed
- fix crash when `eventstream.rpc.ClientConnection` was GC'd during `on_connection_shutdown` callback
- change default args to always be `=None`, so that it's easy to pass along defaults from wrapper functions
- centralize logic that sanitizes message args going in each direction between C <-> Python

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
