### PR TITLE
Remove future from operation statistics

### DIFF
--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -724,25 +724,11 @@ class Connection(NativeResource):
         """Queries the connection's internal statistics for incomplete operations.
 
         Returns:
-            A future with a (:class:`OperationStatisticsData`)
+            The (:class:`OperationStatisticsData`) containing the statistics
         """
 
-        future = Future()
-
-        def get_stats_result(
-                incomplete_operation_count,
-                incomplete_operation_size,
-                unacked_operation_count,
-                unacked_operation_size):
-            operation_statistics_data = OperationStatisticsData(
-                incomplete_operation_count,
-                incomplete_operation_size,
-                unacked_operation_count,
-                unacked_operation_size)
-            future.set_result(operation_statistics_data)
-
-        _awscrt.mqtt_client_connection_get_stats(self._binding, get_stats_result)
-        return future
+        result = _awscrt.mqtt_client_connection_get_stats(self._binding)
+        return OperationStatisticsData(result[0], result[1], result[2], result[3])
 
 
 class WebsocketHandshakeTransformArgs:

--- a/awscrt/mqtt5.py
+++ b/awscrt/mqtt5.py
@@ -1848,23 +1848,8 @@ class Client(NativeResource):
         """Queries the client's internal statistics for incomplete operations.
 
         Returns:
-            A future with a (:class:`OperationStatisticsData`)
+            The (:class:`OperationStatisticsData`) containing the statistics
         """
 
-        future = Future()
-
-        def get_stats_result(
-                incomplete_operation_count,
-                incomplete_operation_size,
-                unacked_operation_count,
-                unacked_operation_size):
-            operation_statistics_data = OperationStatisticsData(
-                incomplete_operation_count,
-                incomplete_operation_size,
-                unacked_operation_count,
-                unacked_operation_size)
-            future.set_result(operation_statistics_data)
-
-        _awscrt.mqtt5_client_get_stats(self._binding, get_stats_result)
-
-        return future
+        result = _awscrt.mqtt5_client_get_stats(self._binding)
+        return OperationStatisticsData(result[0], result[1], result[2], result[3])

--- a/source/mqtt5_client.c
+++ b/source/mqtt5_client.c
@@ -2062,21 +2062,11 @@ done:
         return result;
     }
 
-    if (result) {
-        Py_XDECREF(result);
-    }
-    if (incomplete_operation_count_obj) {
-        Py_XDECREF(incomplete_operation_count_obj);
-    }
-    if (incomplete_operation_size_obj) {
-        Py_XDECREF(incomplete_operation_size_obj);
-    }
-    if (unacked_operation_count_obj) {
-        Py_XDECREF(unacked_operation_count_obj);
-    }
-    if (unacked_operation_size_obj) {
-        Py_XDECREF(unacked_operation_size_obj);
-    }
+    Py_XDECREF(result);
+    Py_XDECREF(incomplete_operation_count_obj);
+    Py_XDECREF(incomplete_operation_size_obj);
+    Py_XDECREF(unacked_operation_count_obj);
+    Py_XDECREF(unacked_operation_size_obj);
 
     return NULL;
 }

--- a/source/mqtt5_client.c
+++ b/source/mqtt5_client.c
@@ -2026,10 +2026,10 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
     aws_mqtt5_client_get_stats(client->native, &stats);
 
     result = PyTuple_New(4);
-    PyTuple_SetItem(result, 0, (unsigned long long)stats.incomplete_operation_count);
-    PyTuple_SetItem(result, 1, (unsigned long long)stats.incomplete_operation_size);
-    PyTuple_SetItem(result, 2, (unsigned long long)stats.unacked_operation_count);
-    PyTuple_SetItem(result, 3, (unsigned long long)stats.unacked_operation_size);
+    PyTuple_SET_ITEM(result, 0, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count));
+    PyTuple_SET_ITEM(result, 1, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size));
+    PyTuple_SET_ITEM(result, 2, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count));
+    PyTuple_SET_ITEM(result, 3, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size));
     success = true;
 
 done:

--- a/source/mqtt5_client.c
+++ b/source/mqtt5_client.c
@@ -2019,6 +2019,10 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
 
     /* These must be DECREF'd when function ends on error */
     PyObject *result = NULL;
