### PR TITLE
Do not decref the result object twice

### DIFF
--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -150,7 +150,6 @@ static void s_on_client_connection_setup(
     }
 
     Py_XDECREF(capsule);
-    Py_XDECREF(result);
     PyGILState_Release(state);
 }
 


### PR DESCRIPTION
The result object is decref'd immediately after the call to `PyObject_CallFunction()`, do not decref it again.

This fixes `Fatal Python error: deallocating None` when running the test suite with the module built for Python 3.11 on Fedora.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.