### PR TITLE
X509 binding

### DIFF
--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -364,6 +364,58 @@ class AwsCredentialsProvider(AwsCredentialsProviderBase):
             http_proxy_options)
         return cls(binding)
 
+    @classmethod
+    def new_x509(
+            cls,
+            *,
+            endpoint: str,
+            thing_name: str,
+            role_alias: str,
+            tls_ctx: awscrt.io.ClientTlsContext,
+            client_bootstrap: Optional[ClientBootstrap] = None,
+            http_proxy_options: Optional[HttpProxyOptions] = None):
+        """
+        Creates a provider that sources credentials from IoT's X509 credentials service.
+
+        Args:
+            endpoint (str): Cognito Identity service regional endpoint to source credentials from.
+                            This is a per-account value that can be determined via the CLI:
+                            `aws iot describe-endpoint --endpoint-type iot:CredentialProvider`
+
+            thing_name (str): The name of the IoT thing to use to fetch credentials.
+
+            role_alias (str): The name of the role alias to fetch credentials through.
+
+            tls_ctx (ClientTlsContext): The client TLS context to use when establishing the http connection to IoT's X509 credentials service.
+
+            client_bootstrap (Optional[ClientBootstrap]): Client bootstrap to use when initiating a socket connection.
+                If not set, uses the static default ClientBootstrap instead.
+
+            http_proxy_options (Optional[HttpProxyOptions]): Optional HTTP proxy options.
+                If None is provided then an HTTP proxy is not used.
+
+        Returns:
+            AwsCredentialsProvider:
+        """
+
+        assert isinstance(endpoint, str)
+        assert isinstance(thing_name, str)
+        assert isinstance(role_alias, str)
+        assert isinstance(tls_ctx, ClientTlsContext)
+        assert isinstance(http_proxy_options, HttpProxyOptions) or http_proxy_options is None
+        if client_bootstrap is None:
+            client_bootstrap = ClientBootstrap.get_or_create_static_default()
+        assert isinstance(client_bootstrap, ClientBootstrap)
+
+        binding = _awscrt.credentials_provider_new_x509(
+            endpoint,
+            thing_name,
+            role_alias,
+            tls_ctx,
+            client_bootstrap,
+            http_proxy_options)
+        return cls(binding)
+
     def get_credentials(self):
         """
         Asynchronously fetch AwsCredentials.

--- a/source/auth.h
+++ b/source/auth.h
@@ -23,6 +23,7 @@ PyObject *aws_py_credentials_provider_new_environment(PyObject *self, PyObject *
 PyObject *aws_py_credentials_provider_new_chain(PyObject *self, PyObject *args);
 PyObject *aws_py_credentials_provider_new_delegate(PyObject *self, PyObject *args);
 PyObject *aws_py_credentials_provider_new_cognito(PyObject *self, PyObject *args);
+PyObject *aws_py_credentials_provider_new_x509(PyObject *self, PyObject *args);
 
 PyObject *aws_py_signing_config_new(PyObject *self, PyObject *args);
 PyObject *aws_py_signing_config_get_algorithm(PyObject *self, PyObject *args);

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -11,6 +11,7 @@
 #include <aws/auth/credentials.h>
 #include <aws/common/string.h>
 #include <aws/http/proxy.h>
+#include <aws/io/tls_channel_handler.h>
 
 static const char *s_capsule_name_credentials = "aws_credentials";
 static const char *s_capsule_name_credentials_provider = "aws_credentials_provider";
@@ -803,6 +804,101 @@ PyObject *aws_py_credentials_provider_new_cognito(PyObject *self, PyObject *args
 done:
     Py_XDECREF(logins_pyseq);
     aws_mem_release(allocator, logins_carray);
+
+    if (success) {
+        return capsule;
+    }
+
+    Py_XDECREF(capsule);
+    return NULL;
+}
+
+PyObject *aws_py_credentials_provider_new_x509(PyObject *self, PyObject *args) {
+    (void)self;
+    struct aws_allocator *allocator = aws_py_get_allocator();
+
+    struct aws_byte_cursor endpoint_cursor;
+    AWS_ZERO_STRUCT(endpoint_cursor);
+    struct aws_byte_cursor thing_name_cursor;
+    AWS_ZERO_STRUCT(thing_name_cursor);
+    struct aws_byte_cursor role_alias_cursor;
+    AWS_ZERO_STRUCT(role_alias_cursor);
+    PyObject *tls_context_py = NULL;
+    PyObject *client_bootstrap_py = NULL;
+    PyObject *http_proxy_options_py = NULL;
+    struct aws_tls_connection_options tls_connection_options;
+    AWS_ZERO_STRUCT(tls_connection_options);
+
+    if (!PyArg_ParseTuple(
+            args,
+            "s#s##sOOO",
+            &endpoint_cursor.ptr,   /* s */
+            &endpoint_cursor.len,   /* # */
+            &thing_name_cursor.ptr, /* s */
+            &thing_name_cursor.len, /* # */
+            &role_alias_cursor.ptr, /* s */
+            &role_alias_cursor.len, /* # */
+            &tls_context_py,        /* O */
+            &client_bootstrap_py,   /* O */
+            &http_proxy_options_py /* O */)) {
+        return NULL;
+    }
+
+    struct aws_client_bootstrap *bootstrap = aws_py_get_client_bootstrap(client_bootstrap_py);
+    if (!bootstrap) {
+        return NULL;
+    }
+
+    struct aws_tls_ctx *tls_context = aws_py_get_tls_ctx(tls_context_py);
+    if (!tls_context) {
+        return NULL;
+    }
+
+    /* From hereon, we need to clean up if errors occur.
+     * Fortunately, the capsule destructor will clean up anything stored inside the binding */
+    PyObject *capsule = NULL;
+    bool success = false;
+    aws_tls_connection_options_init_from_ctx(&tls_connection_options, tls_context);
+
+    struct aws_http_proxy_options http_proxy_options_storage;
+    struct aws_http_proxy_options *http_proxy_options = NULL;
+    if (http_proxy_options_py != Py_None) {
+        http_proxy_options = &http_proxy_options_storage;
+        if (!aws_py_http_proxy_options_init(http_proxy_options, http_proxy_options_py)) {
+            goto done;
+        }
+    }
+
+    struct credentials_provider_binding *binding = NULL;
+    capsule = s_new_credentials_provider_binding_and_capsule(&binding);
+    if (!capsule) {
+        goto done;
+    }
+
+    struct aws_credentials_provider_x509_options options = {
+        .endpoint = endpoint_cursor,
+        .thing_name = thing_name_cursor,
+        .role_alias = role_alias_cursor,
+        .shutdown_options =
+            {
+                .shutdown_callback = s_credentials_provider_shutdown_complete,
+                .shutdown_user_data = binding,
+            },
+        .tls_connection_options = &tls_connection_options,
+        .bootstrap = bootstrap,
+        .proxy_options = http_proxy_options,
+    };
+
+    binding->native = aws_credentials_provider_new_x509(allocator, &options);
+    if (!binding->native) {
+        PyErr_SetAwsLastError();
+        goto done;
+    }
+
+    success = true;
+
+done:
+    aws_tls_connection_options_clean_up(&tls_connection_options);
 
     if (success) {
         return capsule;

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -831,7 +831,7 @@ PyObject *aws_py_credentials_provider_new_x509(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "s#s##sOOO",
+            "s#s#s#OOO",
             &endpoint_cursor.ptr,   /* s */
             &endpoint_cursor.len,   /* # */
             &thing_name_cursor.ptr, /* s */
@@ -894,16 +894,13 @@ PyObject *aws_py_credentials_provider_new_x509(PyObject *self, PyObject *args) {
         PyErr_SetAwsLastError();
         goto done;
     }
-
     success = true;
 
 done:
     aws_tls_connection_options_clean_up(&tls_connection_options);
-
     if (success) {
         return capsule;
     }
-
     Py_XDECREF(capsule);
     return NULL;
 }

--- a/source/module.c
+++ b/source/module.c
@@ -770,6 +770,7 @@ static PyMethodDef s_module_methods[] = {
     AWS_PY_METHOD_DEF(credentials_provider_new_chain, METH_VARARGS),
     AWS_PY_METHOD_DEF(credentials_provider_new_delegate, METH_VARARGS),
     AWS_PY_METHOD_DEF(credentials_provider_new_cognito, METH_VARARGS),
+    AWS_PY_METHOD_DEF(credentials_provider_new_x509, METH_VARARGS),
     AWS_PY_METHOD_DEF(signing_config_new, METH_VARARGS),
     AWS_PY_METHOD_DEF(signing_config_get_algorithm, METH_VARARGS),
     AWS_PY_METHOD_DEF(signing_config_get_signature_type, METH_VARARGS),

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -296,7 +296,7 @@ class ProxyHttpTest(NativeResourceTest):
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 
-    def _create_x509_tls_context_opts():
+    def _create_x509_tls_context_opts(self):
         tls_ctx_opt = TlsContextOptions.create_client_with_mtls_from_path(
             ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH,
             ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH)

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -296,12 +296,11 @@ class ProxyHttpTest(NativeResourceTest):
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 
-
     def _create_x509_tls_context_opts(alpn_list=None):
         tls_ctx_opt = TlsContextOptions.create_client_with_mtls_from_path(
             ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH,
             ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH)
-        if (alpn_list != None):
+        if (alpn_list is not None):
             tls_conn_opt.alpn_list = alpn_list
         tls_ctx = ClientTlsContext(tls_ctx_opt)
         tls_conn_opt = tls_ctx.new_connection_options()
@@ -322,26 +321,33 @@ class ProxyHttpTest(NativeResourceTest):
         )
         return credentials
 
-    def _do_credentials_provider_test(self, provider : AwsCredentialsProvider):
+    def _do_credentials_provider_test(self, provider: AwsCredentialsProvider):
         try:
-            credentials = provider.get_credentials().result(300) # wait 5 minutes
+            credentials = provider.get_credentials().result(300)  # wait 5 minutes
             self.assertNotEqual(credentials, None, "Credentials returned was none")
         except Exception as e:
             raise RuntimeError(e)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(), "Requires Proxy, MQTT, and X509 test env vars")
+    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(),
+                     "Requires Proxy, MQTT, and X509 test env vars")
     def test_x509_credentials_tunneling_proxy_no_auth(self):
-        provider = self._build_proxied_x509_credentials(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Nothing)
+        provider = self._build_proxied_x509_credentials(
+            ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Nothing)
         self._do_credentials_provider_test(provider)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(), "Requires Proxy, MQTT, and X509 test env vars")
+    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(),
+                     "Requires Proxy, MQTT, and X509 test env vars")
     def test_x509_credentials_tunneling_proxy_double_tls_no_auth(self):
-        provider = self._build_proxied_x509_credentials(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
+        provider = self._build_proxied_x509_credentials(
+            ProxyTestType.TUNNELING_DOUBLE_TLS,
+            HttpProxyAuthenticationType.Nothing)
         self._do_credentials_provider_test(provider)
 
-    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(), "Requires Proxy, MQTT, and X509 test env vars")
+    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(),
+                     "Requires Proxy, MQTT, and X509 test env vars")
     def test_x509_credentials_tunneling_proxy_basic_auth(self):
-        provider = self._build_proxied_x509_credentials(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Basic)
+        provider = self._build_proxied_x509_credentials(
+            ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Basic)
         self._do_credentials_provider_test(provider)
 
 

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -5,6 +5,7 @@ from test import NativeResourceTest, TIMEOUT
 from awscrt.http import HttpProxyOptions, HttpProxyAuthenticationType, HttpProxyConnectionType, HttpClientConnection, HttpClientStream, HttpRequest
 from awscrt.io import init_logging, LogLevel, ClientTlsContext, TlsContextOptions, ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup
 from awscrt.mqtt import Client, Connection
+from awscrt.auth import AwsCredentialsProvider
 import os
 import unittest
 from test.test_http_client import Response
@@ -29,6 +30,10 @@ from test.test_mqtt import create_client_id
 # AWS_TEST_TLS_CERT_PATH - file path to certificate used to initialize the tls context of the mqtt connection
 # AWS_TEST_TLS_KEY_PATH - file path to the key used to initialize the tls context of the mqtt connection
 # AWS_TEST_TLS_ROOT_CERT_PATH - file path to the root CA used to initialize the tls context of the mqtt connection
+
+# AWS_TEST_X509_ENDPOINT - AWS account-specific endpoint to source x509 credentials from
+# AWS_TEST_X509_THING_NAME - associated name of the x509 thing
+# AWS_TEST_X509_ROLE_ALIAS - associated role alias ...
 
 # AWS_TEST_IOT_MQTT_ENDPOINT - AWS account-specific endpoint to connect to IoT core by
 
@@ -59,6 +64,10 @@ class ProxyTestConfiguration():
     HTTP_PROXY_TLS_KEY_PATH = os.environ.get('AWS_TEST_TLS_KEY_PATH')
     HTTP_PROXY_TLS_ROOT_CA_PATH = os.environ.get('AWS_TEST_TLS_ROOT_CERT_PATH')
 
+    X509_CREDENTIALS_ENDPOINT = os.environ.get("AWS_TEST_X509_ENDPOINT")
+    X509_CREDENTIALS_THING_NAME = os.environ.get("AWS_TEST_X509_THING_NAME")
+    X509_CREDENTIALS_ROLE_ALIAS = os.environ.get("AWS_TEST_X509_ROLE_ALIAS")
+
     HTTP_PROXY_MQTT_ENDPOINT = os.environ.get('AWS_TEST_IOT_MQTT_ENDPOINT')
 
     @staticmethod
@@ -78,7 +87,15 @@ class ProxyTestConfiguration():
             ProxyTestConfiguration.HTTP_PROXY_MQTT_ENDPOINT is not None and \
             ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH is not None and \
             ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH is not None and \
-            ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH is not None
+            ProxyTestConfiguration.HTTP_PROXY_TLS_ROOT_CA_PATH is not None
+
+    @staticmethod
+    def is_x509_env_initialized():
+        return ProxyTestConfiguration.is_proxy_environment_initialized() and \
+            ProxyTestConfiguration.is_mqtt_env_initialized() and \
+            ProxyTestConfiguration.X509_CREDENTIALS_ENDPOINT is not None and \
+            ProxyTestConfiguration.X509_CREDENTIALS_THING_NAME is not None and \
+            ProxyTestConfiguration.X509_CREDENTIALS_ROLE_ALIAS is not None
 
     @staticmethod
     def get_proxy_host_for_test(test_type, auth_type):
@@ -278,6 +295,54 @@ class ProxyHttpTest(NativeResourceTest):
     @unittest.skipIf(not ProxyTestConfiguration.is_mqtt_env_initialized(), 'requires proxy and MQTT test env vars')
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
+
+
+    def _create_x509_tls_context_opts(alpn_list=None):
+        tls_ctx_opt = TlsContextOptions.create_client_with_mtls_from_path(
+            ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH,
+            ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH)
+        if (alpn_list != None):
+            tls_conn_opt.alpn_list = alpn_list
+        tls_ctx = ClientTlsContext(tls_ctx_opt)
+        tls_conn_opt = tls_ctx.new_connection_options()
+        return tls_conn_opt
+
+    def _build_proxied_x509_credentials(self, test_type, auth_type):
+        event_loop_group = EventLoopGroup(num_threads=1)
+        resolver = DefaultHostResolver(event_loop_group=event_loop_group)
+        bootstrap = ClientBootstrap(event_loop_group=event_loop_group, host_resolver=resolver)
+        proxy_options = ProxyTestConfiguration.create_http_proxy_options_from_environment(test_type, auth_type)
+        credentials = AwsCredentialsProvider.new_x509(
+            endpoint=ProxyTestConfiguration.X509_CREDENTIALS_ENDPOINT,
+            thing_name=ProxyTestConfiguration.X509_CREDENTIALS_THING_NAME,
+            role_alias=ProxyTestConfiguration.X509_CREDENTIALS_ROLE_ALIAS,
+            tls_ctx=ClientTlsContext(self._create_x509_tls_context_opts()),
+            client_bootstrap=bootstrap,
+            http_proxy_options=proxy_options
+        )
+        return credentials
+
+    def _do_credentials_provider_test(self, provider : AwsCredentialsProvider):
+        try:
+            credentials = provider.get_credentials().result(300) # wait 5 minutes
+            self.assertNotEqual(credentials, None, "Credentials returned was none")
+        except Exception as e:
+            raise RuntimeError(e)
+
+    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(), "Requires Proxy, MQTT, and X509 test env vars")
+    def test_x509_credentials_tunneling_proxy_no_auth(self):
+        provider = self._build_proxied_x509_credentials(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Nothing)
+        self._do_credentials_provider_test(provider)
+
+    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(), "Requires Proxy, MQTT, and X509 test env vars")
+    def test_x509_credentials_tunneling_proxy_double_tls_no_auth(self):
+        provider = self._build_proxied_x509_credentials(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
+        self._do_credentials_provider_test(provider)
+
+    @unittest.skipIf(not ProxyTestConfiguration.is_x509_env_initialized(), "Requires Proxy, MQTT, and X509 test env vars")
+    def test_x509_credentials_tunneling_proxy_basic_auth(self):
+        provider = self._build_proxied_x509_credentials(ProxyTestType.TUNNELING_HTTPS, HttpProxyAuthenticationType.Basic)
+        self._do_credentials_provider_test(provider)
 
 
 if __name__ == '__main__':

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -296,12 +296,10 @@ class ProxyHttpTest(NativeResourceTest):
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 
-    def _create_x509_tls_context_opts(alpn_list=None):
+    def _create_x509_tls_context_opts():
         tls_ctx_opt = TlsContextOptions.create_client_with_mtls_from_path(
             ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH,
             ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH)
-        if (alpn_list is not None):
-            tls_conn_opt.alpn_list = alpn_list
         tls_ctx = ClientTlsContext(tls_ctx_opt)
         tls_conn_opt = tls_ctx.new_connection_options()
         return tls_conn_opt

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -296,24 +296,23 @@ class ProxyHttpTest(NativeResourceTest):
     def test_tunneling_http_proxy_mqtt_double_tls(self):
         self._do_proxy_mqtt_test(ProxyTestType.TUNNELING_DOUBLE_TLS, HttpProxyAuthenticationType.Nothing)
 
-    def _create_x509_tls_context_opts(self):
+    def _create_x509_client_tls_context(self):
         tls_ctx_opt = TlsContextOptions.create_client_with_mtls_from_path(
             ProxyTestConfiguration.HTTP_PROXY_TLS_CERT_PATH,
             ProxyTestConfiguration.HTTP_PROXY_TLS_KEY_PATH)
-        tls_ctx = ClientTlsContext(tls_ctx_opt)
-        tls_conn_opt = tls_ctx.new_connection_options()
-        return tls_conn_opt
+        return ClientTlsContext(tls_ctx_opt)
 
     def _build_proxied_x509_credentials(self, test_type, auth_type):
         event_loop_group = EventLoopGroup(num_threads=1)
         resolver = DefaultHostResolver(event_loop_group=event_loop_group)
         bootstrap = ClientBootstrap(event_loop_group=event_loop_group, host_resolver=resolver)
         proxy_options = ProxyTestConfiguration.create_http_proxy_options_from_environment(test_type, auth_type)
+        client_tls_ctx = self._create_x509_client_tls_context()
         credentials = AwsCredentialsProvider.new_x509(
             endpoint=ProxyTestConfiguration.X509_CREDENTIALS_ENDPOINT,
             thing_name=ProxyTestConfiguration.X509_CREDENTIALS_THING_NAME,
             role_alias=ProxyTestConfiguration.X509_CREDENTIALS_ROLE_ALIAS,
-            tls_ctx=ClientTlsContext(self._create_x509_tls_context_opts()),
+            tls_ctx=client_tls_ctx,
             client_bootstrap=bootstrap,
             http_proxy_options=proxy_options
         )


### PR DESCRIPTION
*Description of changes:*

Binds X509 support to the Python AWS credentials provider and adds the tests to make sure it works as expected (modeled tests to be like those in Java).

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
