### PR TITLE
Mosquitto in Codebuild CI

### DIFF
--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# Make a directory to install all of the mosquitto stuff into
+mkdir -p MosquittoInstall
+cd MosquittoInstall
+
+# mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
+echo "Setup mosquitto dependencies from source - OpenSSL (may take a couple minutes - should take no more than 6 minutes)"
+# Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
+{
+    git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
+    cd openssl
+    ./config --prefix=/usr/local --openssldir=/usr/local
+    make
+    sudo make install
+} > /dev/null
+
+# We have to install libwebsockets from source for mosquitto too for websockets support
+# Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
+echo "Setup mosquitto dependencies from source - LibWebsockets (may take a couple minutes - should take no more than 6 minutes)"
+{
+    git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
+    cd libwebsockets
+    mkdir build
+    cd build
+    cmake .. -DLWS_WITH_EXTERNAL_POLL=ON
+    make
+    sudo make install
+cd ../..
+} > /dev/null
+
+# Install mosquitto from source (apt-get version is too old)
+# Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
+echo "Setup mosquitto from source - Mosquitto (may take a couple minutes - should take no more than 6 minutes)"
+{
+    git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
+    cd mosquitto
+    make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
+    cd ..
+    sudo ldconfig
+} > /dev/null
+
+# Get the Mosquttio config file and run it
+echo "Setup mosquitto from source - configure mosquitto and start it running"
+aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
+sudo chmod a+xr ./setup_mosquitto_test_env.sh
+./setup_mosquitto_test_env.sh
+mosquitto -d -c /etc/mosquitto/mosquitto.conf
+
+# Done!
+cd ..

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -15,10 +15,18 @@ phases:
   build:
     commands:
       - echo Build started on `date`
+
+      - # Install Mosquitto
+      - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
+      - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
+      - cd $CODEBUILD_SRC_DIR # just make sure we are in the correct directory
+
       - chmod a+xr ./codebuild/mqtt5_test_setup.sh
-      - source ./codebuild/mqtt5_test_setup.sh s3://aws-crt-test-stuff/TestIotProdMQTT5EnvironmentVariables.txt us-east-1
+      - source ./codebuild/mqtt5_test_setup.sh s3://aws-crt-test-stuff/CodebuildMosquittoIotProdMQTT5EnvironmentVariables.txt us-east-1
+
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - chmod a+xr /tmp/setup_proxy_test_env.sh
+
       - $CODEBUILD_SRC_DIR/codebuild/linux-integration-tests.sh
   post_build:
     commands:

--- a/codebuild/mqtt5-python-canary-test.yml
+++ b/codebuild/mqtt5-python-canary-test.yml
@@ -15,7 +15,6 @@ env:
     BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
     PACKAGE_NAME: aws-crt-python
     CANARY_TEST_EXE: 'python -m unittest --failfast --verbose 2>&1 | tee /tmp/tests.log test.test_mqtt5_canary'
-    CANARY_SERVER_ARN: Mqtt5MosquittoSever
 phases:
   install:
     commands:
@@ -30,9 +29,17 @@ phases:
   build:
     commands:
       - echo Build started on `date`
+
       - source ./codebuild/mqtt5_test_setup.sh s3://aws-crt-test-stuff/TestIotProdMQTT5EnvironmentVariables.txt us-east-1
