### PR TITLE
Support mutual TLS using a certificate from a Windows cert store

### DIFF
--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -434,7 +434,7 @@ class TlsContextOptions:
         Args:
             cert_path (str): Path to certificate in a Windows certificate store.
                 The path must use backslashes and end with the certificate's thumbprint.
-                Example: "CurrentUser\\MY\\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6"
+                Example: ``CurrentUser\MY\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6``
 
         Returns:
             TlsContextOptions

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -282,6 +282,7 @@ class TlsContextOptions:
         '_pkcs11_private_key_label',
         '_pkcs11_cert_file_path',
         '_pkcs11_cert_file_contents',
+        '_windows_cert_store_path',
     )
 
     def __init__(self):
@@ -423,6 +424,27 @@ class TlsContextOptions:
         return opt
 
     @staticmethod
+    def create_client_with_mtls_windows_cert_store_path(cert_path):
+        """
+        Create options configured for use with mutual TLS in client mode,
+        using a certificate in a Windows certificate store.
+
+        NOTE: This configuration only works on Windows devices.
+
+        Args:
+            cert_path (str): Path to certificate in a Windows certificate store.
+                The path must use backslashes and end with the certificate's thumbprint.
+                Example: "CurrentUser\\MY\\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6"
+
+        Returns:
+            TlsContextOptions
+        """
+        assert isinstance(cert_path, str)
+        opt = TlsContextOptions()
+        opt._windows_cert_store_path = cert_path
+        return opt
+
+    @staticmethod
     def create_server_from_path(cert_filepath, pk_filepath):
         """
         Create options configured for use in server mode.
@@ -556,6 +578,7 @@ class ClientTlsContext(NativeResource):
             options._pkcs11_private_key_label,
             options._pkcs11_cert_file_path,
             options._pkcs11_cert_file_contents,
+            options._windows_cert_store_path,
         )
 
     def new_connection_options(self):

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -434,7 +434,7 @@ class TlsContextOptions:
         Args:
             cert_path (str): Path to certificate in a Windows certificate store.
                 The path must use backslashes and end with the certificate's thumbprint.
-                Example: ``CurrentUser\MY\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6``
+                Example: ``CurrentUser\\MY\\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6``
 
         Returns:
             TlsContextOptions

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -96,8 +96,12 @@ class ClientTlsContextTest(NativeResourceTest):
             opt = TlsContextOptions.create_client_with_mtls_pkcs12(
                 'test/resources/unittest.p12', '1234')
             ctx = ClientTlsContext(opt)
-        except NotImplementedError:
-            raise unittest.SkipTest(f'PKCS#12 not supported on this platform ({sys.platform})')
+        except Exception as e:
+            if 'PLATFORM_NOT_SUPPORTED' in str(e):
+                raise unittest.SkipTest(f'PKCS#12 not supported on this platform ({sys.platform})')
+            else:
+                # well then this is a real error
+                raise e
 
     def test_override_default_trust_store_dir(self):
         opt = TlsContextOptions()


### PR DESCRIPTION
Add the ability to use a client certificate located in a Windows certificate store. Previously, the client certificate and private key had to be passed by filepath or file contents. With this change, certificates and keys stored on TPM devices can be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
