### PR TITLE
Connection builder simplification

### DIFF
--- a/awscrt/_test.py
+++ b/awscrt/_test.py
@@ -10,6 +10,8 @@ import sys
 import time
 import types
 
+from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
+
 
 def native_memory_usage() -> int:
     """
@@ -80,6 +82,10 @@ def check_for_leaks(*, timeout_sec=10.0):
             if the test results will be made public as it may result in secrets
             being leaked.
     """
+    ClientBootstrap.release_static_default()
+    EventLoopGroup.release_static_default()
+    DefaultHostResolver.release_static_default()
+
     if os.getenv('AWS_CRT_MEMORY_TRACING') != '2':
         raise RuntimeError("environment variable AWS_CRT_MEMORY_TRACING=2 must be set for accurate leak checks")
 

--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -125,7 +125,7 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
         self._binding = binding
 
     @classmethod
-    def new_default_chain(cls, client_bootstrap):
+    def new_default_chain(cls, client_bootstrap=None):
         """
         Create the default provider chain used by most AWS SDKs.
 
@@ -137,12 +137,16 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
         4.  (conditional, on by default) EC2 Instance Metadata
 
         Args:
-            client_bootstrap (ClientBootstrap): Client bootstrap to use when initiating socket connection.
+            client_bootstrap (Optional[ClientBootstrap]): Client bootstrap to use when initiating socket connection.
+                If not set, uses the default static ClientBootstrap instead.
 
         Returns:
             AwsCredentialsProvider:
         """
-        assert isinstance(client_bootstrap, ClientBootstrap)
+        assert isinstance(client_bootstrap, ClientBootstrap) or client_bootstrap is None
+
+        if client_bootstrap is None:
+            client_bootstrap = ClientBootstrap.get_or_create_static_default()
 
         binding = _awscrt.credentials_provider_new_chain_default(client_bootstrap)
         return cls(binding)
@@ -170,7 +174,7 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
     @classmethod
     def new_profile(
             cls,
-            client_bootstrap,
+            client_bootstrap=None,
             profile_name=None,
             config_filepath=None,
             credentials_filepath=None):
@@ -179,7 +183,8 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
         loaded from the aws credentials file.
 
         Args:
-            client_bootstrap (ClientBootstrap): Client bootstrap to use when initiating socket connection.
+            client_bootstrap (Optional[ClientBootstrap]): Client bootstrap to use when initiating socket connection.
+                If not set, uses the static default ClientBootstrap instead.
 
             profile_name (Optional[str]): Name of profile to use.
                 If not set, uses value from AWS_PROFILE environment variable.
@@ -196,10 +201,13 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
         Returns:
             AwsCredentialsProvider:
         """
-        assert isinstance(client_bootstrap, ClientBootstrap)
+        assert isinstance(client_bootstrap, ClientBootstrap) or client_bootstrap is None
         assert isinstance(profile_name, str) or profile_name is None
         assert isinstance(config_filepath, str) or config_filepath is None
         assert isinstance(credentials_filepath, str) or credentials_filepath is None
+
+        if client_bootstrap is None:
+            client_bootstrap = ClientBootstrap.get_or_create_static_default()
 
         binding = _awscrt.credentials_provider_new_profile(
             client_bootstrap, profile_name, config_filepath, credentials_filepath)

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -258,7 +258,7 @@ class ClientConnection(NativeResource):
             handler: ClientConnectionHandler,
             host_name: str,
             port: int,
-            bootstrap: ClientBootstrap,
+            bootstrap: ClientBootstrap = None,
             socket_options: Optional[SocketOptions] = None,
             tls_connection_options: Optional[TlsConnectionOptions] = None) -> Future:
         """Asynchronously establish a new ClientConnection.

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -271,6 +271,7 @@ class ClientConnection(NativeResource):
             port: Connect to port.
 
             bootstrap: Client bootstrap to use when initiating socket connection.
+                If None is provided, the default singleton is used.
 
             socket_options: Optional socket options.
                 If None is provided, then default options are used.
@@ -296,6 +297,9 @@ class ClientConnection(NativeResource):
 
         # Connection is not made available to user until setup callback fires
         connection = cls(host_name, port, handler)
