### PR TITLE
Add AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,18 @@ jobs:
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
 
+  use-openssl:
+    runs-on: ubuntu-20.04 # latest
+    steps:
+      - name: Build ${{ env.PACKAGE_NAME }}
+        env:
+          AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO: 1
+        runs: |
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }}
+
+
 
   windows:
     runs-on: windows-2022 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
 
-  use-openssl:
+  use-system-libcrypto:
     runs-on: ubuntu-20.04 # latest
     steps:
       - name: Build ${{ env.PACKAGE_NAME }}
@@ -113,6 +113,15 @@ jobs:
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}
 
+          # assert it's linked against the system's libcrypto.so
+          AWSCRT_PATH=`python3 -c "import _awscrt; print(_awscrt.__file__)"`
+          printf "AWSCRT_PATH: $AWSCRT_PATH\n"
+
+          LINKED_AGAINST=`ldd $AWSCRT_PATH`
+          printf "LINKED AGAINST:\n$LINKED_AGAINST\n"
+
+          USES_LIBCRYPTO_SO=`echo "$LINKED_AGAINST" | grep 'libcrypto*.so' | head -1`
+          test -n "$USES_LIBCRYPTO_SO"
 
 
   windows:
@@ -140,6 +149,10 @@ jobs:
   openbsd:
     runs-on: ubuntu-latest # macos would be faster. TODO: diagnose why some tests are failing
     steps:
+      # Cannot use builder to checkout as OpenBSD doesn't ship git in the base install
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         uses: cross-platform-actions/action@v0.10.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,6 @@ jobs:
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}
-
-    steps:
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         env:
           AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO: 1
-        runs: |
+        run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - cp310-cp310
           - cp311-cp311
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     # Only aarch64 needs this, but it doesn't hurt anything
     - name: Install qemu/docker
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -53,6 +56,9 @@ jobs:
         image:
           - raspbian-bullseye
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     # set arm arch
     - name: Install qemu/docker
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -73,6 +79,9 @@ jobs:
           - opensuse-leap
           - rhel8-x64
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
         # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
@@ -96,6 +105,9 @@ jobs:
           - gcc-7
           - gcc-8
     steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -105,9 +117,12 @@ jobs:
   use-openssl:
     runs-on: ubuntu-20.04 # latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Build ${{ env.PACKAGE_NAME }}
         env:
-          AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO: 1
+          AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO: '1'
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
@@ -121,6 +136,9 @@ jobs:
       matrix:
         arch: [x86, x64]
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
@@ -130,6 +148,9 @@ jobs:
   osx:
     runs-on: macos-11 # latest
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
@@ -161,7 +182,7 @@ jobs:
   tests-ok-without-env-vars:
     runs-on: ubuntu-20.04 # latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Run tests without env-vars or AWS creds
@@ -178,7 +199,7 @@ jobs:
   package-source:
     runs-on: ubuntu-20.04 # latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Package source + install
@@ -192,7 +213,7 @@ jobs:
   check-docs:
     runs-on: ubuntu-20.04 # latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Check docs
@@ -205,7 +226,7 @@ jobs:
     runs-on: ubuntu-20.04 # latest
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}
 
+    steps:
+      - name: Assert libcrypto.so used
+        run: |
           # assert it's linked against the system's libcrypto.so
           AWSCRT_PATH=`python3 -c "import _awscrt; print(_awscrt.__file__)"`
           printf "AWSCRT_PATH: $AWSCRT_PATH\n"

--- a/README.md
+++ b/README.md
@@ -12,22 +12,25 @@ Python 3 bindings for the AWS Common Runtime.
 This library is licensed under the Apache 2.0 License.
 
 ## Minimum Requirements:
+
 *   Python 3.7+
 
 ## Installation
 
 To install from pip:
-````bash
+
+```bash
 python3 -m pip install awscrt
-````
+```
 
 To install from Github:
