### PR TITLE
Raise AwsCrtError from C, instead of basic RuntimeError.

### DIFF
--- a/awscrt/_c_lib_importer.py
+++ b/awscrt/_c_lib_importer.py
@@ -1,0 +1,29 @@
+"""
+Our python files MUST import _awscrt like this:
+```
+from awscrt._c_lib_importer import _awscrt
+```
+
+to ensure that _awscrt.init_c_library_with_python_stuff(...)
+is called before any other C function.
+
+Unfortunately, we can get circular dependencies when the "python stuff" is defined
+in another file that also needs to import _c_lib_importer.
+If this happens to you, hack around it like this:
+```
+# putting this import at end of file to work around circular dependency
+from awscrt._c_lib_importer import _awscrt  # noqa
+```
+
+But this should be rare, importing at the start of the
+file should work in most cases.
+"""
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+import _awscrt
+from awscrt.exceptions import AwsCrtError
+
+
+_awscrt.init_c_library_with_python_stuff(AwsCrtError)

--- a/awscrt/_test.py
+++ b/awscrt/_test.py
@@ -1,7 +1,11 @@
 """
 Private utilities for testing
 """
-import _awscrt
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+from awscrt._c_lib_importer import _awscrt
 from awscrt import NativeResource
 import gc
 import inspect

--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -5,7 +5,7 @@ AWS client-side authentication: standard credentials providers and signing.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 from awscrt import NativeResource
 import awscrt.exceptions
 from awscrt.http import HttpRequest, HttpProxyOptions

--- a/awscrt/checksums.py
+++ b/awscrt/checksums.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 
 
 def crc32(input: bytes, previous_crc32: int = 0) -> int:

--- a/awscrt/common.py
+++ b/awscrt/common.py
@@ -1,7 +1,11 @@
 """
 Cross-platform library for `awscrt`.
 """
-import _awscrt
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+from awscrt._c_lib_importer import _awscrt
 
 
 def get_cpu_group_count() -> int:

--- a/awscrt/crypto.py
+++ b/awscrt/crypto.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 
 
 class Hash:

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -5,7 +5,7 @@ event-stream RPC (remote procedure call) protocol library for `awscrt`.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 from abc import ABC, abstractmethod
 from awscrt import NativeResource
 import awscrt.exceptions

--- a/awscrt/exceptions.py
+++ b/awscrt/exceptions.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
-
 
 def from_code(code):
     """Given an AWS Common Runtime error code, return an exception.
@@ -21,19 +19,17 @@ def from_code(code):
     if builtin:
         return builtin()
 
-    name = _awscrt.get_error_name(code)
-    msg = _awscrt.get_error_message(code)
-    return AwsCrtError(code=code, name=name, message=msg)
+    return AwsCrtError(code=code)
 
 
-class AwsCrtError(Exception):
+class AwsCrtError(RuntimeError):
     """
     Base exception class for AWS Common Runtime exceptions.
 
     Args:
         code (int): Int value of error.
-        name (str): Name of error.
-        message (str): Message about error.
+        name (str): Name of error (optional).
+        message (str): Message about error (optional).
 
     Attributes:
         code (int): Int value of error.
@@ -41,10 +37,10 @@ class AwsCrtError(Exception):
         message (str): Message about error.
     """
 
-    def __init__(self, code, name, message):
+    def __init__(self, code, name=None, message=None):
         self.code = code
-        self.name = name
-        self.message = message
+        self.name = _awscrt.get_error_name(code) if name is None else name
+        self.message = _awscrt.get_error_message(code) if message is None else message
 
     def __repr__(self):
         return "{0}(name={1}, message={2}, code={3})".format(
@@ -52,3 +48,7 @@ class AwsCrtError(Exception):
 
     def __str__(self):
         return "{}: {}".format(self.name, self.message)
+
+
+# putting this import at end of file to work around circular dependency
+from awscrt._c_lib_importer import _awscrt  # noqa

--- a/awscrt/http.py
+++ b/awscrt/http.py
@@ -7,7 +7,7 @@ All network operations in `awscrt.http` are asynchronous.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 from concurrent.futures import Future
 from awscrt import NativeResource
 import awscrt.exceptions

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -8,7 +8,7 @@ Long-running event-loop threads are used for concurrency.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 from awscrt import NativeResource
 from enum import IntEnum
 import threading

--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -6,7 +6,7 @@ All network operations in `awscrt.mqtt` are asynchronous.
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 from concurrent.futures import Future
 from enum import IntEnum
 from inspect import signature

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -5,7 +5,7 @@ S3 client
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-import _awscrt
+from awscrt._c_lib_importer import _awscrt
 from concurrent.futures import Future
 from awscrt import NativeResource
 from awscrt.http import HttpRequest

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from awscrt.io import *
+from awscrt.exceptions import AwsCrtError
 from test import NativeResourceTest, TIMEOUT
 import io
 import os
@@ -216,14 +217,16 @@ class Pkcs11LibTest(NativeResourceTest):
         lib_path = self._lib_path()
         lib1 = Pkcs11Lib(file=lib_path, behavior=Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
         # InitializeFinalizeBehavior.STRICT behavior should fail if the PKCS#11 lib is already loaded
-        with self.assertRaises(Exception):
+        with self.assertRaises(AwsCrtError) as raises:
             lib2 = Pkcs11Lib(file=lib_path, behavior=Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
+        self.assertEqual(raises.exception.name, "AWS_ERROR_PKCS11_CKR_CRYPTOKI_ALREADY_INITIALIZED")
 
     def test_omit_behavior(self):
         lib_path = self._lib_path()
         # InitializeFinalizeBehavior.OMIT should fail unless another instance of the PKCS#11 lib is already loaded
-        with self.assertRaises(Exception):
+        with self.assertRaises(AwsCrtError) as raises:
             lib = Pkcs11Lib(file=lib_path, behavior=Pkcs11Lib.InitializeFinalizeBehavior.OMIT)
+        self.assertEqual(raises.exception.name, "AWS_ERROR_PKCS11_CKR_CRYPTOKI_NOT_INITIALIZED")
 
         # InitializeFinalizeBehavior.OMIT behavior should be fine when another
         # instance of the PKCS#11 lib is already loaded


### PR DESCRIPTION
**Issue:**
The exceptions raised by sync vs async C code are different.

Sync C code always raises a  generic `RuntimeError` with everything in a long text description, like:
`RuntimeError("2066 (AWS_ERROR_HTTP_WEBSOCKET_CLOSE_FRAME_SENT): Websocket has sent CLOSE frame, no more data will be sent.")`

Async code will raise a nicer `AwsCrtError`, with separate `name`, `code`, and `message` properties, like:
`AwsCrtError(name="AWS_ERROR_HTTP_WEBSOCKET_CLOSE_FRAME_SENT", message="Websocket has sent CLOSE frame, no more data will be sent.", code=2066)`

**Background:**
It's not easy for our C code to use a class like `AwsCrtError` that is defined in our Python code.

**Description of changes:**
- Sync C code raises `AwsCrtError` instead of `RuntimeError`
- Change `AwsCrtError`'s to inherit from `RuntimeError` instead of `Exception`
  - This if for backwards compatibility, if anyone wrote code to catch a `RuntimeException` they'll still catch the `AwsCrtError`
- Do some trickery to initialize the C library with stuff from our Python code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