+
+        if not bootstrap:
+            bootstrap = ClientBootstrap.get_or_create_static_default()
 
         # connection._binding is set within the following call */
         _awscrt.event_stream_rpc_client_connection_connect(

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -11,7 +11,7 @@ import _awscrt
 from concurrent.futures import Future
 from awscrt import NativeResource
 import awscrt.exceptions
-from awscrt.io import ClientBootstrap, EventLoopGroup, DefaultHostResolver, InputStream, TlsConnectionOptions, SocketOptions
+from awscrt.io import ClientBootstrap, InputStream, TlsConnectionOptions, SocketOptions
 from enum import IntEnum
 
 

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -94,7 +94,7 @@ class HttpClientConnection(HttpConnectionBase):
 
             port (int): Connect to port.
 
-            bootstrap (ClientBootstrap): Client bootstrap to use when initiating socket connection.
+            bootstrap (Optional [ClientBootstrap]): Client bootstrap to use when initiating socket connection.
                 If None is provided, the default singleton is used.
 
             socket_options (Optional[SocketOptions]): Optional socket options.

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -82,7 +82,7 @@ class HttpClientConnection(HttpConnectionBase):
     def new(cls,
             host_name,
             port,
-            bootstrap,
+            bootstrap=None,
             socket_options=None,
             tls_connection_options=None,
             proxy_options=None):

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -95,6 +95,7 @@ class HttpClientConnection(HttpConnectionBase):
             port (int): Connect to port.
 
             bootstrap (ClientBootstrap): Client bootstrap to use when initiating socket connection.
+                If None is provided, the default singleton is used.
 
             socket_options (Optional[SocketOptions]): Optional socket options.
                 If None is provided, then default options are used.
@@ -124,9 +125,7 @@ class HttpClientConnection(HttpConnectionBase):
                 socket_options = SocketOptions()
 
             if not bootstrap:
-                event_loop_group = EventLoopGroup(1)
-                host_resolver = DefaultHostResolver(event_loop_group)
-                bootstrap = ClientBootstrap(event_loop_group, host_resolver)
+                bootstrap = ClientBootstrap.get_or_create_static_default()
 
             connection = cls()
             connection._host_name = host_name

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -94,7 +94,6 @@ class EventLoopGroup(NativeResource):
         self.shutdown_event = shutdown_event
         self._binding = _awscrt.event_loop_group_new(num_threads, is_pinned, cpu_group, on_shutdown)
 
-
     @staticmethod
     def get_or_create_static_default():
         global _static_event_loop_group
@@ -103,23 +102,22 @@ class EventLoopGroup(NativeResource):
                 return _static_event_loop_group
 
         os_cpu_count = os.cpu_count()
-        if os_cpu_count == None:
+        if os_cpu_count is None:
             os_cpu_count = 1 # could not find the processor count - default to 1
         else:
-            #os.cpu_count returns all cores on the system (including virtual ones)
-            #so we divide by two to avoid using all cores on the entire system.
-            os_cpu_count = max(1, int(os_cpu_count/2))
+            # os.cpu_count returns all cores on the system (including virtual ones)
+            # so we divide by two to avoid using all cores on the entire system.
+            os_cpu_count = max(1, int(os_cpu_count / 2))
 
         _static_event_loop_group = EventLoopGroup(os_cpu_count)
         return _static_event_loop_group
-
 
     @staticmethod
     def release_static_default():
         global _static_event_loop_group
         if '_static_event_loop_group' in globals():
             if isinstance(_static_event_loop_group, EventLoopGroup):
-                del _static_event_loop_group
+                del _static_event_loop_group # lgtm [py/unnecessary-delete]
 
 
 class HostResolverBase(NativeResource):
@@ -142,7 +140,6 @@ class DefaultHostResolver(HostResolverBase):
         super().__init__()
         self._binding = _awscrt.host_resolver_new_default(max_hosts, event_loop_group)
 
-
     @staticmethod
     def get_or_create_static_default():
         global _static_default_host_resolver
@@ -152,12 +149,11 @@ class DefaultHostResolver(HostResolverBase):
         _static_default_host_resolver = DefaultHostResolver(EventLoopGroup.get_or_create_static_default())
         return _static_default_host_resolver
 
-
     @staticmethod
     def release_static_default():
         global _static_default_host_resolver
         if isinstance(_static_default_host_resolver, DefaultHostResolver):
-            del _static_default_host_resolver
+            del _static_default_host_resolver # lgtm [py/unnecessary-delete]
 
 
 class ClientBootstrap(NativeResource):
@@ -188,7 +184,6 @@ class ClientBootstrap(NativeResource):
         self.shutdown_event = shutdown_event
         self._binding = _awscrt.client_bootstrap_new(event_loop_group, host_resolver, on_shutdown)
 
-
     @staticmethod
     def get_or_create_static_default():
         global _static_client_bootstrap
@@ -200,12 +195,11 @@ class ClientBootstrap(NativeResource):
             DefaultHostResolver.get_or_create_static_default())
         return _static_client_bootstrap
 
-
     @staticmethod
     def release_static_default():
         global _static_client_bootstrap
         if isinstance(_static_client_bootstrap, ClientBootstrap):
-            del _static_client_bootstrap
+            del _static_client_bootstrap # lgtm [py/unnecessary-delete]
 
 
 def _read_binary_file(filepath):

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -126,7 +126,7 @@ class DefaultHostResolver(HostResolverBase):
         with DefaultHostResolver._static_host_resolver_lock:
             if DefaultHostResolver._static_host_resolver is None:
                 DefaultHostResolver._static_host_resolver = DefaultHostResolver(
-                    EventLoopGroup.get_or_create_static_default)
+                    EventLoopGroup.get_or_create_static_default())
             return DefaultHostResolver._static_host_resolver
 
     @staticmethod
@@ -169,7 +169,7 @@ class ClientBootstrap(NativeResource):
     @staticmethod
     def get_or_create_static_default():
         with ClientBootstrap._static_client_bootstrap_lock:
-            if ClientBootstrap._static_client_bootstrap_lock is None:
+            if ClientBootstrap._static_client_bootstrap is None:
                 ClientBootstrap._static_client_bootstrap = ClientBootstrap(
                     EventLoopGroup.get_or_create_static_default(),
                     DefaultHostResolver.get_or_create_static_default())

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -87,22 +87,15 @@ class EventLoopGroup(NativeResource):
 
     @staticmethod
     def get_or_create_static_default():
