### PR TITLE
Fix out of memory issue when resubscribing

### DIFF
--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1055,7 +1055,7 @@ static void s_suback_multi_callback(
     }
 
     for (size_t i = 0; i < num_topics; ++i) {
-        struct aws_mqtt_topic_subscription *sub_i;
+        struct aws_mqtt_topic_subscription *sub_i = NULL;
         aws_array_list_get_at(topic_subacks, &sub_i, i);
         PyObject *tuple = Py_BuildValue("(s#i)", sub_i->topic.ptr, sub_i->topic.len, sub_i->qos);
         if (!tuple) {

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1055,10 +1055,9 @@ static void s_suback_multi_callback(
     }
 
     for (size_t i = 0; i < num_topics; ++i) {
-        struct aws_mqtt_topic_subscription sub_i;
+        struct aws_mqtt_topic_subscription *sub_i;
         aws_array_list_get_at(topic_subacks, &sub_i, i);
-
-        PyObject *tuple = Py_BuildValue("(s#i)", sub_i.topic.ptr, sub_i.topic.len, sub_i.qos);
+        PyObject *tuple = Py_BuildValue("(s#i)", sub_i->topic.ptr, sub_i->topic.len, sub_i->qos);
         if (!tuple) {
             error_code = aws_py_translate_py_error();
             goto done_prepping_args;


### PR DESCRIPTION
*Description of changes:*

Fixes an error where Python will report it has ran out of memory (`AWS_ERROR_OOM`) when using `resubscribe_existing_topic` when a client gets disconnected and then reconnects.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
