### PR TITLE
Fix release pipeline

### DIFF
--- a/awscrt/__init__.py
+++ b/awscrt/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     's3'
 ]
 
-__version__ = '1.0.0-dev'
+__version__ = '1.0.0.dev0'
 
 
 class NativeResource:

--- a/codebuild/cd/publish_to_prod_pypi.yml
+++ b/codebuild/cd/publish_to_prod_pypi.yml
@@ -19,7 +19,6 @@ phases:
       - cp -rv $CODEBUILD_SRC_DIR_aws_crt_python_osx/* dist/
       - ls -la dist/
       - cd aws-crt-python
-      - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
       - python3 continuous-delivery/pull-pypirc.py prod
       - python3 -m twine upload -r pypi ../dist/*
   post_build:

--- a/codebuild/cd/publish_to_test_pypi.yml
+++ b/codebuild/cd/publish_to_test_pypi.yml
@@ -19,7 +19,6 @@ phases:
       - cp -rv $CODEBUILD_SRC_DIR_aws_crt_python_osx/* dist/
       - ls -la dist/
       - cd aws-crt-python
-      - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
       - python3 continuous-delivery/pull-pypirc.py alpha
       - python3 -m twine upload -r testpypi ../dist/*
   post_build:

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64-jenkins.sh
@@ -8,8 +8,11 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
+# NOTE: run as current user to avoid git "dubious ownership" error,
+# and so that output artifacts don't belong to "root"
 docker run --rm \
     --mount type=bind,source=`pwd`,target=/aws-crt-python \
+    --user "$(id -u):$(id -g)" \
     --workdir /aws-crt-python \
     --entrypoint /bin/bash \
     $DOCKER_IMAGE \

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64-jenkins.sh
@@ -8,8 +8,11 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
+# NOTE: run as current user to avoid git "dubious ownership" error,
+# and so that output artifacts don't belong to "root"
 docker run --rm \
     --mount type=bind,source=`pwd`,target=/aws-crt-python \
+    --user "$(id -u):$(id -g)" \
     --workdir /aws-crt-python \
     --entrypoint /bin/bash \
     $DOCKER_IMAGE \

--- a/continuous-delivery/build-wheels-osx.sh
+++ b/continuous-delivery/build-wheels-osx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #before running this, you'll need cmake3 and a compiler. These python versions are just
 #using the default python installers from python.org. Each version needs updated pip, wheel, and setuptools
-set -e
+set -ex
 
 /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 ./continuous-delivery/update-version.py
 

--- a/continuous-delivery/update-version.py
+++ b/continuous-delivery/update-version.py
@@ -13,10 +13,7 @@ contents = None
 with open(init_path, 'r+') as init_py:
     contents = init_py.read()
 
-contents = re.sub(r"__version__ = '1\.0\.0-dev'", r"__version__ = '{}'".format(version), contents)
+contents = re.sub(r"__version__ = '[^']+'", f"__version__ = '{version}'", contents)
 
 with open(init_path, 'w') as init_py:
     init_py.write(contents)
-
-# setup = contents[contents.rfind('setuptools.setup'):]
-# print(setup)

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -17,7 +17,7 @@ NONRECURSIVE_PATTERNS = [
 # recurse through subfolders and apply these patterns
 RECURSIVE_PATTERNS = [
     '*.pyc',
-    '__pycache__/'
+    '__pycache__'
 ]
 
 # approved list of folders


### PR DESCRIPTION
**Issue:**
A docker image used in the release process started having git errors:
> fatal: detected dubious ownership in repository at '/aws-crt-python'

**Investigation:**
Git 2.35.2+ introduced additional [safety checks](https://github.blog/2022-04-12-git-security-vulnerability-announced/), that raise errors if the `.git/` folder isn't owned by the user running git. The release process runs this docker container while mounting the `aws-crt-python/` directory along with its `.git` folder. Within docker, the user is `root` by default, and when it saw the `.git/` folder owned by someone else, it freaked out.

We haven't seen this error in previous releases because we were accidentally using a very old build of that docker container. When we got a newer build, it had a newer version of git, which raised this error.

**Description of changes:**
- Fix error by running as current user within docker, instead of running as root.
- Unrelated: change "dev" version from `1.0.0-dev` -> `1.0.0.dev0`.  Python didn't like the old version string and normalized it to `1.0.0.dev0` anyway. This gets rid of some warnings at build time.
- Unrelated: remove some lines where we uselessly query version

**Other fixes considered:**
- Considered removing all git calls from the release pipeline, but this would have been a big change.
- Considered modifying all our docker images so they disabled these new safety checks via `git config --global --add safe.directory '*'`, but I wasn't comfortable lowering security like that given my shallow understanding of these issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