-        EventLoopGroup._static_event_loop_group_lock.acquire()
-        if EventLoopGroup._static_event_loop_group is not None:
-            if isinstance(EventLoopGroup._static_event_loop_group, EventLoopGroup):
-                EventLoopGroup._static_event_loop_group_lock.release()
-                return EventLoopGroup._static_event_loop_group
-        EventLoopGroup._static_event_loop_group = EventLoopGroup()
-        EventLoopGroup._static_event_loop_group_lock.release()
-        return EventLoopGroup._static_event_loop_group
+        with EventLoopGroup._static_event_loop_group_lock:
+            if EventLoopGroup._static_event_loop_group is None:
+                EventLoopGroup._static_event_loop_group = EventLoopGroup()
+            return EventLoopGroup._static_event_loop_group
 
     @staticmethod
     def release_static_default():
-        EventLoopGroup._static_event_loop_group_lock.acquire()
-        if EventLoopGroup._static_event_loop_group is not None:
-            if isinstance(EventLoopGroup._static_event_loop_group, EventLoopGroup):
-                EventLoopGroup._static_event_loop_group = None
-        EventLoopGroup._static_event_loop_group_lock.release()
+        with EventLoopGroup._static_event_loop_group_lock:
+            EventLoopGroup._static_event_loop_group = None
 
 
 class HostResolverBase(NativeResource):
@@ -130,22 +123,16 @@ class DefaultHostResolver(HostResolverBase):
 
     @staticmethod
     def get_or_create_static_default():
-        DefaultHostResolver._static_host_resolver_lock.acquire()
-        if DefaultHostResolver._static_host_resolver is not None:
-            if isinstance(DefaultHostResolver._static_host_resolver, DefaultHostResolver):
-                DefaultHostResolver._static_host_resolver_lock.release()
-                return DefaultHostResolver._static_host_resolver
-        DefaultHostResolver._static_host_resolver = DefaultHostResolver(EventLoopGroup.get_or_create_static_default())
-        DefaultHostResolver._static_host_resolver_lock.release()
-        return DefaultHostResolver._static_host_resolver
+        with DefaultHostResolver._static_host_resolver_lock:
+            if DefaultHostResolver._static_host_resolver is None:
+                DefaultHostResolver._static_host_resolver = DefaultHostResolver(
+                    EventLoopGroup.get_or_create_static_default)
+            return DefaultHostResolver._static_host_resolver
 
     @staticmethod
     def release_static_default():
-        DefaultHostResolver._static_host_resolver_lock.acquire()
-        if DefaultHostResolver._static_host_resolver is not None:
-            if isinstance(DefaultHostResolver._static_host_resolver, DefaultHostResolver):
-                DefaultHostResolver._static_host_resolver = None
-        DefaultHostResolver._static_host_resolver_lock.release()
+        with DefaultHostResolver._static_host_resolver_lock:
+            DefaultHostResolver._static_host_resolver = None
 
 
 class ClientBootstrap(NativeResource):
@@ -181,24 +168,17 @@ class ClientBootstrap(NativeResource):
 
     @staticmethod
     def get_or_create_static_default():
-        ClientBootstrap._static_client_bootstrap_lock.acquire()
-        if ClientBootstrap._static_client_bootstrap is not None:
-            if isinstance(ClientBootstrap._static_client_bootstrap, ClientBootstrap):
-                ClientBootstrap._static_client_bootstrap_lock.release()
-                return ClientBootstrap._static_client_bootstrap
-        ClientBootstrap._static_client_bootstrap = ClientBootstrap(
-            EventLoopGroup.get_or_create_static_default(),
-            DefaultHostResolver.get_or_create_static_default())
-        ClientBootstrap._static_client_bootstrap_lock.release()
-        return ClientBootstrap._static_client_bootstrap
+        with ClientBootstrap._static_client_bootstrap_lock:
+            if ClientBootstrap._static_client_bootstrap_lock is None:
+                ClientBootstrap._static_client_bootstrap = ClientBootstrap(
+                    EventLoopGroup.get_or_create_static_default(),
+                    DefaultHostResolver.get_or_create_static_default())
+            return ClientBootstrap._static_client_bootstrap
 
     @staticmethod
     def release_static_default():
-        ClientBootstrap._static_client_bootstrap_lock.acquire()
-        if ClientBootstrap._static_client_bootstrap is not None:
-            if isinstance(ClientBootstrap._static_client_bootstrap, ClientBootstrap):
-                ClientBootstrap._static_client_bootstrap = None
-        ClientBootstrap._static_client_bootstrap_lock.release()
+        with ClientBootstrap._static_client_bootstrap_lock:
+            ClientBootstrap._static_client_bootstrap = None
 
 
 def _read_binary_file(filepath):

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -103,7 +103,7 @@ class EventLoopGroup(NativeResource):
 
         os_cpu_count = os.cpu_count()
         if os_cpu_count is None:
-            os_cpu_count = 1 # could not find the processor count - default to 1
+            os_cpu_count = 1  # could not find the processor count - default to 1
         else:
             # os.cpu_count returns all cores on the system (including virtual ones)
             # so we divide by two to avoid using all cores on the entire system.
