### PR TITLE
simplify make-docs script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ name: docs
 on:
   push:
     branches:
-      - 'main'
+      - 'autodocs'
 
 jobs:
   update-docs-branch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ name: docs
 on:
   push:
     branches:
-      - 'autodocs'
+      - 'main'
 
 jobs:
   update-docs-branch:

--- a/make-docs.sh
+++ b/make-docs.sh
@@ -14,8 +14,4 @@ popd > /dev/null
 
 cp -a docsrc/build/html/. docs
 
-# The existence of this file tells GitHub Pages to just host the HTML as-is
-# https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
-touch docs/.nojekyll
-
 popd > /dev/null


### PR DESCRIPTION
Don't need a `.nojekyll` file. Jekyll does nothing anyway when you push vanilla HTML.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
