### PR TITLE
Allow passing None for the PKCS11 user pin

### DIFF
--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -374,7 +374,7 @@ class TlsContextOptions:
     @staticmethod
     def create_client_with_mtls_pkcs11(*,
                                        pkcs11_lib: 'Pkcs11Lib',
-                                       user_pin: str,
+                                       user_pin: str = None,
                                        slot_id: int = None,
                                        token_label: str = None,
                                        private_key_label: str = None,
@@ -390,7 +390,7 @@ class TlsContextOptions:
             pkcs11_lib (Pkcs11Lib): Use this PKCS#11 library
 
             user_pin (str): User PIN, for logging into the PKCS#11 token.
-                Pass `None` to log into a token with a "protected authentication path".
+                Pass `None` or do not specify to log into a token with a "protected authentication path".
 
             slot_id (Optional[int]): ID of slot containing PKCS#11 token.
                 If not specified, the token will be chosen based on other criteria (such as token label).

--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -12,6 +12,7 @@ import _awscrt
 from awscrt import NativeResource
 from enum import IntEnum
 import threading
+from typing import Union
 
 
 class LogLevel(IntEnum):
@@ -374,7 +375,7 @@ class TlsContextOptions:
     @staticmethod
     def create_client_with_mtls_pkcs11(*,
                                        pkcs11_lib: 'Pkcs11Lib',
-                                       user_pin: str = None,
+                                       user_pin: Union[str, None],
                                        slot_id: int = None,
                                        token_label: str = None,
                                        private_key_label: str = None,
@@ -390,7 +391,7 @@ class TlsContextOptions:
             pkcs11_lib (Pkcs11Lib): Use this PKCS#11 library
 
             user_pin (str): User PIN, for logging into the PKCS#11 token.
-                Pass `None` or do not specify to log into a token with a "protected authentication path".
+                Pass `None` to log into a token with a "protected authentication path".
 
             slot_id (Optional[int]): ID of slot containing PKCS#11 token.
                 If not specified, the token will be chosen based on other criteria (such as token label).

--- a/source/io.c
+++ b/source/io.c
@@ -505,12 +505,12 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
         if (pkcs11_user_pin != NULL) {
             user_pin_cursor = aws_byte_cursor_from_array(pkcs11_user_pin, pkcs11_user_pin_len);
         } else {
-            AWS_ZERO_STRUCT(pkcs11_user_pin);
+            AWS_ZERO_STRUCT(user_pin_cursor);
         }
 
         struct aws_tls_ctx_pkcs11_options pkcs11_options = {
             .pkcs11_lib = pkcs11_lib,
-            .user_pin = pkcs11_user_pin,
+            .user_pin = user_pin_cursor,
             .slot_id = has_slot_id ? &slot_id_value : NULL,
             .token_label = aws_byte_cursor_from_array(pkcs11_token_label, pkcs11_token_label_len),
             .private_key_object_label = aws_byte_cursor_from_array(pkcs11_priv_key_label, pkcs11_priv_key_label_len),

--- a/source/io.c
+++ b/source/io.c
@@ -501,9 +501,16 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
             }
         }
 
+        struct aws_byte_cursor user_pin_cursor;
+        if (pkcs11_user_pin != NULL) {
+            user_pin_cursor = aws_byte_cursor_from_array(pkcs11_user_pin, pkcs11_user_pin_len);
+        } else {
+            AWS_ZERO_STRUCT(pkcs11_user_pin);
+        }
+
         struct aws_tls_ctx_pkcs11_options pkcs11_options = {
             .pkcs11_lib = pkcs11_lib,
-            .user_pin = aws_byte_cursor_from_array(pkcs11_user_pin, pkcs11_user_pin_len),
+            .user_pin = pkcs11_user_pin,
             .slot_id = has_slot_id ? &slot_id_value : NULL,
             .token_label = aws_byte_cursor_from_array(pkcs11_token_label, pkcs11_token_label_len),
             .private_key_object_label = aws_byte_cursor_from_array(pkcs11_priv_key_label, pkcs11_priv_key_label_len),

--- a/source/io.c
+++ b/source/io.c
@@ -501,16 +501,9 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
             }
         }
 
-        struct aws_byte_cursor user_pin_cursor;
-        if (pkcs11_user_pin != NULL) {
-            user_pin_cursor = aws_byte_cursor_from_array(pkcs11_user_pin, pkcs11_user_pin_len);
-        } else {
-            AWS_ZERO_STRUCT(user_pin_cursor);
-        }
-
         struct aws_tls_ctx_pkcs11_options pkcs11_options = {
             .pkcs11_lib = pkcs11_lib,
-            .user_pin = user_pin_cursor,
+            .user_pin = aws_byte_cursor_from_array(pkcs11_user_pin, pkcs11_user_pin_len),
             .slot_id = has_slot_id ? &slot_id_value : NULL,
             .token_label = aws_byte_cursor_from_array(pkcs11_token_label, pkcs11_token_label_len),
             .private_key_object_label = aws_byte_cursor_from_array(pkcs11_priv_key_label, pkcs11_priv_key_label_len),


### PR DESCRIPTION
*Description of changes:*

The documentation for the PKCS11 `create_client_with_mtls_pkcs11()` function states that you can pass `None` as a valid input, but this is not allowed because `user_pin` is not set to `None` by default. When using Python with typing, this causes problems.

This PR fixes that by making the `user_pin` optional by setting it to `null` by default. It also adjusts the C code to check if the value is `null` and, if it is, it passes a zeroed out `aws_byte_cursor`.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