@@ -117,7 +117,7 @@ class EventLoopGroup(NativeResource):
         global _static_event_loop_group
         if '_static_event_loop_group' in globals():
             if isinstance(_static_event_loop_group, EventLoopGroup):
-                del _static_event_loop_group # lgtm [py/unnecessary-delete]
+                del _static_event_loop_group  # lgtm [py/unnecessary-delete]
 
 
 class HostResolverBase(NativeResource):
@@ -153,7 +153,7 @@ class DefaultHostResolver(HostResolverBase):
     def release_static_default():
         global _static_default_host_resolver
         if isinstance(_static_default_host_resolver, DefaultHostResolver):
-            del _static_default_host_resolver # lgtm [py/unnecessary-delete]
+            del _static_default_host_resolver  # lgtm [py/unnecessary-delete]
 
 
 class ClientBootstrap(NativeResource):
@@ -199,7 +199,7 @@ class ClientBootstrap(NativeResource):
     def release_static_default():
         global _static_client_bootstrap
         if isinstance(_static_client_bootstrap, ClientBootstrap):
-            del _static_client_bootstrap # lgtm [py/unnecessary-delete]
+            del _static_client_bootstrap  # lgtm [py/unnecessary-delete]
 
 
 def _read_binary_file(filepath):

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -39,6 +39,7 @@ def init_logging(log_level, file_name):
 
     _awscrt.init_logging(log_level, file_name)
 
+
 """
 Static Defaults (singletons - or as close as possible in Python)
 
@@ -47,6 +48,7 @@ Will be garbage collected when program ends or module is unloaded
 _static_client_bootstrap = None
 _static_default_host_resolver = None
 _static_event_loop_group = None
+
 
 class EventLoopGroup(NativeResource):
     """A collection of event-loops.
@@ -91,14 +93,15 @@ class EventLoopGroup(NativeResource):
 
         self.shutdown_event = shutdown_event
         self._binding = _awscrt.event_loop_group_new(num_threads, is_pinned, cpu_group, on_shutdown)
-    
+
+
     @staticmethod
     def get_or_create_static_default():
         global _static_event_loop_group
         if '_static_event_loop_group' in globals():
             if isinstance(_static_event_loop_group, EventLoopGroup):
                 return _static_event_loop_group
-        
+
         os_cpu_count = os.cpu_count()
         if os_cpu_count == None:
             os_cpu_count = 1 # could not find the processor count - default to 1
@@ -106,16 +109,18 @@ class EventLoopGroup(NativeResource):
             #os.cpu_count returns all cores on the system (including virtual ones)
             #so we divide by two to avoid using all cores on the entire system.
             os_cpu_count = max(1, int(os_cpu_count/2))
-        
+
         _static_event_loop_group = EventLoopGroup(os_cpu_count)
         return _static_event_loop_group
-    
+
+
     @staticmethod
     def release_static_default():
         global _static_event_loop_group
         if '_static_event_loop_group' in globals():
             if isinstance(_static_event_loop_group, EventLoopGroup):
                 del _static_event_loop_group
+
 
 class HostResolverBase(NativeResource):
     """DNS host resolver."""
@@ -136,7 +141,8 @@ class DefaultHostResolver(HostResolverBase):
 
         super().__init__()
         self._binding = _awscrt.host_resolver_new_default(max_hosts, event_loop_group)
-    
+
+
     @staticmethod
     def get_or_create_static_default():
         global _static_default_host_resolver
@@ -145,7 +151,8 @@ class DefaultHostResolver(HostResolverBase):
                 return _static_default_host_resolver
         _static_default_host_resolver = DefaultHostResolver(EventLoopGroup.get_or_create_static_default())
         return _static_default_host_resolver
-    
+
+
     @staticmethod
     def release_static_default():
         global _static_default_host_resolver
@@ -180,21 +187,26 @@ class ClientBootstrap(NativeResource):
 
         self.shutdown_event = shutdown_event
         self._binding = _awscrt.client_bootstrap_new(event_loop_group, host_resolver, on_shutdown)
-    
+
+
     @staticmethod
     def get_or_create_static_default():
         global _static_client_bootstrap
         if '_static_client_bootstrap' in globals():
             if isinstance(_static_client_bootstrap, ClientBootstrap):
                 return _static_client_bootstrap
-        _static_client_bootstrap = ClientBootstrap(EventLoopGroup.get_or_create_static_default(), DefaultHostResolver.get_or_create_static_default())
+        _static_client_bootstrap = ClientBootstrap(
+            EventLoopGroup.get_or_create_static_default(),
+            DefaultHostResolver.get_or_create_static_default())
         return _static_client_bootstrap
-    
+
+
     @staticmethod
     def release_static_default():
         global _static_client_bootstrap
         if isinstance(_static_client_bootstrap, ClientBootstrap):
             del _static_client_bootstrap
+
 
 def _read_binary_file(filepath):
     with open(filepath, mode='rb') as fh:
@@ -761,54 +773,3 @@ class Pkcs11Lib(NativeResource):
             behavior = Pkcs11Lib.InitializeFinalizeBehavior.DEFAULT
 
         self._binding = _awscrt.pkcs11_lib_new(file, behavior)