-      - export ENDPOINT=$(aws secretsmanager get-secret-value --secret-id "$CANARY_SERVER_ARN" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
       - export GIT_HASH=$(git rev-parse HEAD)
+
+      - # Install Mosquitto
+      - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
+      - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
+      - cd $CODEBUILD_SRC_DIR # just make sure we are in the correct directory
+      # Set the endpoint to the Mosquitto server
+      - export ENDPOINT=localhost
+
       - $CODEBUILD_SRC_DIR/codebuild/mqtt5-python-canary-test.sh
   post_build:
     commands:

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -31,6 +31,8 @@ import time
 # AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD - password to use in basic authentication tests
 # AWS_TEST_MQTT5_PROXY_HOST - name of http proxy host to use in proxy-based tests
 # AWS_TEST_MQTT5_PROXY_PORT - port of http proxy host to use in proxy-based tests
+# AWS_TEST_MQTT5_PROXY_MQTT_HOST - host to connect to in HTTP proxy tests
+# AWS_TEST_MQTT5_PROXY_MQTT_PORT - port to connect to in HTTP proxy tests
 # AWS_TEST_MQTT5_CERTIFICATE_FILE - certificate file path
 # AWS_TEST_MQTT5_KEY_FILE - private key file path
 # AWS_TEST_MQTT5_IOT_KEY_PATH - private key file path for MTLS tests
@@ -112,8 +114,8 @@ class Config:
             self.cert = pathlib.Path(self.cert_path).read_text().encode('utf-8')
 
         elif auth_type == AuthType.DIRECT_PROXY:
-            self.endpoint = self._get_env("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST")
-            self.port = self._get_env("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT")
+            self.endpoint = self._get_env("AWS_TEST_MQTT5_PROXY_MQTT_HOST")
+            self.port = self._get_env("AWS_TEST_MQTT5_PROXY_MQTT_PORT")
             self.proxy_endpoint = self._get_env("AWS_TEST_MQTT5_PROXY_HOST")
             self.proxy_port = self._get_env("AWS_TEST_MQTT5_PROXY_PORT")
             self.key_path = self._get_env('AWS_TEST_MQTT5_KEY_FILE')
@@ -122,8 +124,8 @@ class Config:
             self.cert = pathlib.Path(self.cert_path).read_text().encode('utf-8')
 
         elif auth_type == AuthType.WS_PROXY:
-            self.endpoint = self._get_env("AWS_TEST_MQTT5_WS_MQTT_HOST")
-            self.port = self._get_env("AWS_TEST_MQTT5_WS_MQTT_PORT")
+            self.endpoint = self._get_env("AWS_TEST_MQTT5_PROXY_MQTT_HOST")
+            self.port = 443
             self.proxy_endpoint = self._get_env("AWS_TEST_MQTT5_PROXY_HOST")
             self.proxy_port = self._get_env("AWS_TEST_MQTT5_PROXY_PORT")
             self.key_path = self._get_env('AWS_TEST_MQTT5_KEY_FILE')
@@ -250,13 +252,13 @@ class Mqtt5ClientTest(NativeResourceTest):
             client_options.connect_options.password = config.password
 
         if (auth_type == AuthType.DIRECT_TLS or
-                auth_type == AuthType.WS_TLS or
-                auth_type == AuthType.DIRECT_PROXY):
+                auth_type == AuthType.WS_TLS):
             tls_ctx_options = io.TlsContextOptions()
             tls_ctx_options.verify_peer = False
             client_options.tls_ctx = io.ClientTlsContext(tls_ctx_options)
 
-        if auth_type == AuthType.DIRECT_MUTUAL_TLS:
+        if (auth_type == AuthType.DIRECT_MUTUAL_TLS or
+                auth_type == AuthType.DIRECT_PROXY):
             tls_ctx_options = io.TlsContextOptions.create_client_with_mtls_from_path(config.cert_path, config.key_path)
             client_options.tls_ctx = io.ClientTlsContext(tls_ctx_options)
 


### PR DESCRIPTION
*Description of changes:*

Adds installing and running Mosquitto in Codebuild CI. This makes our Codebuild CI more standalone and ensures we can always run the basic MQTT5 tests.

* Doing this required modifying the HTTP proxy tests to run against IoT Core.
  * Adds a shell script to install Mosquttio (and dependencies) in Codebuild. Building from source to use version new enough to work for our purposes (apt-get uses too old of a version for what we need).
* Unfortunately this adds about 6-10 minutes of extra time to the Codebuild Job.
* Also modifies Canary to run against local Mosquitto in Codebuild


__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
