### PR TITLE
Speed up Mac developer builds by only building 1 arch

### DIFF
--- a/codebuild/cd/test_test_pypi.yml
+++ b/codebuild/cd/test_test_pypi.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# this image assumes Ubuntu 14.04 base image
+# this image assumes Ubuntu base image
 phases:
   install:
     commands:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 autopep8 # for code formatting
+setuptools # for installing from source
 sphinx # for building docs
+wheel # for building wheels


### PR DESCRIPTION
**Issue:**
Mac builds take twice as long as other platforms because we compile native code for two architectures (x86_64, arm64) then merge it all into a Universal2 binary that works on both Intel and Apple Silicon.

Most of our developers use Macs, and this really kills iteration time.

**Description of changes:**
When doing a "develop" build (this is only done on local machines, our CI does a normal "install" build), only build for the host architecture. This cuts build time in half.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
