### PR TITLE
Fix links to the API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Python 3 bindings for the AWS Common Runtime.
 
-*   [API documentation](https://awslabs.github.io/aws-crt-python/)
+*   [API documentation](https://awslabs.github.io/aws-crt-python/api)
 *   [Development guide](docs/dev/README.md) for contributors to aws-crt-python's source code.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Python 3 bindings for the AWS Common Runtime.
 
-*   [API documentation](https://awslabs.github.io/aws-crt-python/api)
+*   [API documentation](https://awslabs.github.io/aws-crt-python)
 *   [Development guide](docs/dev/README.md) for contributors to aws-crt-python's source code.
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # AWS Common Runtime (CRT) for Python: Documentation
 ## CRT Usage
-- [General information](https://github.com/awslabs/aws-crt-python) (installation, etc)
+- [General information](https://github.com/awslabs/aws-crt-python#readme) (installation, etc)
 - [API documentation](https://awslabs.github.io/aws-crt-python/api)
 ## CRT Development
 - [Development guide](dev/README.md) for contributors to aws-crt-python's source code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # AWS Common Runtime (CRT) for Python: Documentation
 ## CRT Usage
-- [General information](../README.md) (installation, etc)
+- [General information](https://github.com/awslabs/aws-crt-python) (installation, etc)
 - [API documentation](https://awslabs.github.io/aws-crt-python/api)
 ## CRT Development
 - [Development guide](dev/README.md) for contributors to aws-crt-python's source code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # AWS Common Runtime (CRT) for Python: Documentation
 ## CRT Usage
 - [General information](../README.md) (installation, etc)
-- [API documentation](https://awslabs.github.io/aws-crt-python/)
+- [API documentation](https://awslabs.github.io/aws-crt-python/api)
 ## CRT Development
 - [Development guide](dev/README.md) for contributors to aws-crt-python's source code.


### PR DESCRIPTION
*Description of changes:*

Fixes links to the API documentation pointing to `https://awslabs.github.io/aws-crt-python` rather than `https://awslabs.github.io/aws-crt-python/api`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
