### PR TITLE
added aws_py_translate_py_error() and use it in mqtt_client_connection.c

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -306,7 +306,7 @@ static void s_error_map_init(void) {
     }
 }
 
-int aws_py_raise_error(void) {
+int aws_py_translate_py_error(void) {
     AWS_ASSERT(PyErr_Occurred() != NULL);
     AWS_ASSERT(PyGILState_Check() == 1);
 
@@ -322,6 +322,13 @@ int aws_py_raise_error(void) {
     PyErr_Print();
     fprintf(stderr, "Treating Python exception as error %d(%s)\n", aws_error_code, aws_error_name(aws_error_code));
 
+    return aws_last_error();
+}
+
+int aws_py_raise_error(void) {
+
+    int aws_error_code = AWS_ERROR_UNKNOWN;
+    aws_error_code = aws_py_translate_py_error();
     return aws_raise_error(aws_error_code);
 }
 

--- a/source/module.c
+++ b/source/module.c
@@ -322,13 +322,12 @@ int aws_py_translate_py_error(void) {
     PyErr_Print();
     fprintf(stderr, "Treating Python exception as error %d(%s)\n", aws_error_code, aws_error_name(aws_error_code));
 
-    return aws_last_error();
+    return aws_error_code;
 }
 
 int aws_py_raise_error(void) {
 
-    int aws_error_code = AWS_ERROR_UNKNOWN;
-    aws_error_code = aws_py_translate_py_error();
+    int aws_error_code = aws_py_translate_py_error();
     return aws_raise_error(aws_error_code);
 }
 

--- a/source/module.h
+++ b/source/module.h
@@ -53,9 +53,9 @@ void PyErr_SetAwsLastError(void);
 PyObject *PyErr_AwsLastError(void);
 
 /**
+ * Return an AWS error code corresponding to the current Python error (fallback is AWS_ERROR_UNKNOWN).
+ *
  * Prints the current Python error to stderr and clears the Python error indicator.
- * Finds an AWS error code corresponding to the current Python error (fallback is AWS_ERROR_UNKNOWN).
- * Returns aws_last_error().
  *
  * The Python error indicator MUST be set and the GIL MUST be held when calling this function. */
 int aws_py_translate_py_error(void);

--- a/source/module.h
+++ b/source/module.h
@@ -53,6 +53,14 @@ void PyErr_SetAwsLastError(void);
 PyObject *PyErr_AwsLastError(void);
 
 /**
+ * Prints the current Python error to stderr and clears the Python error indicator.
+ * Finds an AWS error code corresponding to the current Python error (fallback is AWS_ERROR_UNKNOWN).
+ * Returns aws_last_error().
+ *
+ * The Python error indicator MUST be set and the GIL MUST be held when calling this function. */
+int aws_py_translate_py_error(void);
+
+/**
  * Raise an AWS error corresponding to the current Python error.
  *
  * Prints the current Python error to stderr and clears the Python error indicator.

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1050,7 +1050,7 @@ static void s_suback_multi_callback(
     /* Create list of (topic,qos) tuples */
     topic_qos_list = PyList_New(num_topics);
     if (!topic_qos_list) {
-        error_code = aws_py_raise_error();
+        error_code = aws_py_translate_py_error();
         goto done_prepping_args;
     }
 
@@ -1060,7 +1060,7 @@ static void s_suback_multi_callback(
 
         PyObject *tuple = Py_BuildValue("(s#i)", sub_i.topic.ptr, sub_i.topic.len, sub_i.qos);
         if (!tuple) {
-            error_code = aws_py_raise_error();
+            error_code = aws_py_translate_py_error();
             goto done_prepping_args;
         }
 


### PR DESCRIPTION
added aws_py_translate_py_error() and use it in mqtt_client_connection.c


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