+    PyObject *incomplete_operation_count_obj = NULL;
+    PyObject *incomplete_operation_size_obj = NULL;
+    PyObject *unacked_operation_count_obj = NULL;
+    PyObject *unacked_operation_size_obj = NULL;
 
     struct aws_mqtt5_client_operation_statistics stats;
     AWS_ZERO_STRUCT(stats);
@@ -2026,10 +2030,31 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
     aws_mqtt5_client_get_stats(client->native, &stats);
 
     result = PyTuple_New(4);
-    PyTuple_SET_ITEM(result, 0, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count));
-    PyTuple_SET_ITEM(result, 1, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size));
-    PyTuple_SET_ITEM(result, 2, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count));
-    PyTuple_SET_ITEM(result, 3, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size));
+    if (!result) {
+        goto done;
+    }
+
+    incomplete_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count);
+    if (!incomplete_operation_count_obj) {
+        goto done;
+    }
+    incomplete_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size);
+    if (!incomplete_operation_size_obj) {
+        goto done;
+    }
+    unacked_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count);
+    if (!unacked_operation_count_obj) {
+        goto done;
+    }
+    unacked_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size);
+    if (!unacked_operation_size_obj) {
+        goto done;
+    }
+
+    PyTuple_SET_ITEM(result, 0, incomplete_operation_count_obj);
+    PyTuple_SET_ITEM(result, 1, incomplete_operation_size_obj);
+    PyTuple_SET_ITEM(result, 2, unacked_operation_count_obj);
+    PyTuple_SET_ITEM(result, 3, unacked_operation_size_obj);
     success = true;
 
 done:
@@ -2040,5 +2065,18 @@ done:
     if (result) {
         Py_XDECREF(result);
     }
+    if (incomplete_operation_count_obj) {
+        Py_XDECREF(incomplete_operation_count_obj);
+    }
+    if (incomplete_operation_size_obj) {
+        Py_XDECREF(incomplete_operation_size_obj);
+    }
+    if (unacked_operation_count_obj) {
+        Py_XDECREF(unacked_operation_count_obj);
+    }
+    if (unacked_operation_size_obj) {
+        Py_XDECREF(unacked_operation_size_obj);
+    }
+
     return NULL;
 }

--- a/source/mqtt5_client.c
+++ b/source/mqtt5_client.c
@@ -2007,9 +2007,8 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
     bool success = false;
 
     PyObject *impl_capsule;
-    PyObject *get_stats_callback_fn_py;
 
-    if (!PyArg_ParseTuple(args, "OO", &impl_capsule, &get_stats_callback_fn_py)) {
+    if (!PyArg_ParseTuple(args, "O", &impl_capsule)) {
         return NULL;
     }
 
@@ -2018,7 +2017,7 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    /* These must be DECREF'd when function ends */
+    /* These must be DECREF'd when function ends on error */
     PyObject *result = NULL;
 
     struct aws_mqtt5_client_operation_statistics stats;
@@ -2026,26 +2025,20 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
 
     aws_mqtt5_client_get_stats(client->native, &stats);
 
-    result = PyObject_CallFunction(
-        get_stats_callback_fn_py,
-        "(KKKK)",
-        /* K */ (unsigned long long)stats.incomplete_operation_count,
-        /* K */ (unsigned long long)stats.incomplete_operation_size,
-        /* K */ (unsigned long long)stats.unacked_operation_count,
-        /* K */ (unsigned long long)stats.unacked_operation_size);
-    if (!result) {
-        PyErr_WriteUnraisable(PyErr_Occurred());
-        goto done;
-    }
-
+    result = PyTuple_New(4);
+    PyTuple_SetItem(result, 0, (unsigned long long)stats.incomplete_operation_count);
+    PyTuple_SetItem(result, 1, (unsigned long long)stats.incomplete_operation_size);
+    PyTuple_SetItem(result, 2, (unsigned long long)stats.unacked_operation_count);
+    PyTuple_SetItem(result, 3, (unsigned long long)stats.unacked_operation_size);
     success = true;
 
 done:
-
-    Py_XDECREF(result);
-
     if (success) {
-        Py_RETURN_NONE;
+        return result;
+    }
+
+    if (result) {
+        Py_XDECREF(result);
     }
     return NULL;
 }