-
-
-"""
-class Defaults:
-    # A class containing default, preconfigured instances of ClientBootstrap,
-    # EventLoopGroup, and HostResolver
-
-    def __init__(self):
-        self._static_client_bootstrap = None
-        self._static_event_loop_group = None
-        self._static_default_host_resolver = None
-    
-    def __del__(self):
-        if self._static_client_bootstrap is ClientBootstrap:
-            del self._static_client_bootstrap
-            self._static_client_bootstrap = None
-        if self._static_default_host_resolver is DefaultHostResolver:
-            del self._static_default_host_resolver
-            self._static_default_host_resolver = None
-        if self._static_event_loop_group is EventLoopGroup:
-            del self._static_event_loop_group
-            self._static_event_loop_group = None
-    
-    def client_bootstrap_get_or_create_static_default(self):
-        if self._static_client_bootstrap is ClientBootstrap:
-            return self._static_client_bootstrap
-        self._static_client_bootstrap = ClientBootstrap(self.event_loop_group_get_or_create_static_default(), self.host_resolver_get_or_create_static_default())
-        print ("\n Made (class) ClientBootstrap \n")
-        return self._static_client_bootstrap
-    
-    def event_loop_group_get_or_create_static_default(self):
-        if self._static_event_loop_group is EventLoopGroup:
-            return self._static_event_loop_group
-        
-        os_cpu_count = os.cpu_count()
-        if os_cpu_count == None:
-            os_cpu_count = 1 # could not find the processor count - default to 1
-        else:
-            # os.cpu_count returns all cores on the system (including virtual ones)
-            # so we divide by two to avoid using all cores on the entire system.
-            os_cpu_count = max(1, int(os_cpu_count/2))
-        self._static_event_loop_group = EventLoopGroup(os_cpu_count)
-        
-        return self._static_event_loop_group
-    
-    def host_resolver_get_or_create_static_default(self):
-        if self._static_default_host_resolver is DefaultHostResolver:
-            return self._static_default_host_resolver
-        self._static_default_host_resolver = DefaultHostResolver(self.event_loop_group_get_or_create_static_default())
-        return self._static_default_host_resolver
-"""

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -12,7 +12,6 @@ import _awscrt
 from awscrt import NativeResource
 from enum import IntEnum
 import threading
-import os
 
 
 class LogLevel(IntEnum):

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -130,7 +130,7 @@ class Client(NativeResource):
     """MQTT client.
 
     Args:
-        bootstrap (ClientBootstrap): Client bootstrap to use when initiating new socket connections.
+        bootstrap (Optional [ClientBootstrap]): Client bootstrap to use when initiating new socket connections.
             If None is provided, the default singleton is used.
 
         tls_ctx (Optional[ClientTlsContext]): TLS context for secure socket connections.

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -244,7 +244,7 @@ class Connection(NativeResource):
 
         proxy_options (Optional[awscrt.http.HttpProxyOptions]):
             Optional proxy options for all connections.
-        
+
         using_static_default (Optional[bool]):
             If true, the connection will clean the static default ClientHandler, EventLoopGroup, and HostResolver.
         """
@@ -441,7 +441,7 @@ class Connection(NativeResource):
         try:
             _awscrt.mqtt_client_connection_disconnect(self._binding, on_disconnect)
 
-            if self.using_static_defaults == True:
+            if self.using_static_defaults:
                 ClientBootstrap.release_static_default()
                 DefaultHostResolver.release_static_default()
                 EventLoopGroup.release_static_default()

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -139,7 +139,7 @@ class Client(NativeResource):
 
     __slots__ = ('tls_ctx')
 
-    def __init__(self, bootstrap, tls_ctx=None):
+    def __init__(self, bootstrap=None, tls_ctx=None):
         assert isinstance(bootstrap, ClientBootstrap) or bootstrap is None
         assert tls_ctx is None or isinstance(tls_ctx, ClientTlsContext)
 

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -441,11 +441,6 @@ class Connection(NativeResource):
         try:
             _awscrt.mqtt_client_connection_disconnect(self._binding, on_disconnect)
 
-            if self.using_static_defaults:
-                ClientBootstrap.release_static_default()
-                DefaultHostResolver.release_static_default()
-                EventLoopGroup.release_static_default()
-
         except Exception as e:
             future.set_exception(e)
 

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -55,6 +55,7 @@ class S3Client(NativeResource):
 
     Keyword Args:
         bootstrap (ClientBootstrap): Client bootstrap to use when initiating socket connection.
+            If None is provided, the default singleton is used.
 
         region (str): Region that the S3 bucket lives in.
 
@@ -94,7 +95,7 @@ class S3Client(NativeResource):
             tls_connection_options=None,
             part_size=None,
             throughput_target_gbps=None):
-        assert isinstance(bootstrap, ClientBootstrap)
+        assert isinstance(bootstrap, ClientBootstrap) or bootstrap is None
         assert isinstance(region, str)
         assert isinstance(credential_provider, AwsCredentialsProvider) or credential_provider is None
         assert isinstance(tls_connection_options, TlsConnectionOptions) or tls_connection_options is None
@@ -113,6 +114,9 @@ class S3Client(NativeResource):
             shutdown_event.set()
         self._region = region
         self.shutdown_event = shutdown_event
