### PR TITLE
Remove linker hack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -306,9 +306,6 @@ def awscrt_ext():
         extra_link_args += ['-framework', 'Security']
 
     else:  # unix
-        # linker will prefer shared libraries over static if it can find both.
-        # force linker to choose static variant by using using "-l:libcrypto.a" syntax instead of just "-lcrypto".
-        libraries = [':lib{}.a'.format(x) for x in libraries]
         # OpenBSD doesn't have librt; functions are found in libc instead.
         if not sys.platform.startswith('openbsd'):
             libraries += ['rt']


### PR DESCRIPTION
This hack was an attempt to work around a long-standing bug where we had our include-paths and linker-paths in the wrong order. This was fixed in https://github.com/awslabs/aws-crt-python/pull/455 so we don't need the hack anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
