### PR TITLE
Fix linking on OpenBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,7 +298,9 @@ def awscrt_ext():
         # linker will prefer shared libraries over static if it can find both.
         # force linker to choose static variant by using using "-l:libcrypto.a" syntax instead of just "-lcrypto".
         libraries = [':lib{}.a'.format(x) for x in libraries]
-        libraries += ['rt']
+        # OpenBSD doesn't have librt; functions are found in libc instead.
+        if not sys.platform.startswith('openbsd'):
+            libraries += ['rt']
 
         # hide the symbols from libcrypto.a
         # this prevents weird crashes if an application also ends up using


### PR DESCRIPTION
*Issue #, if available:*

This doesn't fully address, but is needed to support #447.

*Description of changes:*

OpenBSD doesn't ship with librt (anything needed from librt should be found in libc). 

With this PR and the changes detailed in #447, the Python bindings build and are usable on OpenBSD.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
