### PR TITLE
Tests use env vars so they're easier to run locally

### DIFF
--- a/.builder/actions/aws_crt_python.py
+++ b/.builder/actions/aws_crt_python.py
@@ -1,8 +1,11 @@
 
 import Builder
 import argparse
-import os
+import os.path
+import pathlib
+import subprocess
 import sys
+import tempfile
 
 
 class InstallPythonReqs(Builder.Action):
@@ -27,6 +30,42 @@ class InstallPythonReqs(Builder.Action):
         return Builder.Script(steps, name='install-python-reqs')
 
 
+class SetupForTests(Builder.Action):
+
+    def run(self, env):
+        # we want to use boto3 to pull data from secretsmanager
+        # boto3 might need to be installed first...
+        try:
+            import boto3
+        except BaseException:
+            subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'boto3'])
+            import boto3
+
+        secrets = boto3.client('secretsmanager')
+
+        # get string from secretsmanager and store in environment variable
+        def setenv_from_secret(env_var_name, secret_name):
+            response = secrets.get_secret_value(SecretId=secret_name)
+            env.shell.setenv(env_var_name, response['SecretString'])
+
+        # get file contents from secretsmanager, store as file under /tmp
+        # and store path in environment variable
+        def setenv_tmpfile_from_secret(env_var_name, secret_name, file_name):
+            response = secrets.get_secret_value(SecretId=secret_name)
+            file_contents = response['SecretString']
+            file_path = os.path.join(tempfile.gettempdir(), file_name)
+            pathlib.File(file_path).write_text(file_contents)
+            env.shell.setenv(env_var_name, file_path)
+
+        setenv_from_secret('AWS_TEST_IOT_MQTT_ENDPOINT', 'unit-test/endpoint')
+
+        setenv_tmpfile_from_secret('AWS_TEST_TLS_CERT_PATH', 'unit-test/certificate', 'certificate.pem')
+        setenv_tmpfile_from_secret('AWS_TEST_TLS_KEY_PATH', 'unit-test/privatekey', 'privatekey.pem')
+
+        # tests must run with leak detection turned on
+        env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
+
+
 class AWSCrtPython(Builder.Action):
 
     def run(self, env):
@@ -36,12 +75,10 @@ class AWSCrtPython(Builder.Action):
         args = parser.parse_known_args(env.args.args)[0]
         python = args.python if args.python else sys.executable
 
