### PR TITLE
Don't run aws-lc's codegen at build time.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,8 @@ class AwsLib:
 AWS_LIBS = []
 if sys.platform != 'darwin' and sys.platform != 'win32':
     AWS_LIBS.append(AwsLib('aws-lc',
-                    libname='crypto', # compiled library name is not "aws-lc"
+                    # We're linking against "libcrypto.a" not "libaws-lc.a"
+                    libname='crypto',
                     extra_cmake_args=[
                         # We don't need libssl.a, we're only using libcrypto.a
                         '-DBUILD_LIBSSL=OFF',

--- a/setup.py
+++ b/setup.py
@@ -115,16 +115,15 @@ class AwsLib:
 # They're built along with the extension, in the order listed.
 AWS_LIBS = []
 if sys.platform != 'darwin' and sys.platform != 'win32':
-    AWS_LIBS.append(AwsLib('aws-lc',
-                    # We're linking against "libcrypto.a" not "libaws-lc.a"
-                    libname='crypto',
-                    extra_cmake_args=[
-                        # We don't need libssl.a, we're only using libcrypto.a
-                        '-DBUILD_LIBSSL=OFF',
-                        # Disable running codegen on user's machine.
-                        # Up-to-date generated code is already in repo.
-                        '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON',
-                    ]))
+    AWS_LIBS.append(AwsLib(name='aws-lc',
+                           libname='crypto',  # We link against libcrypto.a
+                           extra_cmake_args=[
+                               # We don't need libssl.a
+                               '-DBUILD_LIBSSL=OFF',
+                               # Disable running codegen on user's machine.
+                               # Up-to-date generated code is already in repo.
+                               '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON',
+                           ]))
     AWS_LIBS.append(AwsLib('s2n'))
 AWS_LIBS.append(AwsLib('aws-c-common'))
 AWS_LIBS.append(AwsLib('aws-c-cal'))

--- a/setup.py
+++ b/setup.py
@@ -115,24 +115,15 @@ class AwsLib:
 # They're built along with the extension, in the order listed.
 AWS_LIBS = []
 if sys.platform != 'darwin' and sys.platform != 'win32':
-    awslc_cmake_args = [
-        # Only need libcrypto.a, don't need libssl.a
-        '-DBUILD_LIBSSL=OFF',
-        # Don't need to run codegen on user's machine,
-        # up-to-date generated code is already in source control.
-        '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON']
-    AWS_LIBS.append(AwsLib('aws-lc', awslc_cmake_args, libname='crypto'))
-
     AWS_LIBS.append(AwsLib('aws-lc',
+                    libname='crypto', # compiled library name is not "aws-lc"
                     extra_cmake_args=[
                         # We don't need libssl.a, we're only using libcrypto.a
                         '-DBUILD_LIBSSL=OFF',
                         # Disable running codegen on user's machine.
                         # Up-to-date generated code is already in repo.
-                        '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON'],
-                    # repo name is different than compiled library name
-                    libname='crypto'))
-
+                        '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON',
+                    ]))
     AWS_LIBS.append(AwsLib('s2n'))
 AWS_LIBS.append(AwsLib('aws-c-common'))
 AWS_LIBS.append(AwsLib('aws-c-cal'))

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,24 @@ class AwsLib:
 # They're built along with the extension, in the order listed.
 AWS_LIBS = []
 if sys.platform != 'darwin' and sys.platform != 'win32':
-    AWS_LIBS.append(AwsLib('aws-lc', ['-DBUILD_LIBSSL=OFF'], 'crypto'))
+    awslc_cmake_args = [
+        # Only need libcrypto.a, don't need libssl.a
+        '-DBUILD_LIBSSL=OFF',
+        # Don't need to run codegen on user's machine,
+        # up-to-date generated code is already in source control.
+        '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON']
+    AWS_LIBS.append(AwsLib('aws-lc', awslc_cmake_args, libname='crypto'))
+
+    AWS_LIBS.append(AwsLib('aws-lc',
+                    extra_cmake_args=[
+                        # We don't need libssl.a, we're only using libcrypto.a
+                        '-DBUILD_LIBSSL=OFF',
+                        # Disable running codegen on user's machine.
+                        # Up-to-date generated code is already in repo.
+                        '-DDISABLE_PERL=ON', '-DDISABLE_GO=ON'],
+                    # repo name is different than compiled library name
+                    libname='crypto'))
+
     AWS_LIBS.append(AwsLib('s2n'))
 AWS_LIBS.append(AwsLib('aws-c-common'))
 AWS_LIBS.append(AwsLib('aws-c-cal'))


### PR DESCRIPTION
aws-lc uses codegen to create some of its source files, and it runs these generators if the user's machine has Go and Perl installed. However, up-to-date versions of the generated files are already committed to the repo, so it's not necessary for users to run codegen on their machines.

Disabling codegen should fix the awscrt package on piwheels.org, which compiles wheels for Raspberry Pi. The piwheels build machines have Go installed, but prevent git from making network calls during the build process, and Go uses git to fetch dependencies, and .... man it took a while to figure out what was going wrong there.

Anyway, turn off the unnecessary complexity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