--- a/source/mqtt5_client.c
+++ b/source/mqtt5_client.c
@@ -2019,10 +2019,6 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
 
     /* These must be DECREF'd when function ends on error */
     PyObject *result = NULL;
-    PyObject *incomplete_operation_count_obj = NULL;
-    PyObject *incomplete_operation_size_obj = NULL;
-    PyObject *unacked_operation_count_obj = NULL;
-    PyObject *unacked_operation_size_obj = NULL;
 
     struct aws_mqtt5_client_operation_statistics stats;
     AWS_ZERO_STRUCT(stats);
@@ -2034,39 +2030,32 @@ PyObject *aws_py_mqtt5_client_get_stats(PyObject *self, PyObject *args) {
         goto done;
     }
 
-    incomplete_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count);
-    if (!incomplete_operation_count_obj) {
-        goto done;
-    }
-    incomplete_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size);
-    if (!incomplete_operation_size_obj) {
-        goto done;
-    }
-    unacked_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count);
-    if (!unacked_operation_count_obj) {
-        goto done;
-    }
-    unacked_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size);
-    if (!unacked_operation_size_obj) {
+    PyTuple_SET_ITEM(result, 0, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count));
+    if (PyTuple_GET_ITEM(result, 0) == NULL) {
         goto done;
     }
 
-    PyTuple_SET_ITEM(result, 0, incomplete_operation_count_obj);
-    PyTuple_SET_ITEM(result, 1, incomplete_operation_size_obj);
-    PyTuple_SET_ITEM(result, 2, unacked_operation_count_obj);
-    PyTuple_SET_ITEM(result, 3, unacked_operation_size_obj);
+    PyTuple_SET_ITEM(result, 1, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size));
+    if (PyTuple_GET_ITEM(result, 1) == NULL) {
+        goto done;
+    }
+
+    PyTuple_SET_ITEM(result, 2, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count));
+    if (PyTuple_GET_ITEM(result, 2) == NULL) {
+        goto done;
+    }
+
+    PyTuple_SET_ITEM(result, 3, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size));
+    if (PyTuple_GET_ITEM(result, 3) == NULL) {
+        goto done;
+    }
+
     success = true;
 
 done:
     if (success) {
         return result;
     }
-
     Py_XDECREF(result);
-    Py_XDECREF(incomplete_operation_count_obj);
-    Py_XDECREF(incomplete_operation_size_obj);
-    Py_XDECREF(unacked_operation_count_obj);
-    Py_XDECREF(unacked_operation_size_obj);
-
     return NULL;
 }

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1191,10 +1191,6 @@ PyObject *aws_py_mqtt_client_connection_get_stats(PyObject *self, PyObject *args
 
     /* These must be DECREF'd when function ends on error */
     PyObject *result = NULL;
-    PyObject *incomplete_operation_count_obj = NULL;
-    PyObject *incomplete_operation_size_obj = NULL;
-    PyObject *unacked_operation_count_obj = NULL;
-    PyObject *unacked_operation_size_obj = NULL;
 
     struct aws_mqtt_connection_operation_statistics stats;
     AWS_ZERO_STRUCT(stats);
@@ -1206,39 +1202,32 @@ PyObject *aws_py_mqtt_client_connection_get_stats(PyObject *self, PyObject *args
         goto done;
     }
 
-    incomplete_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count);
-    if (!incomplete_operation_count_obj) {
-        goto done;
-    }
-    incomplete_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size);
-    if (!incomplete_operation_size_obj) {
-        goto done;
-    }
-    unacked_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count);
-    if (!unacked_operation_count_obj) {
-        goto done;
-    }
-    unacked_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size);
-    if (!unacked_operation_size_obj) {
+    PyTuple_SET_ITEM(result, 0, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count));
+    if (PyTuple_GET_ITEM(result, 0) == NULL) {
         goto done;
     }
 