-````bash
+
+```bash
 git clone https://github.com/awslabs/aws-crt-python.git
 cd aws-crt-python
 git submodule update --init
 python3 -m pip install .
-````
+```
 
 To use from your Python application, declare `awscrt` as a dependency in your `setup.py` file.
 
@@ -39,20 +42,27 @@ Please note that on Mac, once a private key is used with a certificate, that cer
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain. Using key from Keychain instead of the one provided.
 ```
 
-## OpenSSL and LibCrypto (Unix when install from Github only)
-
-If your application uses OpenSSL, set environment variable 'AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO' to 1 before install.
+### OpenSSL and LibCrypto (Unix only)
 
 aws-crt-python does not use OpenSSL for TLS.
 On Apple and Windows devices, the OS's default TLS library is used.
 On Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
 But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
-To simplify the build process, the source code for s2n-tls and libcrypto are
-included as git submodules and built along with aws-crt-python.
-But if your application is also loading the system installation of OpenSSL
-(i.e. your application uses libcurl which uses libssl which uses libcrypto)
-there may be crashes as the application tries to use two different versions of libcrypto at once.
+You can ignore all this on Windows and Apple platforms, where aws-crt-python
+uses the OS's default libraries for TLS and cryptography math.
+To simplify installation, aws-crt-python has its own copy of libcrypto.
+This lets you install a wheel from PyPI without having OpenSSL installed.
+Unix wheels on PyPI come with libcrypto statically compiled in.
+Code to build libcrypto comes from [AWS-LC](https://github.com/aws/aws-lc).
+AWS-LC's code is included in the PyPI source package, 
+and the git repository includes it as a submodule.
+If you need aws-crt-python to use the libcrypto included on your system, 
+set environment variable `AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1` while building from source:
 
-`export AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1` will cause aws-crt-python to link against your system's existing `libcrypto`, instead of building its own copy.
+```sh
+AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1 python3 -m pip install --no-binary :all: --verbose awscrt
+```
 
-You can ignore all this on Windows and Apple platforms, where aws-crt-python uses the OS's default libraries for TLS and cryptography math.
+( `--no-binary :all:` ensures you do not use the wheel from PyPI always uses AWS-LC)
+You can ignore all this on Windows and Apple platforms, where aws-crt-python
+uses the OS's default libraries for TLS and cryptography math.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,21 @@ Please note that on Mac, once a private key is used with a certificate, that cer
 ```
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain. Using key from Keychain instead of the one provided.
 ```
+
+## OpenSSL and LibCrypto (Unix when install from Github only)
+
+If your application uses OpenSSL, set environment variable 'AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO' to 1 before install.
+
+aws-crt-python does not use OpenSSL for TLS.
+On Apple and Windows devices, the OS's default TLS library is used.
+On Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
+But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
+To simplify the build process, the source code for s2n-tls and libcrypto are
+included as git submodules and built along with aws-crt-python.
+But if your application is also loading the system installation of OpenSSL
+(i.e. your application uses libcurl which uses libssl which uses libcrypto)
+there may be crashes as the application tries to use two different versions of libcrypto at once.
+
+`export AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1` will cause aws-crt-python to link against your system's existing `libcrypto`, instead of building its own copy.
+
+You can ignore all this on Windows and Apple platforms, where aws-crt-python uses the OS's default libraries for TLS and cryptography math.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ set environment variable `AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1` while building f
 ```sh
 AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1 python3 -m pip install --no-binary :all: --verbose awscrt
 ```
-( `--no-binary :all:` ensures you do not use the wheel from PyPI always uses AWS-LC)
+( `--no-binary :all:` ensures you do not use the precompiled wheel from PyPI)
 
 You can ignore all this on Windows and Apple platforms, where aws-crt-python
 uses the OS's default libraries for TLS and cryptography math.

--- a/README.md
+++ b/README.md
@@ -40,22 +40,25 @@ aws-crt-python does not use OpenSSL for TLS.
 On Apple and Windows devices, the OS's default TLS library is used.
 On Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
 But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
+
 You can ignore all this on Windows and Apple platforms, where aws-crt-python
 uses the OS's default libraries for TLS and cryptography math.
+
 To simplify installation, aws-crt-python has its own copy of libcrypto.
 This lets you install a wheel from PyPI without having OpenSSL installed.
 Unix wheels on PyPI come with libcrypto statically compiled in.
 Code to build libcrypto comes from [AWS-LC](https://github.com/aws/aws-lc).
 AWS-LC's code is included in the PyPI source package, 
 and the git repository includes it as a submodule.
+
 If you need aws-crt-python to use the libcrypto included on your system, 
 set environment variable `AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1` while building from source:
 
 ```sh
 AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1 python3 -m pip install --no-binary :all: --verbose awscrt
 ```
-
 ( `--no-binary :all:` ensures you do not use the wheel from PyPI always uses AWS-LC)
+
 You can ignore all this on Windows and Apple platforms, where aws-crt-python
 uses the OS's default libraries for TLS and cryptography math.
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ On Apple and Windows devices, the OS's default TLS library is used.
 On Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
 But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
 
-You can ignore all this on Windows and Apple platforms, where aws-crt-python
-uses the OS's default libraries for TLS and cryptography math.
-
 To simplify installation, aws-crt-python has its own copy of libcrypto.
 This lets you install a wheel from PyPI without having OpenSSL installed.
 Unix wheels on PyPI come with libcrypto statically compiled in.

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -25,12 +25,12 @@ set(BUILD_TESTING OFF)
 # On Unix we use S2N for TLS and AWS-LC crypto.
 # (On Windows and Apple we use the default OS libraries)
 if(UNIX AND NOT APPLE)
-    set(DISABLE_GO ON) # Build without using Go, we don't want the extra dependency
-    set(DISABLE_PERL ON) # Build without using Perl, we don't want the extra dependency
-    set(BUILD_LIBSSL OFF) # Don't need libssl, only need libcrypto
-
     option(USE_OPENSSL "Set this if you want to use your system's OpenSSL compatible libcrypto" OFF)
-    if (NOT USE_OPENSSL)
+
+    if(NOT USE_OPENSSL)
+        set(DISABLE_GO ON) # Build without using Go, we don't want the extra dependency
+        set(DISABLE_PERL ON) # Build without using Perl, we don't want the extra dependency
+        set(BUILD_LIBSSL OFF) # Don't need libssl, only need libcrypto
         add_subdirectory(aws-lc)
     endif()
 

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -28,7 +28,11 @@ if(UNIX AND NOT APPLE)
     set(DISABLE_GO ON) # Build without using Go, we don't want the extra dependency
     set(DISABLE_PERL ON) # Build without using Perl, we don't want the extra dependency
     set(BUILD_LIBSSL OFF) # Don't need libssl, only need libcrypto
-    add_subdirectory(aws-lc)
+
+    option(USE_OPENSSL "Set this if you want to use your system's OpenSSL compatible libcrypto" OFF)
+    if (NOT USE_OPENSSL)
+        add_subdirectory(aws-lc)
+    endif()
 
     set(UNSAFE_TREAT_WARNINGS_AS_ERRORS OFF)
     add_subdirectory(s2n)

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ def get_cmake_path():
 def using_system_libcrypto():
     return 'AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO' in os.environ
 
+
 class AwsLib:
     def __init__(self, name, extra_cmake_args=[], libname=None):
         self.name = name

--- a/setup.py
+++ b/setup.py
@@ -312,6 +312,7 @@ def awscrt_ext():
         # OpenBSD doesn't have librt; functions are found in libc instead.
         if not sys.platform.startswith('openbsd'):
             libraries += ['rt']
+
         if using_system_libcrypto():
             libraries += ['crypto']
 

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ def get_cmake_path():
 
 
 def using_system_libcrypto():
-    return 'AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO' in os.environ
+    return os.getenv('AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO') == '1'
 
 
 class AwsLib:
@@ -313,13 +313,12 @@ def awscrt_ext():
         if not sys.platform.startswith('openbsd'):
             libraries += ['rt']
 
+        # hide the symbols from libcrypto.a
+        # this prevents weird crashes if an application also ends up using
+        # libcrypto.so from the system's OpenSSL installation.
+        extra_link_args += ['-Wl,--exclude-libs,libcrypto.a']
         if using_system_libcrypto():
             extra_link_args += ['-lcrypto']
-        else:
-            # hide the symbols from libcrypto.a
-            # this prevents weird crashes if an application also ends up using
-            # libcrypto.so from the system's OpenSSL installation.
-            extra_link_args += ['-Wl,--exclude-libs,libcrypto.a']
 
         # python usually adds -pthread automatically, but we've observed
         # rare cases where that didn't happen, so let's be explicit.

--- a/setup.py
+++ b/setup.py
@@ -121,8 +121,8 @@ def get_cmake_path():
     raise Exception("CMake must be installed to build from source.")
 
 
-use_openssl = os.environ.get('AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO', False)
-
+def using_system_libcrypto():
+    return 'AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO' in os.environ
 
 class AwsLib:
     def __init__(self, name, extra_cmake_args=[], libname=None):
@@ -135,7 +135,7 @@ class AwsLib:
 # They're built along with the extension.
 AWS_LIBS = []
 if sys.platform != 'darwin' and sys.platform != 'win32':
-    if not use_openssl:
+    if not using_system_libcrypto():
         # aws-lc produces libcrypto.a
         AWS_LIBS.append(AwsLib('aws-lc', libname='crypto'))
     AWS_LIBS.append(AwsLib('s2n'))
@@ -186,7 +186,7 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
             f'-DCMAKE_BUILD_TYPE={build_type}',
         ])
 
-        if use_openssl:
+        if using_system_libcrypto():
             cmake_args.append('-DUSE_OPENSSL=ON')
 
         if sys.platform == 'darwin':
@@ -312,7 +312,7 @@ def awscrt_ext():
         if not sys.platform.startswith('openbsd'):
             libraries += ['rt']
 
-        if use_openssl:
+        if using_system_libcrypto():
             extra_link_args += ['-lcrypto']
         else:
             # hide the symbols from libcrypto.a

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ def get_cmake_path():
     raise Exception("CMake must be installed to build from source.")
 
 
-use_openssl = os.environ.get('USE_OPENSSL', False)
+use_openssl = os.environ.get('AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO', False)
 
 
 class AwsLib:

--- a/setup.py
+++ b/setup.py
@@ -256,8 +256,11 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
         else:
             print("Skip building dependencies, source not found.")
 
-        # update paths so awscrt_ext can access dependencies
-        self.include_dirs.append(os.path.join(dep_install_path, 'include'))
+        # update paths so awscrt_ext can access dependencies.
+        # add to the front of any list so that our dependencies are preferred
+        # over anything that might already be on the system (i.e. libcrypto.a)
+
+        self.include_dirs.insert(0, os.path.join(dep_install_path, 'include'))
 
         # some platforms (ex: fedora) use /lib64 instead of just /lib
         lib_dir = 'lib'
@@ -266,7 +269,7 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
         if is_32bit() and os.path.exists(os.path.join(dep_install_path, 'lib32')):
             lib_dir = 'lib32'
 
-        self.library_dirs.append(os.path.join(dep_install_path, lib_dir))
+        self.library_dirs.insert(0, os.path.join(dep_install_path, lib_dir))
 
         # continue with normal build_ext.run()
         super().run()


### PR DESCRIPTION
original: https://github.com/awslabs/aws-crt-python/pull/454

- Use `AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO` as the env var name instead
- Added CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
