### PR TITLE
366: fix fatal_warnings linker arg typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -320,7 +320,7 @@ def awscrt_ext():
 
     if distutils.ccompiler.get_default_compiler() != 'msvc':
         extra_compile_args += ['-Wextra', '-Werror', '-Wno-strict-aliasing', '-std=gnu99']
-        extra_link_args += ['-Wl,-fatal_warnings']
+        extra_link_args += ['-Wl,-fatal-warnings']
 
     return setuptools.Extension(
         '_awscrt',


### PR DESCRIPTION
*Issue #, if available:*
#366 

*Description of changes:*
Fixed typo, see issue.

I've confirmed that i can successfully `pip install git+https://github.com/timblaktu/aws-crt-python.git@bugfix366-fatal_warnings-linker-typo`.

Also I was able to get the latest awscli tag `2.7.29` working by modifying awscli's `setup.py` to use a test branch on my fork (identical to PR src branch except changed version in __init__.py):

```
sed -i 's/awscrt.*$/''awscrt @ git+ssh:\/\/git@github.com\/timblaktu\/aws-crt-python@366-localtest''/g' setup.cfg 
```

Once this PR is merged, we can remove this hack..

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