+
+        if not bootstrap:
+            bootstrap = ClientBootstrap.get_or_create_static_default()
         s3_client_core = _S3ClientCore(bootstrap, credential_provider, tls_connection_options)
 
         # C layer uses 0 to indicate defaults

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -54,7 +54,7 @@ class S3Client(NativeResource):
     """S3 client
 
     Keyword Args:
-        bootstrap (ClientBootstrap): Client bootstrap to use when initiating socket connection.
+        bootstrap (Optional [ClientBootstrap]): Client bootstrap to use when initiating socket connection.
             If None is provided, the default singleton is used.
 
         region (str): Region that the S3 bucket lives in.

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -24,12 +24,41 @@ class EventLoopGroupTest(NativeResourceTest):
         shutdown_event = event_loop_group.shutdown_event
         del event_loop_group
         self.assertTrue(shutdown_event.wait(TIMEOUT))
+    
+    def test_init_defaults_singleton(self):
+        event_loop_group = EventLoopGroup.get_or_create_static_default()
+        EventLoopGroup.release_static_default()
+    
+    def test_init_defaults_singleton_is_singleton(self):
+        event_loop_group_one = EventLoopGroup.get_or_create_static_default()
+        event_loop_group_two = EventLoopGroup.get_or_create_static_default()
+        self.assertTrue(event_loop_group_one == event_loop_group_two)
+        EventLoopGroup.release_static_default()
+    
+    def test_shutdown_complete_singleton(self):
+        event_loop_group = EventLoopGroup.get_or_create_static_default()
+        shutdown_event = event_loop_group.shutdown_event
+        del event_loop_group
+        EventLoopGroup.release_static_default()
+        self.assertTrue(shutdown_event.wait(TIMEOUT))
 
 
 class DefaultHostResolverTest(NativeResourceTest):
     def test_init(self):
         event_loop_group = EventLoopGroup()
         host_resolver = DefaultHostResolver(event_loop_group)
+    
+    def test_init_singleton(self):
+        host_resolver = DefaultHostResolver.get_or_create_static_default()
+        DefaultHostResolver.release_static_default()
+        EventLoopGroup.release_static_default()
+    
+    def test_init_singleton_is_singleton(self):
+        host_resolver_one = DefaultHostResolver.get_or_create_static_default()
+        host_resolver_two = DefaultHostResolver.get_or_create_static_default()
+        self.assertTrue(host_resolver_one == host_resolver_two)
+        DefaultHostResolver.release_static_default()
+        EventLoopGroup.release_static_default()
 
 
 class ClientBootstrapTest(NativeResourceTest):
@@ -42,6 +71,27 @@ class ClientBootstrapTest(NativeResourceTest):
         bootstrap_shutdown_event = bootstrap.shutdown_event
         del bootstrap
         self.assertTrue(bootstrap_shutdown_event.wait(TIMEOUT))
+    
+    def test_create_destroy_singleton(self):
+        bootstrap = ClientBootstrap.get_or_create_static_default()
+
+        # ensure shutdown_event fires
+        bootstrap_shutdown_event = bootstrap.shutdown_event
+        del bootstrap
+
+        ClientBootstrap.release_static_default()
+        EventLoopGroup.release_static_default()
+        DefaultHostResolver.release_static_default()
+
+        self.assertTrue(bootstrap_shutdown_event.wait(TIMEOUT))
+    
+    def test_init_singleton_is_singleton(self):
+        client_one = ClientBootstrap.get_or_create_static_default()
+        client_two = ClientBootstrap.get_or_create_static_default()
+        self.assertTrue(client_one == client_two)
+        ClientBootstrap.release_static_default()
+        EventLoopGroup.release_static_default()
+        DefaultHostResolver.release_static_default()
 
 
 class ClientTlsContextTest(NativeResourceTest):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -78,6 +78,7 @@ class ClientBootstrapTest(NativeResourceTest):
     def test_init_singleton_is_singleton(self):
         client_one = ClientBootstrap.get_or_create_static_default()
         client_two = ClientBootstrap.get_or_create_static_default()
+        self.assertTrue(client_one == client_two)
 
 
 class ClientTlsContextTest(NativeResourceTest):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -24,17 +24,17 @@ class EventLoopGroupTest(NativeResourceTest):
         shutdown_event = event_loop_group.shutdown_event
         del event_loop_group
         self.assertTrue(shutdown_event.wait(TIMEOUT))
-    
+
     def test_init_defaults_singleton(self):
         event_loop_group = EventLoopGroup.get_or_create_static_default()
         EventLoopGroup.release_static_default()
-    
+
     def test_init_defaults_singleton_is_singleton(self):
         event_loop_group_one = EventLoopGroup.get_or_create_static_default()
         event_loop_group_two = EventLoopGroup.get_or_create_static_default()
         self.assertTrue(event_loop_group_one == event_loop_group_two)
         EventLoopGroup.release_static_default()
-    
+
     def test_shutdown_complete_singleton(self):
         event_loop_group = EventLoopGroup.get_or_create_static_default()
         shutdown_event = event_loop_group.shutdown_event
@@ -47,12 +47,12 @@ class DefaultHostResolverTest(NativeResourceTest):
     def test_init(self):
         event_loop_group = EventLoopGroup()
         host_resolver = DefaultHostResolver(event_loop_group)
-    
+
     def test_init_singleton(self):
         host_resolver = DefaultHostResolver.get_or_create_static_default()
         DefaultHostResolver.release_static_default()
         EventLoopGroup.release_static_default()
-    
+
     def test_init_singleton_is_singleton(self):
         host_resolver_one = DefaultHostResolver.get_or_create_static_default()
         host_resolver_two = DefaultHostResolver.get_or_create_static_default()
@@ -71,7 +71,7 @@ class ClientBootstrapTest(NativeResourceTest):
         bootstrap_shutdown_event = bootstrap.shutdown_event
         del bootstrap
         self.assertTrue(bootstrap_shutdown_event.wait(TIMEOUT))
-    
+
     def test_create_destroy_singleton(self):
         bootstrap = ClientBootstrap.get_or_create_static_default()
 
@@ -84,7 +84,7 @@ class ClientBootstrapTest(NativeResourceTest):
         DefaultHostResolver.release_static_default()
 
         self.assertTrue(bootstrap_shutdown_event.wait(TIMEOUT))
-    
+
     def test_init_singleton_is_singleton(self):
         client_one = ClientBootstrap.get_or_create_static_default()
         client_two = ClientBootstrap.get_or_create_static_default()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -27,13 +27,11 @@ class EventLoopGroupTest(NativeResourceTest):
 
     def test_init_defaults_singleton(self):
         event_loop_group = EventLoopGroup.get_or_create_static_default()
-        EventLoopGroup.release_static_default()
 
     def test_init_defaults_singleton_is_singleton(self):
         event_loop_group_one = EventLoopGroup.get_or_create_static_default()
         event_loop_group_two = EventLoopGroup.get_or_create_static_default()
         self.assertTrue(event_loop_group_one == event_loop_group_two)
-        EventLoopGroup.release_static_default()
 
     def test_shutdown_complete_singleton(self):
         event_loop_group = EventLoopGroup.get_or_create_static_default()
@@ -50,15 +48,11 @@ class DefaultHostResolverTest(NativeResourceTest):
 
     def test_init_singleton(self):
         host_resolver = DefaultHostResolver.get_or_create_static_default()
-        DefaultHostResolver.release_static_default()
-        EventLoopGroup.release_static_default()
 
     def test_init_singleton_is_singleton(self):
         host_resolver_one = DefaultHostResolver.get_or_create_static_default()
         host_resolver_two = DefaultHostResolver.get_or_create_static_default()
         self.assertTrue(host_resolver_one == host_resolver_two)
-        DefaultHostResolver.release_static_default()
-        EventLoopGroup.release_static_default()
 
 
 class ClientBootstrapTest(NativeResourceTest):
@@ -78,20 +72,12 @@ class ClientBootstrapTest(NativeResourceTest):
         # ensure shutdown_event fires
         bootstrap_shutdown_event = bootstrap.shutdown_event
         del bootstrap
-
         ClientBootstrap.release_static_default()
-        EventLoopGroup.release_static_default()
-        DefaultHostResolver.release_static_default()
-
         self.assertTrue(bootstrap_shutdown_event.wait(TIMEOUT))
 
     def test_init_singleton_is_singleton(self):
         client_one = ClientBootstrap.get_or_create_static_default()
         client_two = ClientBootstrap.get_or_create_static_default()
-        self.assertTrue(client_one == client_two)
-        ClientBootstrap.release_static_default()
-        EventLoopGroup.release_static_default()
-        DefaultHostResolver.release_static_default()
 
 
 class ClientTlsContextTest(NativeResourceTest):

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -224,7 +224,7 @@ class MqttConnectionSingletonTest(NativeResourceTest):
             tls_opts = TlsContextOptions.create_client_with_mtls_from_path(config.cert_path, config.key_path)
             tls = ClientTlsContext(tls_opts)
 
-        client = Client(tls)
+        client = Client(tls_ctx=tls)
         connection = Connection(
             client=client,
             client_id=create_client_id(),

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -60,11 +60,6 @@ class MqttConnectionTest(NativeResourceTest):
     def _create_connection(self, auth_type=AuthType.CERT_AND_KEY, use_static_singletons=False):
         config = Config(auth_type)
 
-        if not use_static_singletons:
-            elg = EventLoopGroup()
-            resolver = DefaultHostResolver(elg)
-            bootstrap = ClientBootstrap(elg, resolver)
-
         if auth_type == AuthType.CERT_AND_KEY:
             tls_opts = TlsContextOptions.create_client_with_mtls_from_path(config.cert_path, config.key_path)
             tls = ClientTlsContext(tls_opts)
@@ -92,8 +87,11 @@ class MqttConnectionTest(NativeResourceTest):
                     raise
 
         if use_static_singletons:
-            client = Client(tls)
+            client = Client(tls_ctx=tls)
         else:
+            elg = EventLoopGroup()
+            resolver = DefaultHostResolver(elg)
+            bootstrap = ClientBootstrap(elg, resolver)
             client = Client(bootstrap, tls)
 
         connection = Connection(

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -237,6 +237,11 @@ class MqttConnectionSingletonTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
+        # free singletons
+        ClientBootstrap.release_static_default()
+        EventLoopGroup.release_static_default()
+        DefaultHostResolver.release_static_default()
+
     def test_pub_sub(self):
         connection = self._create_connection()
         connection.connect().result(TIMEOUT)
@@ -273,6 +278,11 @@ class MqttConnectionSingletonTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
+        # free singletons
+        ClientBootstrap.release_static_default()
+        EventLoopGroup.release_static_default()
+        DefaultHostResolver.release_static_default()
+
     def test_on_message(self):
         connection = self._create_connection()
         received = Future()
@@ -302,6 +312,11 @@ class MqttConnectionSingletonTest(NativeResourceTest):
 
         # disconnect
         connection.disconnect().result(TIMEOUT)
+
+        # free singletons
+        ClientBootstrap.release_static_default()
+        EventLoopGroup.release_static_default()
+        DefaultHostResolver.release_static_default()
 
 
 if __name__ == 'main':

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -213,5 +213,95 @@ class MqttConnectionTest(NativeResourceTest):
         connection.disconnect().result(TIMEOUT)
 
 
+class MqttConnectionSingletonTest(NativeResourceTest):
+    TEST_TOPIC = '/test/me/senpai'
+    TEST_MSG = 'NOTICE ME!'.encode('utf8')
+
+    def _create_connection(self, auth_type=AuthType.CERT_AND_KEY):
+        config = Config(auth_type)
+
+        if auth_type == AuthType.CERT_AND_KEY:
+            tls_opts = TlsContextOptions.create_client_with_mtls_from_path(config.cert_path, config.key_path)
+            tls = ClientTlsContext(tls_opts)
+
+        client = Client(tls)
+        connection = Connection(
+            client=client,
+            client_id=create_client_id(),
+            host_name=config.endpoint,
+            port=8883)
+        return connection
+
+    def test_connect_disconnect(self):
+        connection = self._create_connection()
+        connection.connect().result(TIMEOUT)
+        connection.disconnect().result(TIMEOUT)
+
+    def test_pub_sub(self):
+        connection = self._create_connection()
+        connection.connect().result(TIMEOUT)
+        received = Future()
+
+        def on_message(**kwargs):
+            received.set_result(kwargs)
+
+        # subscribe
+        subscribed, packet_id = connection.subscribe(self.TEST_TOPIC, QoS.AT_LEAST_ONCE, on_message)
+        suback = subscribed.result(TIMEOUT)
+        self.assertEqual(packet_id, suback['packet_id'])
+        self.assertEqual(self.TEST_TOPIC, suback['topic'])
+        self.assertIs(QoS.AT_LEAST_ONCE, suback['qos'])
+
+        # publish
+        published, packet_id = connection.publish(self.TEST_TOPIC, self.TEST_MSG, QoS.AT_LEAST_ONCE)
+        puback = published.result(TIMEOUT)
+        self.assertEqual(packet_id, puback['packet_id'])
+
+        # receive message
+        rcv = received.result(TIMEOUT)
+        self.assertEqual(self.TEST_TOPIC, rcv['topic'])
+        self.assertEqual(self.TEST_MSG, rcv['payload'])
+        self.assertFalse(rcv['dup'])
+        self.assertEqual(QoS.AT_LEAST_ONCE, rcv['qos'])
+        self.assertFalse(rcv['retain'])
+
+        # unsubscribe
+        unsubscribed, packet_id = connection.unsubscribe(self.TEST_TOPIC)
+        unsuback = unsubscribed.result(TIMEOUT)
+        self.assertEqual(packet_id, unsuback['packet_id'])
+
+        # disconnect
+        connection.disconnect().result(TIMEOUT)
+
+    def test_on_message(self):
+        connection = self._create_connection()
+        received = Future()
+
+        def on_message(**kwargs):
+            received.set_result(kwargs)
+
+        # on_message for connection has to be set before connect, or possible race will happen
+        connection.on_message(on_message)
+
+        connection.connect().result(TIMEOUT)
+        # subscribe without callback
+        subscribed, packet_id = connection.subscribe(self.TEST_TOPIC, QoS.AT_LEAST_ONCE)
+        subscribed.result(TIMEOUT)
+
+        # publish
+        published, packet_id = connection.publish(self.TEST_TOPIC, self.TEST_MSG, QoS.AT_LEAST_ONCE)
+        puback = published.result(TIMEOUT)
+
+        # receive message
+        rcv = received.result(TIMEOUT)
+        self.assertEqual(self.TEST_TOPIC, rcv['topic'])
+        self.assertEqual(self.TEST_MSG, rcv['payload'])
+        self.assertFalse(rcv['dup'])
+        self.assertEqual(QoS.AT_LEAST_ONCE, rcv['qos'])
+        self.assertFalse(rcv['retain'])
+
+        # disconnect
+        connection.disconnect().result(TIMEOUT)
+
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -303,5 +303,6 @@ class MqttConnectionSingletonTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
+
 if __name__ == 'main':
     unittest.main()


### PR DESCRIPTION
*Description of changes:*

These changes make it where it's not required to create and manage a DefaultHostResolver, EventLoopGroup, or ClientBootstrap to make a connection. Instead, default singletons have been added to handle this use case.

The constructors of several classes have also been altered to allow passing a ClientBootstrap to be optional rather than required. When optional, the ClientBootstrap singleton will be used.
The MQTT connection class will free the singletons if no ClientBootstrap is passed, making the samples not require creating or directly referencing the ClientBootstrap at all.

Finally, the singletons were added to the testing to ensure they work as expected moving forward.

_______

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
