### PR TITLE
Add note about resubscribe limits to api docs

### DIFF
--- a/awscrt/mqtt.py
+++ b/awscrt/mqtt.py
@@ -643,6 +643,15 @@ class Connection(NativeResource):
 
         This is to help when resuming a connection with a clean session.
 
+        **Important**: Currently the resubscribe function does not take the AWS IoT Core maximum subscriptions
+        per subscribe request quota into account. If the client has more subscriptions than the maximum,
+        resubscribing must be done manually using the `subscribe()` function for each desired topic
+        filter. The client will be disconnected by AWS IoT Core if the resubscribe exceeds the subscriptions
+        per subscribe request quota.
+
+        The AWS IoT Core maximum subscriptions per subscribe request quota is listed at the following URL:
+        https://docs.aws.amazon.com/general/latest/gr/iot-core.html#genref_max_subscriptions_per_subscribe_request
+
         Returns:
             Tuple[concurrent.futures.Future, int]: Tuple containing a Future and
             the ID of the SUBSCRIBE packet. The Future completes when a SUBACK


### PR DESCRIPTION
*Issue #, if available:*

Helps fix https://github.com/aws/aws-iot-device-sdk-python-v2/issues/420 by documenting the behavior of the resubscribe function.

*Description of changes:*

Adds documentation on the limits of the resubscribe function in relation to the AWS IoT Core limits.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
