### PR TITLE
MQTT on-message callback takes more args

### DIFF
--- a/mqtt_test.py
+++ b/mqtt_test.py
@@ -47,9 +47,12 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 receive_results = {}
 receive_event = threading.Event()
-def on_receive_message(topic, payload, **kwargs):
+def on_receive_message(topic, payload, dup, qos, retain, **kwargs):
     receive_results['topic'] = topic
     receive_results['payload'] = payload
+    receive_results['dup'] = dup
+    receive_results['qos'] = qos
+    receive_results['retain'] = retain
     receive_event.set()
 
 # Run

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -220,6 +220,10 @@ static void s_s3_request_on_finish(
     (void)meta_request;
     struct s3_meta_request_binding *request_binding = user_data;
 
+    if (request_binding->recv_file) {
+        fclose(request_binding->recv_file);
+        request_binding->recv_file = NULL;
+    }
     /*************** GIL ACQUIRE ***************/
     PyGILState_STATE state;
     if (aws_py_gilstate_ensure(&state)) {
@@ -280,6 +284,7 @@ static void s_s3_meta_request_capsule_destructor(PyObject *capsule) {
 
     if (meta_request->recv_file) {
         fclose(meta_request->recv_file);
+        meta_request->recv_file = NULL;
     }
     if (meta_request->native) {
         aws_s3_meta_request_release(meta_request->native);

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -129,6 +129,9 @@ class MqttConnectionTest(NativeResourceTest):
         rcv = received.result(TIMEOUT)
         self.assertEqual(self.TEST_TOPIC, rcv['topic'])
         self.assertEqual(self.TEST_MSG, rcv['payload'])
+        self.assertFalse(rcv['dup'])
+        self.assertEqual(QoS.AT_LEAST_ONCE, rcv['qos'])
+        self.assertFalse(rcv['retain'])
 
         # unsubscribe
         unsubscribed, packet_id = connection.unsubscribe(self.TEST_TOPIC)
@@ -172,6 +175,61 @@ class MqttConnectionTest(NativeResourceTest):
 
         # receive message
         rcv = received.result(TIMEOUT)
+        self.assertEqual(self.TEST_TOPIC, rcv['topic'])
+        self.assertEqual(self.TEST_MSG, rcv['payload'])
+        self.assertFalse(rcv['dup'])
+        self.assertEqual(QoS.AT_LEAST_ONCE, rcv['qos'])
+        self.assertFalse(rcv['retain'])
+
+        # disconnect
+        connection.disconnect().result(TIMEOUT)
+
+    def test_on_message_old_fn_signature(self):
+        # ensure that message-received callbacks with the old function signature still work
+        config = Config.get()
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+
+        tls_opts = TlsContextOptions.create_client_with_mtls(config.cert, config.key)
+        tls = ClientTlsContext(tls_opts)
+
+        client = Client(bootstrap, tls)
+        connection = Connection(
+            client=client,
+            client_id=create_client_id(),
+            host_name=config.endpoint,
+            port=8883)
+
+        any_received = Future()
+        sub_received = Future()
+
+        # Note: Testing degenerate callback signature that failed to take
+        # forward-compatibility **kwargs.
+        def on_any_message(topic, payload):
+            any_received.set_result({'topic': topic, 'payload': payload})
+
+        def on_sub_message(topic, payload):
+            sub_received.set_result({'topic': topic, 'payload': payload})
+
+        # on_message for connection has to be set before connect, or possible race will happen
+        connection.on_message(on_any_message)
+
+        connection.connect().result(TIMEOUT)
+        # subscribe without callback
+        subscribed, packet_id = connection.subscribe(self.TEST_TOPIC, QoS.AT_LEAST_ONCE, on_sub_message)
+        subscribed.result(TIMEOUT)
+
+        # publish
+        published, packet_id = connection.publish(self.TEST_TOPIC, self.TEST_MSG, QoS.AT_LEAST_ONCE)
+        puback = published.result(TIMEOUT)
+
+        # receive message
+        rcv = any_received.result(TIMEOUT)
+        self.assertEqual(self.TEST_TOPIC, rcv['topic'])
+        self.assertEqual(self.TEST_MSG, rcv['payload'])
+
+        rcv = sub_received.result(TIMEOUT)
         self.assertEqual(self.TEST_TOPIC, rcv['topic'])
         self.assertEqual(self.TEST_MSG, rcv['payload'])
 


### PR DESCRIPTION
Users can now know the `qos`, `retain`, and `dup` of received messages.

This is a backwards-compatible change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
