### PR TITLE
Speed up builds by using a root CMakeLists.txt

### DIFF
--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+cmake_minimum_required(VERSION 3.1)
+project(aws-crt-dependencies)
+
+# This magic lets us build everything all at once
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/aws-c-common/cmake)
+include(AwsFindPackage)
+set(IN_SOURCE_BUILD ON)
+
+# Always build static libs
+set(BUILD_SHARED_LIBS=OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE=ON)
+
+# Don't build the dependencies' tests
+include(CTest)
+set(BUILD_TESTING OFF)
+
+if(UNIX AND NOT APPLE)
+    set(DISABLE_GO ON) # Build without using go, we don't want the extra dependency
+    set(DISABLE_PERL ON) # Build without using perl, we don't want the extra dependency
+    set(BUILD_LIBSSL OFF) # Don't need libssl, only need libcrypto
+    add_subdirectory(aws-lc)
+
+    set(UNSAFE_TREAT_WARNINGS_AS_ERRORS OFF)
+    add_subdirectory(s2n)
+endif()
+
+add_subdirectory(aws-c-common)
+add_subdirectory(aws-c-sdkutils)
+add_subdirectory(aws-c-cal)
+add_subdirectory(aws-c-io)
+add_subdirectory(aws-checksums)
+add_subdirectory(aws-c-compression)
+add_subdirectory(aws-c-event-stream)
+add_subdirectory(aws-c-http)
+add_subdirectory(aws-c-auth)
+add_subdirectory(aws-c-mqtt)
+add_subdirectory(aws-c-s3)

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 # This CMakeLists.txt exists so we can build all the C libraries we depend on
-# simultanously. This is much faster than building dependencies one at a time.
+# simultaneously. This is much faster than building dependencies one at a time.
 #
 # This CMakeLists.txt does NOT build the Python extension itself.
 # We let setuptools handle that.

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 cmake_minimum_required(VERSION 3.1)
+
+# This CMakeLists.txt exists so we can build all the C libraries we depend on
+# simultanously. This is much faster than building dependencies one at a time.
+#
+# This CMakeLists.txt does NOT build the Python extension itself.
+# We let setuptools handle that.
 project(aws-crt-dependencies)
 
 # This magic lets us build everything all at once
@@ -8,7 +14,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/aws-c-common/cmake)
 include(AwsFindPackage)
 set(IN_SOURCE_BUILD ON)
 
-# Always build static libs
+# Build dependencies as static libs
 set(BUILD_SHARED_LIBS=OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE=ON)
 
@@ -16,9 +22,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE=ON)
 include(CTest)
 set(BUILD_TESTING OFF)
 
+# On Unix we use S2N for TLS and AWS-LC crypto.
+# (On Windows and Apple we use the default OS libraries)
 if(UNIX AND NOT APPLE)
-    set(DISABLE_GO ON) # Build without using go, we don't want the extra dependency
-    set(DISABLE_PERL ON) # Build without using perl, we don't want the extra dependency
+    set(DISABLE_GO ON) # Build without using Go, we don't want the extra dependency
+    set(DISABLE_PERL ON) # Build without using Perl, we don't want the extra dependency
     set(BUILD_LIBSSL OFF) # Don't need libssl, only need libcrypto
     add_subdirectory(aws-lc)
 

--- a/setup.py
+++ b/setup.py
@@ -316,8 +316,8 @@ def awscrt_ext():
         if is_development_mode():
             extra_compile_args += ['-Wextra', '-Werror']
 
-            # ...except when we shortcuts in development mode and don't make a
-            # proper MacOS Universal2 binary. The linker warns us about this,
+            # ...except when we take shortcuts in development mode and don't make
+            # a proper MacOS Universal2 binary. The linker warns us about this,
             # but WHATEVER. Building everything twice (x86_64 and arm64) takes too long.
             if not is_macos_universal2():
                 extra_link_args += ['-Wl,-fatal_warnings']


### PR DESCRIPTION
**Issue:**
Developer iteration on aws-crt-python is slow.

We've noticed that other CRT language bindings ([Java](https://github.com/awslabs/aws-crt-java/blob/cb306b46e3738298f669086895622c3d42cb76f0/CMakeLists.txt), [NodeJS](https://github.com/awslabs/aws-crt-nodejs/blob/380028fbf21e27fa735f02b460b882a41a52a424/CMakeLists.txt), etc) build much faster.

**Description of changes:**
Do like the other aws-crt-Use a root CMakeLists.txt that includes all the other dependencies. This lets us build all dependencies in parallel.

**Results:**
Approximately 2X speedup (builds in half the time)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
