### PR TITLE
more eventstream tests

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -224,6 +224,22 @@ PyObject *PyErr_AwsLastError(void) {
     return PyErr_Format(PyExc_RuntimeError, "%d (%s): %s", err, name, msg);
 }
 
+#define AWS_DEFINE_ERROR_INFO_CRT(CODE, STR)                                                                           \
+    [(CODE)-AWS_ERROR_ENUM_BEGIN_RANGE(AWS_CRT_PYTHON_PACKAGE_ID)] = AWS_DEFINE_ERROR_INFO(CODE, STR, "aws-crt-python")
+
+/* clang-format off */
+static struct aws_error_info s_errors[] = {
+    AWS_DEFINE_ERROR_INFO_CRT(
+        AWS_ERROR_CRT_CALLBACK_EXCEPTION,
+        "Callback raised an exception."),
+};
+/* clang-format on */
+
+static struct aws_error_info_list s_error_list = {
+    .error_list = s_errors,
+    .count = AWS_ARRAY_SIZE(s_errors),
+};
+
 /* Mappings between Python built-in exception types and AWS_ERROR_ codes
  * Stored in hashtables as `PyObject*` of Python exception type, and `int` of AWS_ERROR_ enum (cast to void*) */
 static struct aws_hash_table s_py_to_aws_error_map;
@@ -596,6 +612,7 @@ PyMODINIT_FUNC PyInit__awscrt(void) {
     }
 #endif
 
+    aws_register_error_info(&s_error_list);
     s_error_map_init();
 
     return m;

--- a/source/module.h
+++ b/source/module.h
@@ -18,6 +18,15 @@ struct aws_byte_buf;
 struct aws_byte_cursor;
 struct aws_string;
 
+#define AWS_CRT_PYTHON_PACKAGE_ID 10
+
+/* Error codes, unique to aws-crt-python, for passing back to C layers */
+enum aws_crt_python_errors {
+    AWS_ERROR_CRT_CALLBACK_EXCEPTION = AWS_ERROR_ENUM_BEGIN_RANGE(AWS_CRT_PYTHON_PACKAGE_ID),
+
+    AWS_ERROR_CRT_END_RANGE = AWS_ERROR_ENUM_END_RANGE(AWS_CRT_PYTHON_PACKAGE_ID)
+};
+
 /* AWS Specific Helpers */
 PyObject *PyUnicode_FromAwsByteCursor(const struct aws_byte_cursor *cursor);
 PyObject *PyUnicode_FromAwsString(const struct aws_string *aws_str);


### PR DESCRIPTION
No actual behavior changes, just code improvements

- when exceptions in setup callback close connection, use new  AWS_ERROR_CRT_CALLBACK_EXCEPTION code instead of AWS_ERROR_UNKNOWN
- add test that exceptions in setup callback close connection
- add deadlock regression test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
