### PR TITLE
Drop support for Python 3.6, add wheels for Python 3.11

### DIFF
--- a/.builder/actions/aws_crt_python.py
+++ b/.builder/actions/aws_crt_python.py
@@ -13,6 +13,7 @@ import tempfile
 # (I.e. run builder with --python=/opt/python/cp310-cp310/bin/python)
 PYTHON_EXECUTABLE = '{python}'
 
+
 class InstallPythonReqs(Builder.Action):
     def __init__(self, trust_hosts=False, deps=[]):
         self.trust_hosts = trust_hosts

--- a/.builder/actions/aws_crt_python.py
+++ b/.builder/actions/aws_crt_python.py
@@ -233,7 +233,7 @@ class AWSCrtPython(Builder.Action):
         parser = argparse.ArgumentParser()
         parser.add_argument('--python')
         args = parser.parse_known_args(env.args.args)[0]
-        python = args.python if args.python else sys.executable
+        python = args.python if args.python else "{python}"
 
         actions = [
             InstallPythonReqs(deps=[], python=python),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: python36-eol
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.22
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-python
   LINUX_BASE_IMAGE: ubuntu-18-x64
@@ -60,7 +60,7 @@ jobs:
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
- 
+
   linux-compat:
     runs-on: ubuntu-20.04 # latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.10
+  BUILDER_VERSION: v0.9.21
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-python
@@ -29,11 +29,11 @@ jobs:
           - x86
           - aarch64
         python:
-          - cp36-cp36m
           - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
           - cp310-cp310
+          - cp311-cp311
     steps:
     # Only aarch64 needs this, but it doesn't hurt anything
     - name: Install qemu/docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.21
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: python36-eol
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-python
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python 3 bindings for the AWS Common Runtime.
 This library is licensed under the Apache 2.0 License.
 
 ## Minimum Requirements:
-*   Python 3.6+
+*   Python 3.7+
 
 ## Installation
 

--- a/codebuild/cd/manylinux-x64-build.yml
+++ b/codebuild/cd/manylinux-x64-build.yml
@@ -12,8 +12,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - /opt/python/cp36-cp36m/bin/python setup.py sdist bdist_wheel
-      - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp36-cp36m-linux_x86_64.whl
       - /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp37-cp37m-linux_x86_64.whl
       - /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel

--- a/codebuild/cd/manylinux-x86-build.yml
+++ b/codebuild/cd/manylinux-x86-build.yml
@@ -12,8 +12,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - /opt/python/cp36-cp36m/bin/python setup.py sdist bdist_wheel
-      - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp36-cp36m-linux_i686.whl
       - /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp37-cp37m-linux_i686.whl
       - /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
@@ -2,7 +2,7 @@
 #run build-wheels script in manylinux2014 docker image
 set -ex
 
-DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt/manylinux2014-aarch64:latest
+DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt-manylinux2014-aarch64:latest
 
 $(aws --region us-east-1 ecr get-login --no-include-email)
 

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp36-cp36m/bin/python setup.py sdist bdist_wheel
-auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp36*.whl
-
 /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp37*.whl
 
@@ -18,6 +15,9 @@ auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp39*.whl
 
 /opt/python/cp310-cp310/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp310*.whl
+
+/opt/python/cp311-cp311/bin/python setup.py sdist bdist_wheel
+auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp311*.whl
 
 rm dist/*.whl
 cp -rv wheelhouse/* dist/

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
@@ -2,7 +2,7 @@
 #run build-wheels script in manylinux2014 docker image
 set -ex
 
-DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt/manylinux2014-x64:latest
+DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt-manylinux2014-x64:latest
 
 $(aws --region us-east-1 ecr get-login --no-include-email)
 

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp36-cp36m/bin/python setup.py sdist bdist_wheel
-auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp36*.whl
-
 /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp37*.whl
 
@@ -18,6 +15,9 @@ auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp39*.whl
 
 /opt/python/cp310-cp310/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp310*.whl
+
+/opt/python/cp311-cp311/bin/python setup.py sdist bdist_wheel
+auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp311*.whl
 
 rm dist/*.whl
 cp -rv wheelhouse/* dist/

--- a/continuous-delivery/build-wheels-osx.sh
+++ b/continuous-delivery/build-wheels-osx.sh
@@ -5,10 +5,10 @@ set -e
 
 /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 ./continuous-delivery/update-version.py
 
-/Library/Frameworks/Python.framework/Versions/3.6/bin/python3 setup.py bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 setup.py sdist bdist_wheel
+/Library/Frameworks/Python.framework/Versions/3.11/bin/python3 setup.py sdist bdist_wheel
 
 #now you just need to run twine (that's in a different script)

--- a/continuous-delivery/build-wheels-win32.bat
+++ b/continuous-delivery/build-wheels-win32.bat
@@ -1,11 +1,11 @@
 
 "C:\Program Files (x86)\Python39-32\python.exe" .\continuous-delivery\update-version.py || goto error
 
-"C:\Program Files (x86)\Python36-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python37-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python38-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python39-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python310-32\python.exe" setup.py sdist bdist_wheel || goto error
+"C:\Program Files (x86)\Python311-32\python.exe" setup.py sdist bdist_wheel || goto error
 
 goto :EOF
 

--- a/continuous-delivery/build-wheels-win64.bat
+++ b/continuous-delivery/build-wheels-win64.bat
@@ -1,10 +1,10 @@
 "C:\Program Files\Python39\python.exe" continuous-delivery\update-version.py || goto error
 
-"C:\Program Files\Python36\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python37\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python38\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python39\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python310\python.exe" setup.py sdist bdist_wheel || goto error
+"C:\Program Files\Python311\python.exe" setup.py sdist bdist_wheel || goto error
 
 goto :EOF
 

--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,7 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     ext_modules=[awscrt_ext()],
     cmdclass={'build_ext': awscrt_build_ext},
     test_suite='test',


### PR DESCRIPTION
Python 3.6 went End of Life 10 months ago (end of 2021). Drop support so we can start using sweet 3.7+ features like [dataclasses](https://docs.python.org/3/library/dataclasses.html).

Also, start building wheels for Python 3.11. I installed `3.11.0` on the Mac and Windows machines we use to build wheels, and ensured the manylinux docker images we use for Linux wheels are up to date.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
