### PR TITLE
Mqtt311 operation statistics support

### DIFF
--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -14,6 +14,7 @@ from awscrt import NativeResource
 import awscrt.exceptions
 from awscrt.http import HttpProxyOptions, HttpRequest
 from awscrt.io import ClientBootstrap, ClientTlsContext, SocketOptions
+from dataclasses import dataclass
 
 
 class QoS(IntEnum):
@@ -164,6 +165,7 @@ class OperationStatisticsData:
     incomplete_operation_size: int = 0
     unacked_operation_count: int = 0
     unacked_operation_size: int = 0
+
 
 class Connection(NativeResource):
     """MQTT client connection.

--- a/source/module.c
+++ b/source/module.c
@@ -706,6 +706,7 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(mqtt_client_connection_unsubscribe, METH_VARARGS),
     AWS_PY_METHOD_DEF(mqtt_client_connection_disconnect, METH_VARARGS),
     AWS_PY_METHOD_DEF(mqtt_ws_handshake_transform_complete, METH_VARARGS),
+    AWS_PY_METHOD_DEF(mqtt_client_connection_get_stats, METH_VARARGS),
 
     /* MQTT5 Client */
     AWS_PY_METHOD_DEF(mqtt5_client_new, METH_VARARGS),

--- a/source/mqtt_client_connection.h
+++ b/source/mqtt_client_connection.h
@@ -20,6 +20,7 @@ PyObject *aws_py_mqtt_client_connection_on_message(PyObject *self, PyObject *arg
 PyObject *aws_py_mqtt_client_connection_unsubscribe(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_resubscribe_existing_topics(PyObject *self, PyObject *args);
 PyObject *aws_py_mqtt_client_connection_disconnect(PyObject *self, PyObject *args);
+PyObject *aws_py_mqtt_client_connection_get_stats(PyObject *self, PyObject *args);
 
 PyObject *aws_py_mqtt_ws_handshake_transform_complete(PyObject *self, PyObject *args);
 

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -242,7 +242,7 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
 
         # check operation statistics
-        statistics = connection.get_stats()
+        statistics = connection.get_stats().result(TIMEOUT)
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)
@@ -254,7 +254,7 @@ class MqttConnectionTest(NativeResourceTest):
         self.assertEqual(packet_id, puback['packet_id'])
 
         # check operation statistics
-        statistics = connection.get_stats()
+        statistics = connection.get_stats().result(TIMEOUT)
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)
@@ -273,7 +273,7 @@ class MqttConnectionTest(NativeResourceTest):
         expected_size = len(self.TEST_TOPIC) + len(self.TEST_MSG) + 4
 
         # check operation statistics
-        statistics = connection.get_stats()
+        statistics = connection.get_stats().result(TIMEOUT)
         self.assertEqual(statistics.incomplete_operation_count, 1)
         self.assertEqual(statistics.incomplete_operation_size, expected_size)
         # NOTE: Unacked will be zero because we have not invoked the future yet
@@ -286,7 +286,7 @@ class MqttConnectionTest(NativeResourceTest):
         self.assertEqual(packet_id, puback['packet_id'])
 
         # check operation statistics
-        statistics = connection.get_stats()
+        statistics = connection.get_stats().result(TIMEOUT)
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -276,7 +276,8 @@ class MqttConnectionTest(NativeResourceTest):
         statistics = connection.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 1)
         self.assertEqual(statistics.incomplete_operation_size, expected_size)
-        # NOTE: Unacked will be zero because we have not invoked the future yet and so it has not had time to move to the socket
+        # NOTE: Unacked will be zero because we have not invoked the future yet
+        # and so it has not had time to move to the socket
         self.assertEqual(statistics.unacked_operation_count, 0)
         self.assertEqual(statistics.unacked_operation_size, 0)
 

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -1240,7 +1240,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         client1, callbacks = self._test_connect(auth_type=AuthType.DIRECT_MUTUAL_TLS, client_options=client_options)
 
         # Make sure the operation statistics are empty
-        statistics = client1.get_stats()
+        statistics = client1.get_stats().result(TIMEOUT)
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)
@@ -1257,7 +1257,7 @@ class Mqtt5ClientTest(NativeResourceTest):
             publish_future.result(TIMEOUT)
 
         # Make sure the operation statistics are empty
-        statistics = client1.get_stats()
+        statistics = client1.get_stats().result(TIMEOUT)
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)


### PR DESCRIPTION
*Description of changes:*

Adds operation statistics support to `aws-crt-nodejs` for MQTT311. Also adds operation statistics support tests for both MQTT311 and MQTT5 to increase code coverage and safety.

~~Relies on https://github.com/awslabs/aws-c-mqtt/pull/247 being merged and released.~~

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