-    PyTuple_SET_ITEM(result, 0, incomplete_operation_count_obj);
-    PyTuple_SET_ITEM(result, 1, incomplete_operation_size_obj);
-    PyTuple_SET_ITEM(result, 2, unacked_operation_count_obj);
-    PyTuple_SET_ITEM(result, 3, unacked_operation_size_obj);
+    PyTuple_SET_ITEM(result, 1, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size));
+    if (PyTuple_GET_ITEM(result, 1) == NULL) {
+        goto done;
+    }
+
+    PyTuple_SET_ITEM(result, 2, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count));
+    if (PyTuple_GET_ITEM(result, 2) == NULL) {
+        goto done;
+    }
+
+    PyTuple_SET_ITEM(result, 3, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size));
+    if (PyTuple_GET_ITEM(result, 3) == NULL) {
+        goto done;
+    }
+
     success = true;
 
 done:
     if (success) {
         return result;
     }
-
     Py_XDECREF(result);
-    Py_XDECREF(incomplete_operation_count_obj);
-    Py_XDECREF(incomplete_operation_size_obj);
-    Py_XDECREF(unacked_operation_count_obj);
-    Py_XDECREF(unacked_operation_size_obj);
-
     return NULL;
 }

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1201,10 +1201,10 @@ PyObject *aws_py_mqtt_client_connection_get_stats(PyObject *self, PyObject *args
     if (!result) {
         goto done;
     }
-    PyTuple_SET_ITEM(result, 0, (unsigned long long)stats.incomplete_operation_count);
-    PyTuple_SET_ITEM(result, 1, (unsigned long long)stats.incomplete_operation_size);
-    PyTuple_SET_ITEM(result, 2, (unsigned long long)stats.unacked_operation_count);
-    PyTuple_SET_ITEM(result, 3, (unsigned long long)stats.unacked_operation_size);
+    PyTuple_SET_ITEM(result, 0, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count));
+    PyTuple_SET_ITEM(result, 1, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size));
+    PyTuple_SET_ITEM(result, 2, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count));
+    PyTuple_SET_ITEM(result, 3, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size));
     success = true;
 
 done:

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1234,21 +1234,11 @@ done:
         return result;
     }
 
-    if (result) {
-        Py_XDECREF(result);
-    }
-    if (incomplete_operation_count_obj) {
-        Py_XDECREF(incomplete_operation_count_obj);
-    }
-    if (incomplete_operation_size_obj) {
-        Py_XDECREF(incomplete_operation_size_obj);
-    }
-    if (unacked_operation_count_obj) {
-        Py_XDECREF(unacked_operation_count_obj);
-    }
-    if (unacked_operation_size_obj) {
-        Py_XDECREF(unacked_operation_size_obj);
-    }
+    Py_XDECREF(result);
+    Py_XDECREF(incomplete_operation_count_obj);
+    Py_XDECREF(incomplete_operation_size_obj);
+    Py_XDECREF(unacked_operation_count_obj);
+    Py_XDECREF(unacked_operation_size_obj);
 
     return NULL;
 }

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1191,6 +1191,10 @@ PyObject *aws_py_mqtt_client_connection_get_stats(PyObject *self, PyObject *args
 
     /* These must be DECREF'd when function ends on error */
     PyObject *result = NULL;
+    PyObject *incomplete_operation_count_obj = NULL;
+    PyObject *incomplete_operation_size_obj = NULL;
+    PyObject *unacked_operation_count_obj = NULL;
+    PyObject *unacked_operation_size_obj = NULL;
 
     struct aws_mqtt_connection_operation_statistics stats;
     AWS_ZERO_STRUCT(stats);
@@ -1201,10 +1205,28 @@ PyObject *aws_py_mqtt_client_connection_get_stats(PyObject *self, PyObject *args
     if (!result) {
         goto done;
     }
-    PyTuple_SET_ITEM(result, 0, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count));
-    PyTuple_SET_ITEM(result, 1, PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size));
-    PyTuple_SET_ITEM(result, 2, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count));
-    PyTuple_SET_ITEM(result, 3, PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size));
+
+    incomplete_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_count);
+    if (!incomplete_operation_count_obj) {
+        goto done;
+    }
+    incomplete_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.incomplete_operation_size);
+    if (!incomplete_operation_size_obj) {
+        goto done;
+    }
+    unacked_operation_count_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_count);
+    if (!unacked_operation_count_obj) {
+        goto done;
+    }
+    unacked_operation_size_obj = PyLong_FromUnsignedLongLong((unsigned long long)stats.unacked_operation_size);
+    if (!unacked_operation_size_obj) {
+        goto done;
+    }
+
+    PyTuple_SET_ITEM(result, 0, incomplete_operation_count_obj);
+    PyTuple_SET_ITEM(result, 1, incomplete_operation_size_obj);
+    PyTuple_SET_ITEM(result, 2, unacked_operation_count_obj);
+    PyTuple_SET_ITEM(result, 3, unacked_operation_size_obj);
     success = true;
 
 done:
@@ -1215,5 +1237,18 @@ done:
     if (result) {
         Py_XDECREF(result);
     }
+    if (incomplete_operation_count_obj) {
+        Py_XDECREF(incomplete_operation_count_obj);
+    }
+    if (incomplete_operation_size_obj) {
+        Py_XDECREF(incomplete_operation_size_obj);
+    }
+    if (unacked_operation_count_obj) {
+        Py_XDECREF(unacked_operation_count_obj);
+    }
+    if (unacked_operation_size_obj) {
+        Py_XDECREF(unacked_operation_size_obj);
+    }
+
     return NULL;
 }

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -276,10 +276,12 @@ class MqttConnectionTest(NativeResourceTest):
         statistics = connection.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 1)
         self.assertEqual(statistics.incomplete_operation_size, expected_size)
-        # NOTE: Unacked will be zero because we have not invoked the future yet
-        # and so it has not had time to move to the socket
-        self.assertEqual(statistics.unacked_operation_count, 0)
-        self.assertEqual(statistics.unacked_operation_size, 0)
+        # NOTE: Unacked MAY be zero because we have not invoked the future yet
+        # and so it has not had time to move to the socket. With Python especially, it seems to heavily depend on how fast
+        # the test is executed, which makes it sometimes rarely get into the unacked operation and then it is non-zero.
+        # To fix this, we just make sure it is within expected bounds (0 or within packet size).
+        self.assertTrue(statistics.unacked_operation_count <= 1)
+        self.assertTrue(statistics.unacked_operation_count <= expected_size)
 
         # wait for PubAck
         puback = published.result(TIMEOUT)

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -242,7 +242,7 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
 
         # check operation statistics
-        statistics = connection.get_stats().result(TIMEOUT)
+        statistics = connection.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)
@@ -254,7 +254,7 @@ class MqttConnectionTest(NativeResourceTest):
         self.assertEqual(packet_id, puback['packet_id'])
 
         # check operation statistics
-        statistics = connection.get_stats().result(TIMEOUT)
+        statistics = connection.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)
@@ -273,7 +273,7 @@ class MqttConnectionTest(NativeResourceTest):
         expected_size = len(self.TEST_TOPIC) + len(self.TEST_MSG) + 4
 
         # check operation statistics
-        statistics = connection.get_stats().result(TIMEOUT)
+        statistics = connection.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 1)
         self.assertEqual(statistics.incomplete_operation_size, expected_size)
         # NOTE: Unacked will be zero because we have not invoked the future yet
@@ -286,7 +286,7 @@ class MqttConnectionTest(NativeResourceTest):
         self.assertEqual(packet_id, puback['packet_id'])
 
         # check operation statistics
-        statistics = connection.get_stats().result(TIMEOUT)
+        statistics = connection.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -1240,7 +1240,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         client1, callbacks = self._test_connect(auth_type=AuthType.DIRECT_MUTUAL_TLS, client_options=client_options)
 
         # Make sure the operation statistics are empty
-        statistics = client1.get_stats().result(TIMEOUT)
+        statistics = client1.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)
@@ -1257,7 +1257,7 @@ class Mqtt5ClientTest(NativeResourceTest):
             publish_future.result(TIMEOUT)
 
         # Make sure the operation statistics are empty
-        statistics = client1.get_stats().result(TIMEOUT)
+        statistics = client1.get_stats()
         self.assertEqual(statistics.incomplete_operation_count, 0)
         self.assertEqual(statistics.incomplete_operation_size, 0)
         self.assertEqual(statistics.unacked_operation_count, 0)


### PR DESCRIPTION
*Description of changes:*

Adjusts operation statistics getting functions in both MQTT311 and MQTT5 to return the statistics directly rather than via a future.

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
