### PR TITLE
Handle user calling sys.exit() from WebSocket callback

### DIFF
--- a/awscrt/websocket.py
+++ b/awscrt/websocket.py
@@ -388,7 +388,7 @@ class WebSocket(NativeResource):
             try:
                 if on_complete is not None:
                     on_complete(cbdata)
-            except Exception:
+            except BaseException:
                 print("Exception in WebSocket.send_frame on_complete callback", file=sys.stderr)
                 sys.excepthook(*sys.exc_info())
                 self.close()
@@ -457,7 +457,7 @@ class _WebSocketCore(NativeResource):
         # Do not let exceptions from the user's callback bubble up any further.
         try:
             self._on_connection_setup_cb(cbdata)
-        except Exception:
+        except BaseException:
             print("Exception in WebSocket on_connection_setup callback", file=sys.stderr)
             sys.excepthook(*sys.exc_info())
             if cbdata.websocket is not None:
@@ -472,7 +472,7 @@ class _WebSocketCore(NativeResource):
         try:
             if self._on_connection_shutdown_cb is not None:
                 self._on_connection_shutdown_cb(cbdata)
-        except Exception:
+        except BaseException:
             print("Exception in WebSocket on_connection_shutdown callback", file=sys.stderr)
             sys.excepthook(*sys.exc_info())
 
@@ -485,7 +485,7 @@ class _WebSocketCore(NativeResource):
         try:
             if self._on_incoming_frame_begin_cb is not None:
                 self._on_incoming_frame_begin_cb(cbdata)
-        except Exception:
+        except BaseException:
             print("Exception in WebSocket on_incoming_frame_begin callback", file=sys.stderr)
             sys.excepthook(*sys.exc_info())
             return False  # close websocket
@@ -499,7 +499,7 @@ class _WebSocketCore(NativeResource):
         try:
             if self._on_incoming_frame_payload_cb is not None:
                 self._on_incoming_frame_payload_cb(cbdata)
-        except Exception:
+        except BaseException:
             print("Exception in WebSocket on_incoming_frame_payload callback", file=sys.stderr)
             sys.excepthook(*sys.exc_info())
             return False  # close websocket
@@ -517,7 +517,7 @@ class _WebSocketCore(NativeResource):
         try:
             if self._on_incoming_frame_complete_cb is not None:
                 self._on_incoming_frame_complete_cb(cbdata)
-        except Exception:
+        except BaseException:
             print("Exception in WebSocket on_incoming_frame_complete callback", file=sys.stderr)
             sys.excepthook(*sys.exc_info())
             return False  # close websocket


### PR DESCRIPTION
**Issue:**
If user called `sys.exit()` from a WebSocket callback, the program would exit non-gracefully, printing out a big old C stack trace.

**Diagnosis:**
The websocket callbacks are doing some [extra zealous error checking](https://github.com/awslabs/aws-crt-python/blob/edf0ef624bd84ab6d669b9b8639e2d9a43140c95/source/websocket.c#L246-L250) when calling from C->Python. The Python code is supposed to catch and handle any exceptions resulting from the user's code. C will murder the applications if any other exceptions leak back to C, with the thinking that these must result from bugs in OUR code, so best to just die.

Anyway, `sys.exit()` results in a `SystemExit` exception, which inherits from`BaseException` instead of `Exception`, so it was slipping through the Python code's `except Exception:` filter.

**Description of changes:**
Handle `BaseException` (not just ~Exception~) in the Python section of the callback, so that `SystemExit` doesn't leak back into C and trigger the extra zealous error checker.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
