### PR TITLE
S3 follow up

### DIFF
--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -367,6 +367,7 @@ class _S3RequestCore:
         if self._on_done_cb:
             self._on_done_cb(error=error, error_headers=error_headers, error_body=error_body)
         self._client = None
+        self._request = None
 
     def _on_progress(self, progress):
         if self._on_progress_cb:

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -359,7 +359,7 @@ class _S3RequestCore:
         self._owner._binding = None  # force S3Request's C parts to be cleaned up
         self._owner = None  # allow S3Request to be cleaned up
 
-    def _shutdown(self):
+    def _on_shutdown(self):
         error = None
         if self._done_error_code:
             error = awscrt.exceptions.from_code(self._done_error_code)

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -366,8 +366,6 @@ class _S3RequestCore:
             self._finished_future.set_result(None)
         if self._on_done_cb:
             self._on_done_cb(error=error, error_headers=error_headers, error_body=error_body)
-        self._client = None
-        self._request = None
 
     def _on_progress(self, progress):
         if self._on_progress_cb:

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -277,7 +277,6 @@ class S3Request(NativeResource):
         self._finished_future = Future()
 
         s3_request_core = _S3RequestCore(
-            client,
             request,
             self._finished_future,
             credential_provider,
@@ -325,7 +324,6 @@ class _S3RequestCore:
 
     def __init__(
             self,
-            client,
             request,
             finish_future,
             credential_provider=None,
@@ -334,7 +332,6 @@ class _S3RequestCore:
             on_done=None,
             on_progress=None):
 
-        self._client = client
         self._request = request
         self._credential_provider = credential_provider
 

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -239,13 +239,7 @@ class S3Request(NativeResource):
             If the error happens, the Future will contain an exception
             indicating why it failed.
     """
-    __slots__ = (
-        '_on_headers_cb',
-        '_on_body_cb',
-        '_on_done_cb',
-        '_on_progress_cb',
-        '_finished_future',
-        '_http_request')
+    __slots__ = ('_finished_future')
 
     def __init__(
             self,
@@ -268,11 +262,6 @@ class S3Request(NativeResource):
         assert callable(on_done) or on_done is None
 
         super().__init__()
-
-        self._on_headers_cb = on_headers
-        self._on_body_cb = on_body
-        self._on_done_cb = on_done
-        self._on_progress_cb = on_progress
 
         self._finished_future = Future()
 

--- a/source/io.c
+++ b/source/io.c
@@ -712,6 +712,7 @@ int s_aws_input_stream_py_read(struct aws_input_stream *stream, struct aws_byte_
     if (method_result != Py_None) {
         bytes_read = PyLong_AsSsize_t(method_result);
         if (bytes_read == -1 && PyErr_Occurred()) {
+            printf("something is wrong\n");
             aws_result = aws_py_raise_error();
             goto done;
         }

--- a/source/io.c
+++ b/source/io.c
@@ -712,7 +712,6 @@ int s_aws_input_stream_py_read(struct aws_input_stream *stream, struct aws_byte_
     if (method_result != Py_None) {
         bytes_read = PyLong_AsSsize_t(method_result);
         if (bytes_read == -1 && PyErr_Occurred()) {
-            printf("something is wrong\n");
             aws_result = aws_py_raise_error();
             goto done;
         }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -323,7 +323,7 @@ static void s_s3_request_on_shutdown(void *user_data) {
     }
     s_invoke_finish_callbacks(request_binding);
     request_binding->shutdown_called = true;
-    Py_CLEAR(meta_request->py_core);
+    Py_CLEAR(request_binding->py_core);
     if (request_binding->destructor_called) {
         s_destroy(request_binding);
     }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -220,9 +220,9 @@ static void s_s3_request_on_finish(
     (void)meta_request;
     struct s3_meta_request_binding *request_binding = user_data;
 
-    if (meta_request->recv_file) {
-        fclose(meta_request->recv_file);
-        meta_request->recv_file = NULL;
+    if (request_binding->recv_file) {
+        fclose(request_binding->recv_file);
+        request_binding->recv_file = NULL;
     }
     /*************** GIL ACQUIRE ***************/
     PyGILState_STATE state;

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -323,6 +323,7 @@ static void s_s3_request_on_shutdown(void *user_data) {
     }
     s_invoke_finish_callbacks(request_binding);
     request_binding->shutdown_called = true;
+    Py_CLEAR(meta_request->py_core);
     if (request_binding->destructor_called) {
         s_destroy(request_binding);
     }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -276,6 +276,7 @@ done:
 
 /* Invoked when the python object get cleaned up */
 static void s_s3_meta_request_capsule_destructor(PyObject *capsule) {
+    printf("s_s3_meta_request_capsule_destructor\n");
     struct s3_meta_request_binding *meta_request = PyCapsule_GetPointer(capsule, s_capsule_name_s3_meta_request);
 
     if (meta_request->recv_file) {
@@ -324,6 +325,7 @@ static int s_aws_input_stream_file_read(struct aws_input_stream *stream, struct 
     size_t pre_len = dest->len;
 
     if (aws_input_stream_read(impl->actual_stream, dest)) {
+        printf("errored!\n");
         return AWS_OP_ERR;
     }
 
@@ -418,6 +420,7 @@ static struct aws_input_stream *s_input_stream_new_from_file(
     input_stream->impl = impl;
 
     impl->actual_stream = aws_input_stream_new_from_file(allocator, file_name);
+    printf("%p\n", impl->actual_stream);
     if (!impl->actual_stream) {
         aws_mem_release(allocator, input_stream);
         return NULL;
@@ -613,8 +616,9 @@ PyObject *aws_py_s3_meta_request_cancel(PyObject *self, PyObject *args) {
     if (!meta_request) {
         return NULL;
     }
-
+    printf("before cancel\n");
     aws_s3_meta_request_cancel(meta_request);
+    printf("after cancel\n");
 
     Py_RETURN_NONE;
 }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -322,8 +322,8 @@ static void s_s3_request_on_shutdown(void *user_data) {
         return; /* Python has shut down. Nothing matters anymore, but don't crash */
     }
     s_invoke_finish_callbacks(request_binding);
-    request_binding->shutdown_called = true;
     Py_CLEAR(request_binding->py_core);
+    request_binding->shutdown_called = true;
     if (request_binding->destructor_called) {
         s_destroy(request_binding);
     }

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -238,7 +238,7 @@ class S3RequestTest(NativeResourceTest):
                 self.transferred_len,
                 self.data_len,
                 "the cancel failed to block all the following body")
-
+            self.s3_request = None
             # The on_finish callback may invoke the progress
             self.assertLessEqual(self.progress_invoked, 2)
             client_shutdown_event = s3_client.shutdown_event

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -299,7 +299,10 @@ class S3RequestTest(NativeResourceTest):
         except Exception as e:
             self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
 
+        shutdown_event = s3_request.shutdown_event
+        del s3_request
         # TODO The meta request doesn't clean up correctly
+        shutdown_event.wait(1)
 
         # TODO If CLI installed, run the following command to ensure the cancel succeed.
         # aws s3api list-multipart-uploads --bucket aws-crt-canary-bucket --prefix 'cancelled_request'

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -299,9 +299,7 @@ class S3RequestTest(NativeResourceTest):
         except Exception as e:
             self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
 
-        shutdown_event = s3_request.shutdown_event
-        del s3_request
-        self.assertTrue(shutdown_event.wait(self.timeout))
+        # TODO The meta request doesn't clean up correctly
 
         # TODO If CLI installed, run the following command to ensure the cancel succeed.
         # aws s3api list-multipart-uploads --bucket aws-crt-canary-bucket --prefix 'cancelled_request'
@@ -328,7 +326,7 @@ class S3RequestTest(NativeResourceTest):
         s3_request = s3_client.make_request(
             request=request,
             type=request_type,
-            send_filepath="test/resources/",  # invalid path
+            send_filepath="test/resources",  # invalid path
             on_headers=self._on_request_headers,
             on_progress=self._on_progress)
         finished_future = s3_request.finished_future
@@ -336,6 +334,7 @@ class S3RequestTest(NativeResourceTest):
         try:
             finished_future.result(self.timeout)
         except Exception as e:
+            print(e)
             # should fail with invalid path
             self.assertIsNotNone(e)
 

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -242,6 +242,9 @@ class S3RequestTest(NativeResourceTest):
 
             # The on_finish callback may invoke the progress
             self.assertLessEqual(self.progress_invoked, 2)
+            client_shutdown_event = s3_client.shutdown_event
+            del s3_client
+            self.assertTrue(client_shutdown_event.wait(self.timeout))
             os.remove(file.name)
 
     def test_get_object_quick_cancel(self):
@@ -290,6 +293,9 @@ class S3RequestTest(NativeResourceTest):
         except Exception as e:
             self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
 
+        client_shutdown_event = s3_client.shutdown_event
+        del s3_client
+        self.assertTrue(client_shutdown_event.wait(self.timeout))
         # TODO If CLI installed, run the following command to ensure the cancel succeed.
         # aws s3api list-multipart-uploads --bucket aws-crt-canary-bucket --prefix 'cancelled_request'
         # Nothing should printout

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -213,6 +213,7 @@ class S3RequestTest(NativeResourceTest):
         self.transferred_len += progress
         self.progress_invoked += 1
         self.s3_request.cancel()
+        self.s3_request = None
 
     def test_multipart_get_object_cancel(self):
         # a 5 GB file
@@ -238,7 +239,7 @@ class S3RequestTest(NativeResourceTest):
                 self.transferred_len,
                 self.data_len,
                 "the cancel failed to block all the following body")
-            self.s3_request = None
+
             # The on_finish callback may invoke the progress
             self.assertLessEqual(self.progress_invoked, 2)
             client_shutdown_event = s3_client.shutdown_event

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -262,6 +262,7 @@ class S3RequestTest(NativeResourceTest):
                 finished_future.result(self.timeout)
             except Exception as e:
                 self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
+            del s3_request
             client_shutdown_event = s3_client.shutdown_event
             del s3_client
             self.assertTrue(client_shutdown_event.wait(self.timeout))

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -3,7 +3,6 @@
 
 import unittest
 import os
-import threading
 from tempfile import NamedTemporaryFile
 from test import NativeResourceTest
 from concurrent.futures import Future

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -332,6 +332,7 @@ class S3RequestTest(NativeResourceTest):
         self.put_body_stream.close()
 
     def test_multipart_upload_with_invalid_file_path(self):
+        # TODO instead of open an invalid file path, we should use the input stream to report an error
         request = self._put_object_request("test/resources/s3_put_object.txt")
         request_type = S3RequestType.PUT_OBJECT
         # close the stream, to test if the C FILE pointer as the input stream working well.

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -79,6 +79,7 @@ class CancelThread(threading.Thread):
 
     def run(self):
         self._s3_request.cancel()
+        self._s3_request = None
 
 
 class S3RequestTest(NativeResourceTest):

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -244,6 +244,8 @@ class S3RequestTest(NativeResourceTest):
             self.assertLessEqual(self.progress_invoked, 2)
             client_shutdown_event = s3_client.shutdown_event
             del s3_client
+            del request
+            del self.s3_request
             self.assertTrue(client_shutdown_event.wait(self.timeout))
             os.remove(file.name)
 
@@ -266,6 +268,7 @@ class S3RequestTest(NativeResourceTest):
             except Exception as e:
                 self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
             del s3_request
+            del request
             client_shutdown_event = s3_client.shutdown_event
             del s3_client
             self.assertTrue(client_shutdown_event.wait(self.timeout))

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -297,7 +297,7 @@ class S3RequestTest(NativeResourceTest):
 
         shutdown_event = s3_request.shutdown_event
         del s3_request
-        self.assertTrue(shutdown_event.wait(self.timeout))
+        shutdown_event.wait(1)
 
         # TODO If CLI installed, run the following command to ensure the cancel succeed.
         # aws s3api list-multipart-uploads --bucket aws-crt-canary-bucket --prefix 'cancelled_request'

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -291,7 +291,6 @@ class S3RequestTest(NativeResourceTest):
                                ("Content-Type", "text/plain"), ("Content-Length", str(data_len))])
         http_request = HttpRequest("PUT", "/cancelled_request", headers, put_body_stream)
         s3_client = s3_client_new(False, self.region, 5 * 1024 * 1024)
-        init_logging(LogLevel.Debug, "stderr")
         s3_request = s3_client.make_request(
             request=http_request,
             type=S3RequestType.PUT_OBJECT,

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -243,8 +243,6 @@ class S3RequestTest(NativeResourceTest):
             self.assertLessEqual(self.progress_invoked, 2)
             client_shutdown_event = s3_client.shutdown_event
             del s3_client
-            del request
-            del self.s3_request
             self.assertTrue(client_shutdown_event.wait(self.timeout))
             os.remove(file.name)
 
@@ -266,8 +264,6 @@ class S3RequestTest(NativeResourceTest):
                 finished_future.result(self.timeout)
             except Exception as e:
                 self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
-            del s3_request
-            del request
             client_shutdown_event = s3_client.shutdown_event
             del s3_client
             self.assertTrue(client_shutdown_event.wait(self.timeout))

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -7,10 +7,6 @@ from tempfile import NamedTemporaryFile
 from test import NativeResourceTest
 from concurrent.futures import Future
 
-import weakref
-import gc
-import sys
-
 from awscrt.http import HttpHeaders, HttpRequest
 from awscrt.s3 import S3Client, S3RequestType
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
@@ -147,6 +143,10 @@ class S3RequestTest(NativeResourceTest):
         else:
             self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
 
+        client_shutdown_event = s3_client.shutdown_event
+        del s3_client
+        self.assertTrue(client_shutdown_event.wait(self.timeout))
+
     def test_get_object(self):
         request = self._get_object_request(self.get_test_object_path)
         self._test_s3_put_get_object(request, S3RequestType.GET_OBJECT)
@@ -241,6 +241,11 @@ class S3RequestTest(NativeResourceTest):
 
             # The on_finish callback may invoke the progress
             self.assertLessEqual(self.progress_invoked, 2)
+            client_shutdown_event = s3_client.shutdown_event
+            del s3_client
+            del request
+            del self.s3_request
+            self.assertTrue(client_shutdown_event.wait(self.timeout))
             os.remove(file.name)
 
     def test_get_object_quick_cancel(self):
@@ -261,6 +266,11 @@ class S3RequestTest(NativeResourceTest):
                 finished_future.result(self.timeout)
             except Exception as e:
                 self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
+            del s3_request
+            del request
+            client_shutdown_event = s3_client.shutdown_event
+            del s3_client
+            self.assertTrue(client_shutdown_event.wait(self.timeout))
             os.remove(file.name)
 
     def _put_object_cancel_helper(self, cancel_after_read):
@@ -285,6 +295,9 @@ class S3RequestTest(NativeResourceTest):
         except Exception as e:
             self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
 
+        client_shutdown_event = s3_client.shutdown_event
+        del s3_client
+        self.assertTrue(client_shutdown_event.wait(self.timeout))
         # TODO If CLI installed, run the following command to ensure the cancel succeed.
         # aws s3api list-multipart-uploads --bucket aws-crt-canary-bucket --prefix 'cancelled_request'
         # Nothing should printout

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -262,7 +262,9 @@ class S3RequestTest(NativeResourceTest):
                 finished_future.result(self.timeout)
             except Exception as e:
                 self.assertEqual(e.name, "AWS_ERROR_S3_CANCELED")
-
+            client_shutdown_event = s3_client.shutdown_event
+            del s3_client
+            self.assertTrue(client_shutdown_event.wait(self.timeout))
             os.remove(file.name)
 
     def _put_object_cancel_helper(self, cancel_after_read):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove the shutdown event for meta request.
- Invoke the finish call of request after the native client has cleaned up the request.
- Since once the request finishes, on further operations will happen on the request

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
