### PR TITLE
Revert "simplify make-docs script (#354)"

### DIFF
--- a/make-docs.sh
+++ b/make-docs.sh
@@ -14,4 +14,8 @@ popd > /dev/null
 
 cp -a docsrc/build/html/. docs
 
+# The existence of this file tells GitHub Pages to just host the HTML as-is
+# https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
+touch docs/.nojekyll
+
 popd > /dev/null


### PR DESCRIPTION
This reverts commit 5f4a2fafd6ae3f3a58749185d5a976cb9aadd1bd.

Don't ask me why aws-crt-python's docs need this file to look right, but all the other CRT repos don't. I don't know.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
