### PR TITLE
Revert "Remove linker hack (#462)". Always link dependencies statically.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -306,6 +306,9 @@ def awscrt_ext():
         extra_link_args += ['-framework', 'Security']
 
     else:  # unix
+        # linker will prefer shared libraries over static if it can find both.
+        # force linker to choose static variant by using using "-l:libcrypto.a" syntax instead of just "-lcrypto".
+        libraries = [':lib{}.a'.format(x) for x in libraries]
         # OpenBSD doesn't have librt; functions are found in libc instead.
         if not sys.platform.startswith('openbsd'):
             libraries += ['rt']

--- a/setup.py
+++ b/setup.py
@@ -307,8 +307,15 @@ def awscrt_ext():
 
     else:  # unix
         # linker will prefer shared libraries over static if it can find both.
-        # force linker to choose static variant by using using "-l:libcrypto.a" syntax instead of just "-lcrypto".
+        # force linker to choose static variant by using using
+        # "-l:libaws-c-common.a" syntax instead of just "-laws-c-common".
+        #
+        # This helps AWS developers creating Lambda applications from Brazil.
+        # In Brazil, both shared and static libs are available.
+        # But Lambda requires all shared libs to be explicitly packaged up.
+        # So it's simpler to link them in statically and have less runtime dependencies.
         libraries = [':lib{}.a'.format(x) for x in libraries]
+
         # OpenBSD doesn't have librt; functions are found in libc instead.
         if not sys.platform.startswith('openbsd'):
             libraries += ['rt']


### PR DESCRIPTION
**Issue:**
"Remove linker hack (#462)" caused internal Amazon devs to start having issues building Lambda applications.

**Investigation:**
In Amazon's internal build system, dependencies are built as both static and shared libs. "Remove linker hack (#462)"  resulted in a switch from using static libs, to using the shared libs.

Lambda applications need all their runtime dependencies explicitly packaged up. The switch to use shared libs meant devs needed to add a lot more runtime dependencies.

**Description of changes:**
Put back code that forces dependencies to be linked statically, to keep things simple and minimize runtime dependencies.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
