### PR TITLE
Add Packit (https://packit.dev) configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,47 @@
+upstream_package_name: awscrt
+downstream_package_name: python-awscrt
+
+upstream_project_url: https://github.com/awslabs/aws-crt-python
+issue_repository: https://github.com/awslabs/aws-crt-python
+
+upstream_tag_template: v{version}
+
+specfile_path: fedora/python-awscrt.spec
+
+files_to_sync:
+  - fedora/python-awscrt.spec
+  - .packit.yaml
+
+copy_upstream_release_description: true
+
+actions:
+  post-upstream-clone:
+    - git submodule update --init
+  create-archive:
+    - bash -c "sed -i \"s/^__version__ = .*/__version__ = \'${PACKIT_PROJECT_VERSION}\'/\" awscrt/__init__.py"
+    - python3 -m build --sdist --outdir ./fedora/
+    - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
+
+srpm_build_deps:
+  - python3-build
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-all
+
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-all
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-all
+
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched # rawhide updates are created automatically

--- a/fedora/python-awscrt.spec
+++ b/fedora/python-awscrt.spec
@@ -1,0 +1,79 @@
+%global desc %{expand:
+Python bindings for the AWS Common Runtime}
+
+
+Name:           python-awscrt
+Version:        0.16.16
+Release:        1%{?dist}
+
+Summary:        Python bindings for the AWS Common Runtime
+# All files are licensed under Apache-2.0, except:
+# - crt/aws-c-common/include/aws/common/external/cJSON.h is MIT
+# - crt/aws-c-common/source/external/cJSON.c is MIT
+# - crt/s2n/pq-crypto/kyber_r3/KeccakP-brg_endian_avx2.h is BSD-3-Clause
+License:        Apache-2.0 AND MIT AND BSD-3-Clause
+URL:            https://github.com/awslabs/aws-crt-python
+
+Source0:        %{pypi_source awscrt}
+
+# one test requires internet connection, skip it
+Patch0:         skip-test-requiring-network.patch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  openssl-devel
+
+BuildRequires:  python%{python3_pkgversion}-websockets
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=2180988
+ExcludeArch:    s390x
+
+
+%description
+%{desc}
+
+
+%package -n python%{python3_pkgversion}-awscrt
+Summary:        %{summary}
+
+
+%description -n python%{python3_pkgversion}-awscrt
+%{desc}
+
+
+%prep
+%autosetup -p1 -n awscrt-%{version}
+
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+
+%build
+%ifarch %{ix86}
+# disable SSE2 instructions to prevent a crash in aws-c-common thread handling
+# probably caused by a compiler bug
+export CFLAGS="%{optflags} -mno-sse2"
+%endif
+export AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files _awscrt awscrt
+
+
+%check
+PYTHONPATH="%{buildroot}%{python3_sitearch}:%{buildroot}%{python3_sitelib}" %{python3} -m unittest
+
+
+%files -n python%{python3_pkgversion}-awscrt -f %{pyproject_files}
+%doc README.md
+
+
+%changelog
+%autochangelog

--- a/fedora/skip-test-requiring-network.patch
+++ b/fedora/skip-test-requiring-network.patch
@@ -1,0 +1,12 @@
+diff --git a/test/test_http_client.py b/test/test_http_client.py
+index 5af87b6..dd2631a 100644
+--- a/test/test_http_client.py
++++ b/test/test_http_client.py
+@@ -347,6 +347,7 @@ class TestClient(NativeResourceTest):
+                                                      tls_connection_options=tls_conn_opt)
+         return connection_future.result(self.timeout)
+ 
++    @unittest.skip("Requires network")
+     def test_h2_client(self):
+         url = urlparse("https://d1cz66xoahf9cl.cloudfront.net/http_test_doc.txt")
+         connection = self._new_h2_client_connection(url)


### PR DESCRIPTION
With Packit, changes from every pull request would be automatically packaged and built as Fedora RPMs, with the test suite run as part of the build process. New releases would be automatically packaged and proposed as updates to Fedora releases.

For this to work, [Packit-as-a-Service](https://github.com/marketplace/packit-as-a-service) application needs to be installed on this GitHub organization by a person who has a FAS (Fedora Account System) account. @davdunc, if you think this is a good idea, would you be willing to do that? Here is [Packit onboarding guide](https://packit.dev/docs/guide/). If something isn't clear, feel free to ask.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
