### PR TITLE
Add Option to configure Hybrid PQ TLS Cipher Preferences

### DIFF
--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -10,7 +10,7 @@ Long-running event-loop threads are used for concurrency.
 
 import _awscrt
 from awscrt import NativeResource
-from enum import IntEnum
+from enum import Enum, IntEnum
 import threading
 
 
@@ -250,6 +250,14 @@ class TlsVersion(IntEnum):
     DEFAULT = 128  #:
 
 
+class TlsCipherPref(Enum):
+    DEFAULT = (0)
+    PQ_TLSv1_0_2021_05 = (6)
+
+    def __init__(self, tlsCipherEnumVal):
+        self.isSupported = _awscrt.is_tls_cipher_supported(tlsCipherEnumVal)
+
+
 class TlsContextOptions:
     """Options to create a TLS context.
 
@@ -269,6 +277,7 @@ class TlsContextOptions:
         'min_tls_ver',
         'ca_dirpath',
         'ca_buffer',
+        'cipher_pref',
         'alpn_list',
         'certificate_buffer',
         'private_key_buffer',
@@ -291,6 +300,7 @@ class TlsContextOptions:
             setattr(self, slot, None)
 
         self.min_tls_ver = TlsVersion.DEFAULT
+        self.cipher_pref = TlsCipherPref.DEFAULT
         self.verify_peer = True
 
     @staticmethod
@@ -563,6 +573,7 @@ class ClientTlsContext(NativeResource):
         super().__init__()
         self._binding = _awscrt.client_tls_ctx_new(
             options.min_tls_ver.value,
+            options.cipher_pref.value,
             options.ca_dirpath,
             options.ca_buffer,
             _alpn_list_to_str(options.alpn_list),

--- a/source/io.c
+++ b/source/io.c
@@ -90,7 +90,7 @@ PyObject *aws_py_is_tls_cipher_supported(PyObject *self, PyObject *args) {
     int cipher_pref = 0;
 
     if (!PyArg_ParseTuple(args, "i", &cipher_pref)) {
-        return PyErr_AwsLastError();
+        return NULL;
     }
 
     return PyBool_FromLong(aws_tls_is_cipher_pref_supported(cipher_pref));

--- a/source/io.c
+++ b/source/io.c
@@ -83,6 +83,18 @@ PyObject *aws_py_is_alpn_available(PyObject *self, PyObject *args) {
     return PyBool_FromLong(aws_tls_is_alpn_available());
 }
 
+PyObject *aws_py_is_tls_cipher_supported(PyObject *self, PyObject *args) {
+    (void)self;
+    (void)args;
+
+    int cipher_pref = 0;
+
+    if (!PyArg_ParseTuple(args, "i", &cipher_pref)) {
+        return PyErr_AwsLastError();
+    }
+
+    return PyBool_FromLong(aws_tls_is_cipher_pref_supported(cipher_pref));
+}
 /*******************************************************************************
  * AWS_EVENT_LOOP_GROUP
  ******************************************************************************/
@@ -402,7 +414,8 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_py_get_allocator();
 
-    int min_tls_version;
+    int min_tls_version = 0;
+    int cipher_pref = 0;
     const char *ca_dirpath;
     const char *ca_buffer;
     Py_ssize_t ca_buffer_len;
@@ -430,8 +443,9 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "izz#zz#z#zzpOz#Oz#z#z#z#z",
+            "iizz#zz#z#zzpOz#Oz#z#z#z#z",
             /* i */ &min_tls_version,
+            /* i */ &cipher_pref,
             /* z */ &ca_dirpath,
             /* z */ &ca_buffer,
             /* # */ &ca_buffer_len,
@@ -520,6 +534,7 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
     /* From hereon, we need to clean up if errors occur */
 
     ctx_options.minimum_tls_version = min_tls_version;
+    ctx_options.cipher_pref = cipher_pref;
 
     if (ca_dirpath != NULL) {
         if (aws_tls_ctx_options_override_default_trust_store_from_path(&ctx_options, ca_dirpath, NULL)) {

--- a/source/io.h
+++ b/source/io.h
@@ -29,6 +29,11 @@ PyObject *aws_py_init_logging(PyObject *self, PyObject *args);
 PyObject *aws_py_is_alpn_available(PyObject *self, PyObject *args);
 
 /**
+ * Returns True if the input TLS Cipher Preference Enum is suupported on the current platform. False otherwise.
+ */
+PyObject *aws_py_is_tls_cipher_supported(PyObject *self, PyObject *args);
+
+/**
  * Create a new event_loop_group to be managed by a Python Capsule.
  */
 PyObject *aws_py_event_loop_group_new(PyObject *self, PyObject *args);

--- a/source/module.c
+++ b/source/module.c
@@ -680,6 +680,7 @@ static PyMethodDef s_module_methods[] = {
 
     /* IO */
     AWS_PY_METHOD_DEF(is_alpn_available, METH_NOARGS),
+    AWS_PY_METHOD_DEF(is_tls_cipher_supported, METH_VARARGS),
     AWS_PY_METHOD_DEF(event_loop_group_new, METH_VARARGS),
     AWS_PY_METHOD_DEF(host_resolver_new_default, METH_VARARGS),
     AWS_PY_METHOD_DEF(client_bootstrap_new, METH_VARARGS),

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -76,9 +76,6 @@ class TestCredentials(NativeResourceTest):
         expected = b'\x90\x01\x50\x98\x3c\xd2\x4f\xb0\xd6\x96\x3f\x7d\x28\xe1\x7f\x72'
         self.assertEqual(expected, digest)
 
-    def test_is_tls_cipher_supported(self):
-        self.assertEqual(True, TlsCipherPref.DEFAULT.isSupported)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -4,6 +4,7 @@
 
 from test import NativeResourceTest
 from awscrt.crypto import Hash
+from awscrt.io import TlsCipherPref
 import unittest
 
 
@@ -74,6 +75,9 @@ class TestCredentials(NativeResourceTest):
         digest = h.digest()
         expected = b'\x90\x01\x50\x98\x3c\xd2\x4f\xb0\xd6\x96\x3f\x7d\x28\xe1\x7f\x72'
         self.assertEqual(expected, digest)
+
+    def test_is_tls_cipher_supported(self):
+        self.assertEqual(True, TlsCipherPref.DEFAULT.isSupported)
 
 
 if __name__ == '__main__':

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -3,7 +3,7 @@
 
 import awscrt.exceptions
 from awscrt.http import HttpClientConnection, HttpClientStream, HttpHeaders, HttpProxyOptions, HttpRequest, HttpVersion
-from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
+from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions, TlsCipherPref
 from concurrent.futures import Future
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from io import BytesIO
@@ -77,6 +77,8 @@ class TestClient(NativeResourceTest):
     def _new_client_connection(self, secure, proxy_options=None):
         if secure:
             tls_ctx_opt = TlsContextOptions()
+            if (TlsCipherPref.PQ_TLSv1_0_2021_05.isSupported):
+                tls_ctx_opt.cipher_pref = TlsCipherPref.PQ_TLSv1_0_2021_05
             tls_ctx_opt.verify_peer = False
             tls_ctx = ClientTlsContext(tls_ctx_opt)
             tls_conn_opt = tls_ctx.new_connection_options()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -230,6 +230,9 @@ class Pkcs11LibTest(NativeResourceTest):
         strict_lib = Pkcs11Lib(file=lib_path, behavior=Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
         omit_lib = Pkcs11Lib(file=lib_path, behavior=Pkcs11Lib.InitializeFinalizeBehavior.OMIT)
 
+    def test_is_tls_cipher_supported(self):
+        self.assertEqual(True, TlsCipherPref.DEFAULT.is_supported())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add Option to configure Hybrid PQ TLS Cipher Preferences. 

Note: I don't write a lot of Python, and this is the first time I'm writing Python-to-C translation code, so please take an extra close look when reviewing to make sure I didn't make any simple mistakes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
