### PR TITLE
Fixing null pointer bug when connection setup error occurred.

### DIFF
--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -128,10 +128,12 @@ static void s_on_connection_setup(
     struct aws_event_stream_rpc_client_connection *native,
     int error_code,
     void *user_data) {
-
     struct connection_binding *connection = user_data;
     connection->native = native;
-    aws_event_stream_rpc_client_connection_acquire(connection->native);
+
+    if (native) {
+        aws_event_stream_rpc_client_connection_acquire(connection->native);
+    }
 
     AWS_FATAL_ASSERT(((bool)native != (bool)error_code) && "illegal event-stream connection args");
 

--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -154,8 +154,9 @@ static void s_on_connection_setup(
             (void *)connection->native);
 
         PyErr_WriteUnraisable(connection->self_py);
-
-        aws_event_stream_rpc_client_connection_close(connection->native, AWS_ERROR_CRT_CALLBACK_EXCEPTION);
+        if (native) {
+            aws_event_stream_rpc_client_connection_close(connection->native, AWS_ERROR_CRT_CALLBACK_EXCEPTION);
+        }
     }
 
     if (!native) {

--- a/source/event_stream_rpc_client_connection.c
+++ b/source/event_stream_rpc_client_connection.c
@@ -129,13 +129,13 @@ static void s_on_connection_setup(
     int error_code,
     void *user_data) {
     struct connection_binding *connection = user_data;
-    connection->native = native;
-
-    if (native) {
-        aws_event_stream_rpc_client_connection_acquire(connection->native);
-    }
 
     AWS_FATAL_ASSERT(((bool)native != (bool)error_code) && "illegal event-stream connection args");
+
+    if (native) {
+        connection->native = native;
+        aws_event_stream_rpc_client_connection_acquire(connection->native);
+    }
 
     PyGILState_STATE state;
     if (aws_py_gilstate_ensure(&state)) {

--- a/test/test_eventstream_rpc.py
+++ b/test/test_eventstream_rpc.py
@@ -91,10 +91,7 @@ class ContinuationHandler(ClientContinuationHandler):
             self.fail_test("shutdown can only fire once")
         self.record.close_call.set()
 
-
-@skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
-class TestClient(NativeResourceTest):
-
+class FailureClientTests(NativeResourceTest):
     def _fail_test_from_callback(self, msg):
         print("ERROR FROM CALLBACK", msg)
         self._failure_from_callback = msg
@@ -120,6 +117,15 @@ class TestClient(NativeResourceTest):
         self.assertTrue(isinstance(handler.record.setup_call['error'], Exception))
         self.assertIsNone(handler.record.shutdown_call)
         self._assertNoFailuresFromCallbacks()
+
+@skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
+class TestClient(NativeResourceTest):
+    def _fail_test_from_callback(self, msg):
+        print("ERROR FROM CALLBACK", msg)
+        self._failure_from_callback = msg
+
+    def _assertNoFailuresFromCallbacks(self):
+        self.assertIsNone(getattr(self, '_failure_from_callback', None))
 
     def test_connect_success(self):
         elg = EventLoopGroup()

--- a/test/test_eventstream_rpc.py
+++ b/test/test_eventstream_rpc.py
@@ -119,6 +119,7 @@ class FailureClientTests(NativeResourceTest):
         self.assertIsNone(handler.record.shutdown_call)
         self._assertNoFailuresFromCallbacks()
 
+
 @skipUnless(RUN_LOCALHOST_TESTS, "Skipping until we have permanent echo server")
 class TestClient(NativeResourceTest):
     def _fail_test_from_callback(self, msg):

--- a/test/test_eventstream_rpc.py
+++ b/test/test_eventstream_rpc.py
@@ -91,6 +91,7 @@ class ContinuationHandler(ClientContinuationHandler):
             self.fail_test("shutdown can only fire once")
         self.record.close_call.set()
 
+
 class FailureClientTests(NativeResourceTest):
     def _fail_test_from_callback(self, msg):
         print("ERROR FROM CALLBACK", msg)


### PR DESCRIPTION
*Description of changes:*
* When a connection setup error has occurred, native connection is null so acquire() shouldn't be invoked

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
