### PR TITLE
Support Universal macOS Binary.

### DIFF
--- a/continuous-delivery/build-wheels-osx.sh
+++ b/continuous-delivery/build-wheels-osx.sh
@@ -5,7 +5,6 @@ set -e
 
 /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 ./continuous-delivery/update-version.py
 
-export MACOSX_DEPLOYMENT_TARGET="10.9"
 /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 setup.py bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -148,11 +148,11 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
         cmake = get_cmake_path()
 
         # enable parallel builds for cmake 3.12+
-        # using an environment variables because the "--parallel" arg doesn't exist in older versions.
+        # setting environ because "--parallel" arg doesn't exist in older cmake versions.
         # setting a number because if it's blank then "make" will go absolutely
         # bananas and run out of memory on low-end machines.
         if 'CMAKE_BUILD_PARALLEL_LEVEL' not in os.environ:
-            os.environ['CMAKE_BUILD_PARALLEL_LEVEL'] = os.cpu_count()
+            os.environ['CMAKE_BUILD_PARALLEL_LEVEL'] = f'{os.cpu_count()}'
 
         lib_source_dir = os.path.join(PROJECT_DIR, 'crt', aws_lib.name)
 

--- a/setup.py
+++ b/setup.py
@@ -206,8 +206,8 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
 
     def _build_dependency(self, aws_lib, build_dir, install_path):
         if sys.platform == 'darwin' and self.plat_name.endswith('universal2'):
-            # create macOS Universal Binary by compiling for x86_64 and arm64,
-            # each in its own subfolder, and then creating a Universal Binary
+            # create macOS universal binary by compiling for x86_64 and arm64,
+            # each in its own subfolder, and then creating a universal binary
             # by gluing the two together using `lipo`.
 
             # x86_64
@@ -224,7 +224,7 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
                 install_path=os.path.join(build_dir, 'arm64', 'install'),
                 osx_arch='arm64')
 
-            # create Universal Binary at expected install_path
+            # create universal binary at expected install_path
             lib_dir = os.path.join(install_path, 'lib')
             os.makedirs(lib_dir, exist_ok=True)
             lib_file = f'lib{aws_lib.libname}.a'


### PR DESCRIPTION
**Issue #** https://github.com/aws/aws-iot-device-sdk-python-v2/issues/286

Our `universal2` wheels are currently broken. They don't have everything they need to run on both `x86_64` and `arm64`. We only compiled our dependencies for 1 architecture. The linker was warning us about this but we never noticed.

**Description of Changes:**
When building `universal2` wheels, compile dependencies for both `x86_64` and `arm64`, then use `lipo` to glue them together into a universal binary.

Also:
- Turn on linker warnings. This could have helped us catch these problems earlier.
- Use more specific build tmp folder to prevents collisions when building for multiple python versions on the same machine.
- Properly set `MACOSX_DEPLOYMENT_TARGET`

**Alternatives Explored:**
Experimented with compiling both architectures at the same time via `-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64`, but there were big disadvantages to this way. Mainly, we can't pass any compile flag unless it's supported by both architectures. So we couldn't enable fancy stuff like SSE/AVX instructions for the x86_64 build. Seems better to compile for each architecture using the best possible flags, then just glue them together afterwards.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
