### PR TITLE
Include the entire test suite in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,3 +32,5 @@ prune crt/aws-lc/tool
 prune crt/aws-lc/util
 include crt/aws-lc/util/fipstools/CMakeLists.txt
 include crt/aws-lc/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+# by default only test/test*.py are included, include the entire test suite
+graft test


### PR DESCRIPTION
By default, only files matching the test/test*.py pattern are included in source distribution. This leaves the test suite unusable, because resources and some necessary scripts are missing.
Fix that.

Fixes #281.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.