-        # tests must run with leak detection turned on
-        env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
-
         actions = [
             InstallPythonReqs(deps=['boto3'], python=python),
             [python, '-m', 'pip', 'install', '--verbose', '.'],
+            SetupForTests(python=python),
             # "--failfast" because, given how our leak-detection in tests currently works,
             # once one test fails all the rest usually fail too.
             [python, '-m', 'unittest', 'discover', '--verbose', '--failfast'],

--- a/.builder/actions/aws_crt_python.py
+++ b/.builder/actions/aws_crt_python.py
@@ -54,7 +54,7 @@ class SetupForTests(Builder.Action):
             response = secrets.get_secret_value(SecretId=secret_name)
             file_contents = response['SecretString']
             file_path = os.path.join(tempfile.gettempdir(), file_name)
-            pathlib.File(file_path).write_text(file_contents)
+            pathlib.Path(file_path).write_text(file_contents)
             env.shell.setenv(env_var_name, file_path)
 
         setenv_from_secret('AWS_TEST_IOT_MQTT_ENDPOINT', 'unit-test/endpoint')
@@ -77,8 +77,8 @@ class AWSCrtPython(Builder.Action):
 
         actions = [
             InstallPythonReqs(deps=['boto3'], python=python),
+            SetupForTests(),
             [python, '-m', 'pip', 'install', '--verbose', '.'],
-            SetupForTests(python=python),
             # "--failfast" because, given how our leak-detection in tests currently works,
             # once one test fails all the rest usually fail too.
             [python, '-m', 'unittest', 'discover', '--verbose', '--failfast'],

--- a/.builder/actions/aws_crt_python.py
+++ b/.builder/actions/aws_crt_python.py
@@ -65,6 +65,9 @@ class SetupForTests(Builder.Action):
         # tests must run with leak detection turned on
         env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
 
+        # enable S3 tests
+        env.shell.setenv('AWS_TEST_S3', '1')
+
 
 class AWSCrtPython(Builder.Action):
 

--- a/.builder/actions/aws_crt_python.py
+++ b/.builder/actions/aws_crt_python.py
@@ -62,9 +62,6 @@ class SetupForTests(Builder.Action):
         setenv_tmpfile_from_secret('AWS_TEST_TLS_CERT_PATH', 'unit-test/certificate', 'certificate.pem')
         setenv_tmpfile_from_secret('AWS_TEST_TLS_KEY_PATH', 'unit-test/privatekey', 'privatekey.pem')
 
-        # tests must run with leak detection turned on
-        env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
-
         # enable S3 tests
         env.shell.setenv('AWS_TEST_S3', '1')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,25 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
+  # check that tests requiring custom env-vars or AWS credentials are simply skipped
+  tests-ok-without-env-vars:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Run tests without env-vars or AWS creds
+        env:
+          # unset env-vars that provide AWS credentials
+          AWS_ACCESS_KEY_ID:
+          AWS_SECRET_ACCESS_KEY:
+          AWS_DEFAULT_REGION:
+          # aws-lc forbids some gcc versions due to security bugs
+          CC: gcc-10
+        run: |
+          python3 -m pip install --verbose
+          python3 -m unittest discover --failfast --verbose
+
   package-source:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           # aws-lc forbids some gcc versions due to security bugs
           CC: gcc-10
         run: |
-          python3 -m pip install --verbose
+          python3 -m pip install . --verbose
           python3 -m unittest discover --failfast --verbose
 
   package-source:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install from Github:
 ````bash
 git clone https://github.com/awslabs/aws-crt-python.git
 cd aws-crt-python
-git submodule update --init --recursive
+git submodule update --init
 python3 -m pip install .
 ````
 
@@ -37,3 +37,38 @@ Please note that on Mac, once a private key is used with a certificate, that cer
 ```
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain. Using key from Keychain instead of the one provided.
 ```
+
+## Running tests
+
+After install, run from project root:
+```bash
+python3 -m unittest discover --failfast --verbose
+```
+
+`--failfast` stops after one failed test.
+This is useful because a failed test is likely to leak memory,
+which will cause the rest of the tests to fail as well.
+
+`--verbose` makes it easier to see which tests are skipped.
+
+Many tests require an AWS account. These tests are skipped unless
+specific environment variables are set:
+
+MQTT
+* AWS_TEST_IOT_MQTT_ENDPOINT - AWS account-specific endpoint to connect to IoT core by
+* AWS_TEST_TLS_CERT_PATH - file path to certificate used to initialize the TLS context of the MQTT connection
+* AWS_TEST_TLS_KEY_PATH - file path to the private key used to initialize the TLS context of the MQTT connection
+* AWS_TEST_TLS_ROOT_CERT_PATH - file path to the root CA used to initialize the TLS context of the MQTT connection
+
+PROXY
+* AWS_TEST_HTTP_PROXY_HOST - host address of the proxy to use for tests that make open connections to the proxy
+* AWS_TEST_HTTP_PROXY_PORT - port to use for tests that make open connections to the proxy
+* AWS_TEST_HTTPS_PROXY_HOST - host address of the proxy to use for tests that make TLS-protected connections to the proxy
+* AWS_TEST_HTTPS_PROXY_PORT - port to use for tests that make TLS-protected connections to the proxy
+* AWS_TEST_HTTP_PROXY_BASIC_HOST - host address of the proxy to use for tests that make open connections to the proxy with basic authentication
+* AWS_TEST_HTTP_PROXY_BASIC_PORT - port to use for tests that make open connections to the proxy with basic authentication
+* AWS_TEST_BASIC_AUTH_USERNAME - username to use when using basic authentication to the proxy
+* AWS_TEST_BASIC_AUTH_PASSWORD - password to use when using basic authentication to the proxy
+
+S3
+* AWS_TEST_S3 - set to any value to enable S3 tests

--- a/codebuild/linux-integration-tests.sh
+++ b/codebuild/linux-integration-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -euxo pipefail
 
 if test -f "/tmp/setup_proxy_test_env.sh"; then
     source /tmp/setup_proxy_test_env.sh
@@ -15,4 +15,13 @@ cd $CODEBUILD_SRC_DIR
 
 export AWS_TEST_S3=YES
 python -m pip install --verbose .
-python -m unittest discover --failfast --verbose
+python -m unittest discover --failfast --verbose 2>&1 | tee /tmp/tests.log
+
+# ensure no tests were skipped
+if grep -c 'OK (skipped=' /tmp/tests.log
+then
+    echo "ERROR: Some tests were skipped"
+    exit -1
+else
+    echo "No tests skipped"
+fi

--- a/codebuild/linux-integration-tests.sh
+++ b/codebuild/linux-integration-tests.sh
@@ -14,5 +14,6 @@ git submodule update --init
 cd $CODEBUILD_SRC_DIR
 
 export AWS_CRT_MEMORY_TRACING=2
+export AWS_TEST_S3=YES
 python -m pip install --verbose .
 python -m unittest discover test

--- a/codebuild/linux-integration-tests.sh
+++ b/codebuild/linux-integration-tests.sh
@@ -13,7 +13,6 @@ git submodule update --init
 # build package
 cd $CODEBUILD_SRC_DIR
 
-export AWS_CRT_MEMORY_TRACING=2
 export AWS_TEST_S3=YES
 python -m pip install --verbose .
-python -m unittest discover test
+python -m unittest discover --failfast --verbose

--- a/codebuild/linux-integration-tests.sh
+++ b/codebuild/linux-integration-tests.sh
@@ -16,12 +16,3 @@ cd $CODEBUILD_SRC_DIR
 export AWS_TEST_S3=YES
 python -m pip install --verbose .
 python -m unittest discover --failfast --verbose 2>&1 | tee /tmp/tests.log
-
-# ensure no tests were skipped
-if grep -c 'OK (skipped=' /tmp/tests.log
-then
-    echo "ERROR: Some tests were skipped"
-    exit -1
-else
-    echo "No tests skipped"
-fi

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
+# Enable native memory tracing so that tests can detect leaks.
+# This env-var MUST be set before awscrt is imported.
+# the "noqa" comment prevents the autoformatter from moving this line below other imports
+import os
+os.environ['AWS_CRT_MEMORY_TRACING'] = '2'  # noqa
+
 from awscrt import NativeResource
 from awscrt._test import check_for_leaks
 from awscrt.io import init_logging, LogLevel

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -158,6 +158,7 @@ class ProxyTestConfiguration():
             return 443
 
 
+@unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
 class ProxyHttpTest(NativeResourceTest):
 
     def _establish_http_connection(self, test_type, uri, proxy_options):
@@ -192,47 +193,36 @@ class ProxyHttpTest(NativeResourceTest):
         self.assertEqual(200, response.status_code)
         self.assertEqual(200, stream_completion_result)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.FORWARDING, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_legacy_http_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTP, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_proxy_legacy_https_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTPS, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_http_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_https_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_double_tls_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.FORWARDING, HttpProxyAuthenticationType.Basic)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_legacy_http_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTP, HttpProxyAuthenticationType.Basic)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_proxy_legacy_https_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTPS, HttpProxyAuthenticationType.Basic)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_http_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Basic)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_https_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Basic)
 
