### PR TITLE
Fix release pipeline

### DIFF
--- a/codebuild/cd/manylinux-x64-build.yml
+++ b/codebuild/cd/manylinux-x64-build.yml
@@ -12,8 +12,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - /opt/python/cp35-cp35m/bin/python setup.py sdist bdist_wheel
-      - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp35-cp35m-linux_x86_64.whl
       - /opt/python/cp36-cp36m/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp36-cp36m-linux_x86_64.whl
       - /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
@@ -22,6 +20,7 @@ phases:
       - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp38-cp38-linux_x86_64.whl
       - /opt/python/cp39-cp39/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp39-cp39-linux_x86_64.whl
+      # python 3.9 is the last version manylinux1 will ever receive
       - cp -r wheelhouse ../dist
       - cp dist/*.tar.gz ../dist/
   post_build:

--- a/codebuild/cd/manylinux-x86-build.yml
+++ b/codebuild/cd/manylinux-x86-build.yml
@@ -12,8 +12,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - /opt/python/cp35-cp35m/bin/python setup.py sdist bdist_wheel
-      - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp35-cp35m-linux_i686.whl
       - /opt/python/cp36-cp36m/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp36-cp36m-linux_i686.whl
       - /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
@@ -22,6 +20,7 @@ phases:
       - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp38-cp38-linux_i686.whl
       - /opt/python/cp39-cp39/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp39-cp39-linux_i686.whl
+      # python 3.9 is the last version manylinux1 will ever receive
       - cp -r wheelhouse ../dist
   post_build:
     commands:


### PR DESCRIPTION
The release of [v0.13.10](https://github.com/awslabs/aws-crt-python/releases/tag/v0.13.10) just failed.

Failure was due to these python 3.5 calls.

Python 3.6 is our minimum supported version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
