### PR TITLE
Remove some old libcrypto cruft

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -4,14 +4,6 @@
         "android": {
             "enabled": false,
             "_comment": "disabled until we have a reason to support python on android"
-        },
-        "linux": {
-            "imports": [
-                "libcrypto"
-            ],
-            "build_env": {
-                "AWS_LIBCRYPTO_INSTALL": "{deps_dir}/libcrypto"
-            }
         }
     },
     "hosts": {

--- a/codebuild/cd/manylinux-x64-build.yml
+++ b/codebuild/cd/manylinux-x64-build.yml
@@ -7,7 +7,6 @@ phases:
   pre_build:
     commands:
       - export CC=gcc
-      - export AWS_LIBCRYPTO_INSTALL=/opt/openssl
       - cd aws-crt-python
       - /opt/python/cp37-cp37m/bin/python ./continuous-delivery/update-version.py
   build:

--- a/codebuild/cd/manylinux-x86-build.yml
+++ b/codebuild/cd/manylinux-x86-build.yml
@@ -7,7 +7,6 @@ phases:
   pre_build:
     commands:
       - export CC=gcc
-      - export AWS_LIBCRYPTO_INSTALL=/opt/openssl
       - cd aws-crt-python
       - /opt/python/cp37-cp37m/bin/python ./continuous-delivery/update-version.py
   build:

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
@@ -4,8 +4,6 @@ set -ex
 
 /opt/python/cp38-cp38/bin/python ./continuous-delivery/update-version.py
 
-export AWS_LIBCRYPTO_INSTALL=/opt/openssl
-
 /opt/python/cp35-cp35m/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp35*.whl
 

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
@@ -4,8 +4,6 @@ set -ex
 
 /opt/python/cp38-cp38/bin/python ./continuous-delivery/update-version.py
 
-export AWS_LIBCRYPTO_INSTALL=/opt/openssl
-
 /opt/python/cp35-cp35m/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp35*.whl
 

--- a/setup.py
+++ b/setup.py
@@ -104,22 +104,6 @@ def get_cmake_version():
     return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
-def get_libcrypto_static_library(libcrypto_dir):
-    lib_path = os.path.join(libcrypto_dir, 'lib64', 'libcrypt')
-    if is_64bit() and os.path.exists(lib_path):
-        return lib_path
-
-    lib_path = os.path.join(libcrypto_dir, 'lib32', 'libcrypto.a')
-    if is_32bit() and os.path.exists(lib_path):
-        return lib_path
-
-    lib_path = os.path.join(libcrypto_dir, 'lib', 'libcrypto.a')
-    if os.path.exists(lib_path):
-        return lib_path
-
-    raise Exception('Bad AWS_LIBCRYPTO_INSTALL, file not found: ' + lib_path)
-
-
 class AwsLib:
     def __init__(self, name, extra_cmake_args=[], libname=None):
         self.name = name


### PR DESCRIPTION
Now that we build our own libcrypto from the aws-lc submodule, we don't need this stuff for finding a pre-installed version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