@@ -261,15 +251,12 @@ class ProxyHttpTest(NativeResourceTest):
         proxy_options = ProxyTestConfiguration.create_http_proxy_options_from_environment(test_type, auth_type)
         connection = self._establish_mqtt_connection(proxy_options)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_http_proxy_mqtt_no_auth(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Nothing)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_http_proxy_mqtt_basic_auth(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Basic)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -30,7 +30,6 @@ from test.test_mqtt import create_client_id
 # AWS_TEST_TLS_KEY_PATH - file path to the key used to initialize the tls context of the mqtt connection
 # AWS_TEST_TLS_ROOT_CERT_PATH - file path to the root CA used to initialize the tls context of the mqtt connection
 
-# AWS_TEST_IOT_SIGNING_REGION - AWS region to make a websocket connection to
 # AWS_TEST_IOT_MQTT_ENDPOINT - AWS account-specific endpoint to connect to IoT core by
 
 """
@@ -60,7 +59,6 @@ class ProxyTestConfiguration():
     HTTP_PROXY_TLS_KEY_PATH = os.environ.get('AWS_TEST_TLS_KEY_PATH')
     HTTP_PROXY_TLS_ROOT_CA_PATH = os.environ.get('AWS_TEST_TLS_ROOT_CERT_PATH')
 
-    HTTP_PROXY_WS_SIGNING_REGION = os.environ.get('AWS_TEST_IOT_SIGNING_REGION')
     HTTP_PROXY_MQTT_ENDPOINT = os.environ.get('AWS_TEST_IOT_MQTT_ENDPOINT')
 
     @staticmethod
@@ -73,6 +71,14 @@ class ProxyTestConfiguration():
             ProxyTestConfiguration.HTTP_PROXY_BASIC_PORT > 0 and \
             ProxyTestConfiguration.HTTP_PROXY_BASIC_AUTH_USERNAME is not None and \
             ProxyTestConfiguration.HTTP_PROXY_BASIC_AUTH_PASSWORD is not None
+
+    @staticmethod
+    def is_mqtt_env_initialized():
+        return ProxyTestConfiguration.is_proxy_environment_initialized() and \
+            ProxyTestConfiguration.HTTP_PROXY_MQTT_ENDPOINT is not None and \
+            ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH is not None and \
+            ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH is not None and \
+            ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH is not None
 
     @staticmethod
     def get_proxy_host_for_test(test_type, auth_type):
@@ -158,7 +164,6 @@ class ProxyTestConfiguration():
             return 443
 
 
-@unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
 class ProxyHttpTest(NativeResourceTest):
 
     def _establish_http_connection(self, test_type, uri, proxy_options):
@@ -193,36 +198,47 @@ class ProxyHttpTest(NativeResourceTest):
         self.assertEqual(200, response.status_code)
         self.assertEqual(200, stream_completion_result)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.FORWARDING, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_legacy_http_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTP, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_proxy_legacy_https_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTPS, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_http_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_https_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_double_tls_no_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.FORWARDING, HttpProxyAuthenticationType.Basic)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_forwarding_proxy_legacy_http_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTP, HttpProxyAuthenticationType.Basic)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_proxy_legacy_https_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.LEGACY_HTTPS, HttpProxyAuthenticationType.Basic)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_http_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Basic)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_proxy_environment_initialized(), 'requires proxy test env vars')
     def test_tunneling_proxy_https_basic_auth(self):
         self._do_proxy_http_test(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Basic)
 
@@ -251,12 +267,15 @@ class ProxyHttpTest(NativeResourceTest):
         proxy_options = ProxyTestConfiguration.create_http_proxy_options_from_environment(test_type, auth_type)
         connection = self._establish_mqtt_connection(proxy_options)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_mqtt_env_initialized(), 'requires proxy and MQTT test env vars')
     def test_tunneling_http_proxy_mqtt_no_auth(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Nothing)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_mqtt_env_initialized(), 'requires proxy and MQTT test env vars')
     def test_tunneling_http_proxy_mqtt_basic_auth(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_HTTP, HttpProxyAuthenticationType.Basic)
 
+    @unittest.skipIf(not ProxyTestConfiguration.is_mqtt_env_initialized(), 'requires proxy and MQTT test env vars')
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -102,6 +102,7 @@ class FakeReadStream(object):
         return fake_data
 
 
+@unittest.skipUnless(os.environ.get('AWS_TEST_S3'), 'set env var to run test: AWS_TEST_S3')
 class S3ClientTest(NativeResourceTest):
 
     def setUp(self):
@@ -125,8 +126,10 @@ class S3ClientTest(NativeResourceTest):
         self.assertTrue(shutdown_event.wait(self.timeout))
 
 
+@unittest.skipUnless(os.environ.get('AWS_TEST_S3'), 'set env var to run test: AWS_TEST_S3')
 class S3RequestTest(NativeResourceTest):
     def setUp(self):
+        # TODO: use env-vars to customize how these tests are run, instead of relying on hard-coded values
         self.get_test_object_path = "/get_object_test_10MB.txt"
         self.put_test_object_path = "/put_object_test_py_10MB.txt"
         self.region = "us-west-2"


### PR DESCRIPTION
ISSUE: Previously, if a test needed user-specific configuration to run, it would pull things like keys and certs from AWS secretsmanager using boto3. This meant developers that wanted to run the tests locally needed to configure their AWS account exactly like the test expected (inconvenient) or use the dev-team's credentials (kinda dangerous).

DESCRIPTION OF CHANGES: Use environment variables to pass things like certs and key. When CI runs, it still pulls the values from secretsmanager, and sets env-vars accordingly. But ordinary developers can just use env-vars.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
