### PR TITLE
Improved Posix Large File Support

### DIFF
--- a/source/io.c
+++ b/source/io.c
@@ -650,7 +650,7 @@ static void s_aws_input_stream_py_destroy(struct aws_input_stream *stream) {
 
 static int s_aws_input_stream_py_seek(
     struct aws_input_stream *stream,
-    aws_off_t offset,
+    int64_t offset,
     enum aws_stream_seek_basis basis) {
 
     struct aws_input_stream_py_impl *impl = stream->impl;
@@ -664,7 +664,7 @@ static int s_aws_input_stream_py_seek(
         return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
     }
 
-    method_result = PyObject_CallMethod(impl->self_proxy, "_seek", "(li)", offset, basis);
+    method_result = PyObject_CallMethod(impl->self_proxy, "_seek", "(Li)", offset, basis);
     if (!method_result) {
         aws_result = aws_py_raise_error();
         goto done;

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -372,7 +372,7 @@ static int s_aws_input_stream_file_read(struct aws_input_stream *stream, struct 
 }
 static int s_aws_input_stream_file_seek(
     struct aws_input_stream *stream,
-    aws_off_t offset,
+    int64_t offset,
     enum aws_stream_seek_basis basis) {
     struct aws_input_py_stream_file_impl *impl = stream->impl;
     return aws_input_stream_seek(impl->actual_stream, offset, basis);


### PR DESCRIPTION
### ISSUE

Bizarre behavior on 32bit Raspberry Pi OS when aws_input_stream_seek() was called, due to aws-c libraries not being compiled with Large Files Support (LFS), which led to confusion over the size of off_t, which led to stack corruption when functions took arguments of this type.

### CHANGES
This incorporates fixes from https://github.com/awslabs/aws-c-common/pull/808 and https://github.com/awslabs/aws-c-io/pull/386.  

int64_t is now used for offsets instead of off_t/aws_off_t.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
