### PR TITLE
Convert from strlen to strnlen where it's safe and reasonable to do so

### DIFF
--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -102,12 +102,12 @@ static int s_on_incoming_header_block_done(
 
     for (Py_ssize_t i = 0; i < num_headers; ++i) {
         const char *name_str = (const char *)string_cursor.ptr;
-        size_t name_len = strlen((const char *)string_cursor.ptr);
+        size_t name_len = strnlen((const char *)string_cursor.ptr, string_cursor.len);
 
         aws_byte_cursor_advance(&string_cursor, name_len + 1);
 
         const char *value_str = (const char *)string_cursor.ptr;
-        size_t value_len = strlen((const char *)string_cursor.ptr);
+        size_t value_len = strnlen((const char *)string_cursor.ptr, string_cursor.len);
 
         aws_byte_cursor_advance(&string_cursor, value_len + 1);
 

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -102,11 +102,15 @@ static int s_on_incoming_header_block_done(
 
     for (Py_ssize_t i = 0; i < num_headers; ++i) {
         const char *name_str = (const char *)string_cursor.ptr;
+
+        /* the entire header block remaining length is a safe bound for the next header name length */
         size_t name_len = strnlen((const char *)string_cursor.ptr, string_cursor.len);
 
         aws_byte_cursor_advance(&string_cursor, name_len + 1);
 
         const char *value_str = (const char *)string_cursor.ptr;
+
+        /* the entire header block remaining length is a safe bound for the next header value length */
         size_t value_len = strnlen((const char *)string_cursor.ptr, string_cursor.len);
 
         aws_byte_cursor_advance(&string_cursor, value_len + 1);


### PR DESCRIPTION
In the http stream bindings, the overall cursor is always a safe bound for the individual name value pair pieces.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
