### PR TITLE
S3 take sign config

### DIFF
--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -69,7 +69,7 @@ class S3Client(NativeResource):
                 No TLS options will be used, regardless of `tls_connection_options` value.
 
         signing_config (Optional[AwsSigningConfig]):
-             Configuration for signing of the client. Use `create_default_s3_signing_config` to create the default config.
+             Configuration for signing of the client. Use :func:`create_default_s3_signing_config()` to create the default config.
              If None is provided, the request will not be signed.
 
         credential_provider (Optional[AwsCredentialsProvider]): Deprecated, prefer `signing_config` instead.
@@ -175,7 +175,7 @@ class S3Client(NativeResource):
                 :attr:`~S3RequestType.GET_OBJECT`/:attr:`~S3RequestType.PUT_OBJECT` can be accelerated
 
             signing_config (Optional[AwsSigningConfig]):
-                Configuration for signing of the request to override the configuration from client. Use `create_default_s3_signing_config` to create the default config.
+                Configuration for signing of the request to override the configuration from client. Use :func:`create_default_s3_signing_config()` to create the default config.
                 If None is provided, the client configuration will be used.
 
             credential_provider (Optional[AwsCredentialsProvider]):  Deprecated, prefer `signing_config` instead.

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -404,13 +404,11 @@ class _S3RequestCore:
             self._on_progress_cb(progress)
 
 
-def aws_create_default_s3_signing_config(region, credential_provider):
-    assert isinstance(region, str)
-    assert isinstance(credential_provider, AwsCredentialsProvider)
+def aws_create_default_s3_signing_config(region: str, credential_provider: AwsCredentialsProvider):
     return AwsSigningConfig(
         algorithm=AwsSigningAlgorithm.V4,
         service="s3",
-        signed_body_value=AwsSignedBodyHeaderType.X_AMZ_CONTENT_SHA_256,
+        signed_body_header_type=AwsSignedBodyHeaderType.X_AMZ_CONTENT_SHA_256,
         signed_body_value=AwsSignedBodyValue.UNSIGNED_PAYLOAD,
         region=region,
         credentials_provider=credential_provider,

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -405,7 +405,7 @@ class _S3RequestCore:
 
 
 def create_default_s3_signing_config(*, region: str, credential_provider: AwsCredentialsProvider, **kwargs):
-    """Create a default :class:`AwsSigningConfig` for S3 service.
+    """Create a default `AwsSigningConfig` for S3 service.
 
         Attributes:
             region (str): The region to sign against.

--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -10,7 +10,7 @@ from concurrent.futures import Future
 from awscrt import NativeResource
 from awscrt.http import HttpRequest
 from awscrt.io import ClientBootstrap, TlsConnectionOptions
-from awscrt.auth import AwsCredentialsProvider, AwsSignedBodyHeaderType, AwsSignedBodyValue, AwsSigningAlgorithm, AwsSigningConfig
+from awscrt.auth import AwsCredentialsProvider, AwsSignatureType, AwsSignedBodyHeaderType, AwsSignedBodyValue, AwsSigningAlgorithm, AwsSigningConfig
 import awscrt.exceptions
 import threading
 from enum import IntEnum
@@ -407,6 +407,7 @@ class _S3RequestCore:
 def aws_create_default_s3_signing_config(region: str, credential_provider: AwsCredentialsProvider):
     return AwsSigningConfig(
         algorithm=AwsSigningAlgorithm.V4,
+        signature_type=AwsSignatureType.HTTP_REQUEST_HEADERS,
         service="s3",
         signed_body_header_type=AwsSignedBodyHeaderType.X_AMZ_CONTENT_SHA_256,
         signed_body_value=AwsSignedBodyValue.UNSIGNED_PAYLOAD,

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -72,8 +72,8 @@ PyObject *aws_py_s3_client_new(PyObject *self, PyObject *args) {
     struct aws_allocator *allocator = aws_py_get_allocator();
 
     PyObject *bootstrap_py = NULL;
-    PyObject *credential_provider_py = NULL;
     PyObject *signing_config_py = NULL;
+    PyObject *credential_provider_py = NULL;
     PyObject *tls_options_py = NULL;
     PyObject *on_shutdown_py = NULL;
     PyObject *py_core = NULL;
@@ -86,8 +86,8 @@ PyObject *aws_py_s3_client_new(PyObject *self, PyObject *args) {
             args,
             "OOOOOs#iKdO",
             &bootstrap_py,
-            &credential_provider_py,
             &signing_config_py,
+            &credential_provider_py,
             &tls_options_py,
             &on_shutdown_py,
             &region,

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -476,8 +476,8 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
     PyObject *s3_client_py = NULL;
     PyObject *http_request_py = NULL;
     int type;
-    PyObject *credential_provider_py = NULL;
     PyObject *signing_config_py = NULL;
+    PyObject *credential_provider_py = NULL;
     const char *recv_filepath;
     const char *send_filepath;
     const char *region;
@@ -490,8 +490,8 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
             &s3_client_py,
             &http_request_py,
             &type,
-            &credential_provider_py,
             &signing_config_py,
+            &credential_provider_py,
             &recv_filepath,
             &send_filepath,
             &region,
@@ -509,17 +509,18 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    struct aws_credentials_provider *credential_provider = NULL;
-    if (credential_provider_py != Py_None) {
-        credential_provider = aws_py_get_credentials_provider(credential_provider_py);
-        if (!credential_provider) {
-            return NULL;
-        }
-    }
     struct aws_signing_config_aws *signing_config = NULL;
     if (signing_config_py != Py_None) {
         signing_config = aws_py_get_signing_config(signing_config_py);
         if (!signing_config) {
+            return NULL;
+        }
+    }
+
+    struct aws_credentials_provider *credential_provider = NULL;
+    if (credential_provider_py != Py_None) {
+        credential_provider = aws_py_get_credentials_provider(credential_provider_py);
+        if (!credential_provider) {
             return NULL;
         }
     }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -485,7 +485,7 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
     PyObject *py_core = NULL;
     if (!PyArg_ParseTuple(
             args,
-            "OOOOiOzzs#O",
+            "OOOiOOzzs#O",
             &py_s3_request,
             &s3_client_py,
             &http_request_py,

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -477,6 +477,7 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
     PyObject *http_request_py = NULL;
     int type;
     PyObject *credential_provider_py = NULL;
+    PyObject *signing_config_py = NULL;
     const char *recv_filepath;
     const char *send_filepath;
     const char *region;
@@ -484,12 +485,13 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
     PyObject *py_core = NULL;
     if (!PyArg_ParseTuple(
             args,
-            "OOOiOzzs#O",
+            "OOOOiOzzs#O",
             &py_s3_request,
             &s3_client_py,
             &http_request_py,
             &type,
             &credential_provider_py,
+            &signing_config_py,
             &recv_filepath,
             &send_filepath,
             &region,
@@ -514,12 +516,21 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
             return NULL;
         }
     }
+    struct aws_signing_config_aws *signing_config = NULL;
+    if (signing_config_py != Py_None) {
+        signing_config = aws_py_get_signing_config(signing_config_py);
+        if (!signing_config) {
+            return NULL;
+        }
+    }
 
-    struct aws_signing_config_aws signing_config;
-    AWS_ZERO_STRUCT(signing_config);
+    struct aws_signing_config_aws signing_config_from_credentials_provider;
+    AWS_ZERO_STRUCT(signing_config_from_credentials_provider);
     if (credential_provider) {
         struct aws_byte_cursor region_cursor = aws_byte_cursor_from_array((const uint8_t *)region, region_len);
-        aws_s3_init_default_signing_config(&signing_config, region_cursor, credential_provider);
+        aws_s3_init_default_signing_config(
+            &signing_config_from_credentials_provider, region_cursor, credential_provider);
+        signing_config = &signing_config_from_credentials_provider;
     }
 
     struct s3_meta_request_binding *meta_request = aws_mem_calloc(allocator, 1, sizeof(struct s3_meta_request_binding));
@@ -566,7 +577,7 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
     struct aws_s3_meta_request_options s3_meta_request_opt = {
         .type = type,
         .message = meta_request->copied_message ? meta_request->copied_message : http_request,
-        .signing_config = credential_provider ? &signing_config : NULL,
+        .signing_config = signing_config,
         .headers_callback = s_s3_request_on_headers,
         .body_callback = s_s3_request_on_body,
         .finish_callback = s_s3_request_on_finish,

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -74,7 +74,7 @@ def s3_client_new(secure, region, part_size=0):
     host_resolver = DefaultHostResolver(event_loop_group)
     bootstrap = ClientBootstrap(event_loop_group, host_resolver)
     credential_provider = AwsCredentialsProvider.new_default_chain(bootstrap)
-    signing_config = create_default_s3_signing_config(region, credential_provider)
+    signing_config = create_default_s3_signing_config(region=region, credential_provider=credential_provider)
     tls_option = None
     if secure:
         opt = TlsContextOptions()

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -10,7 +10,7 @@ from test import NativeResourceTest
 from concurrent.futures import Future
 
 from awscrt.http import HttpHeaders, HttpRequest
-from awscrt.s3 import S3Client, S3RequestType, aws_create_default_s3_signing_config
+from awscrt.s3 import S3Client, S3RequestType, create_default_s3_signing_config
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
 from awscrt.auth import AwsCredentialsProvider, AwsSignatureType, AwsSignedBodyHeaderType, AwsSignedBodyValue, AwsSigningAlgorithm, AwsSigningConfig
 
@@ -74,7 +74,7 @@ def s3_client_new(secure, region, part_size=0):
     host_resolver = DefaultHostResolver(event_loop_group)
     bootstrap = ClientBootstrap(event_loop_group, host_resolver)
     credential_provider = AwsCredentialsProvider.new_default_chain(bootstrap)
-    signing_config = aws_create_default_s3_signing_config(region, credential_provider)
+    signing_config = create_default_s3_signing_config(region, credential_provider)
     tls_option = None
     if secure:
         opt = TlsContextOptions()

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -103,7 +103,6 @@ class FakeReadStream(object):
         return fake_data
 
 
-@unittest.skipUnless(os.environ.get('AWS_TEST_S3'), 'set env var to run test: AWS_TEST_S3')
 class S3ClientTest(NativeResourceTest):
 
     def setUp(self):

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -12,7 +12,7 @@ from concurrent.futures import Future
 from awscrt.http import HttpHeaders, HttpRequest
 from awscrt.s3 import S3Client, S3RequestType, aws_create_default_s3_signing_config
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
-from awscrt.auth import AwsCredentialsProvider, AwsSignedBodyHeaderType, AwsSignedBodyValue, AwsSigningAlgorithm, AwsSigningConfig
+from awscrt.auth import AwsCredentialsProvider, AwsSignatureType, AwsSignedBodyHeaderType, AwsSignedBodyValue, AwsSigningAlgorithm, AwsSigningConfig
 
 MB = 1024 ** 2
 GB = 1024 ** 3
@@ -456,6 +456,7 @@ class S3RequestTest(NativeResourceTest):
         # Let signer to normalize uri path for us.
         signing_config = AwsSigningConfig(
             algorithm=AwsSigningAlgorithm.V4,
+            signature_type=AwsSignatureType.HTTP_REQUEST_HEADERS,
             service="s3",
             signed_body_header_type=AwsSignedBodyHeaderType.X_AMZ_CONTENT_SHA_256,
             signed_body_value=AwsSignedBodyValue.UNSIGNED_PAYLOAD,

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -10,9 +10,9 @@ from test import NativeResourceTest
 from concurrent.futures import Future
 
 from awscrt.http import HttpHeaders, HttpRequest
-from awscrt.s3 import S3Client, S3RequestType
+from awscrt.s3 import S3Client, S3RequestType, aws_create_default_s3_signing_config
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, TlsConnectionOptions, TlsContextOptions
-from awscrt.auth import AwsCredentialsProvider
+from awscrt.auth import AwsCredentialsProvider, AwsSignedBodyHeaderType, AwsSignedBodyValue, AwsSigningAlgorithm, AwsSigningConfig
 
 MB = 1024 ** 2
 GB = 1024 ** 3
@@ -74,6 +74,7 @@ def s3_client_new(secure, region, part_size=0):
     host_resolver = DefaultHostResolver(event_loop_group)
     bootstrap = ClientBootstrap(event_loop_group, host_resolver)
     credential_provider = AwsCredentialsProvider.new_default_chain(bootstrap)
+    signing_config = aws_create_default_s3_signing_config(region, credential_provider)
     tls_option = None
     if secure:
         opt = TlsContextOptions()
@@ -83,7 +84,7 @@ def s3_client_new(secure, region, part_size=0):
     s3_client = S3Client(
         bootstrap=bootstrap,
         region=region,
-        credential_provider=credential_provider,
+        signing_config=signing_config,
         tls_connection_options=tls_option,
         part_size=part_size)
 
@@ -137,6 +138,7 @@ class S3RequestTest(NativeResourceTest):
         self.bucket_name = "aws-crt-canary-bucket"
         self.timeout = 100  # seconds
         self.num_threads = 0
+        self.special_path = "put_object_test_10MB@$%.txt"
         self.non_ascii_file_name = "ÉxÅmple.txt".encode("utf-8")
 
         self.response_headers = None
@@ -438,6 +440,49 @@ class S3RequestTest(NativeResourceTest):
         request.headers.set("Content-MD5", "something")
         self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT, "AWS_ERROR_S3_INVALID_RESPONSE_STATUS")
         self.put_body_stream.close()
+
+    def test_special_filepath_upload(self):
+        # remove the input file when request done
+        with open(self.special_path, 'wb') as file:
+            file.write(b"a" * 10 * MB)
+        request = self._put_object_request(self.special_path)
+        self.put_body_stream.close()
+        s3_client = s3_client_new(False, self.region, 5 * MB)
+        request_type = S3RequestType.PUT_OBJECT
+
+        event_loop_group = EventLoopGroup()
+        host_resolver = DefaultHostResolver(event_loop_group)
+        bootstrap = ClientBootstrap(event_loop_group, host_resolver)
+        credential_provider = AwsCredentialsProvider.new_default_chain(bootstrap)
+        # Let signer to normalize uri path for us.
+        signing_config = AwsSigningConfig(
+            algorithm=AwsSigningAlgorithm.V4,
+            service="s3",
+            signed_body_header_type=AwsSignedBodyHeaderType.X_AMZ_CONTENT_SHA_256,
+            signed_body_value=AwsSignedBodyValue.UNSIGNED_PAYLOAD,
+            region=self.region,
+            credentials_provider=credential_provider,
+            use_double_uri_encode=False,
+            should_normalize_uri_path=True,
+        )
+
+        s3_request = s3_client.make_request(
+            request=request,
+            type=request_type,
+            send_filepath=self.special_path.decode("utf-8"),
+            signing_config=signing_config,
+            on_headers=self._on_request_headers,
+            on_progress=self._on_progress)
+        finished_future = s3_request.finished_future
+        finished_future.result(self.timeout)
+
+        # check result
+        self.assertEqual(
+            self.data_len,
+            self.transferred_len,
+            "the transferred length reported does not match body we sent")
+        self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
+        os.remove(self.special_path)
 
     def test_non_ascii_filepath_upload(self):
         # remove the input file when request done

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -469,7 +469,7 @@ class S3RequestTest(NativeResourceTest):
         s3_request = s3_client.make_request(
             request=request,
             type=request_type,
-            send_filepath=self.special_path.decode("utf-8"),
+            send_filepath=self.special_path,
             signing_config=signing_config,
             on_headers=self._on_request_headers,
             on_progress=self._on_progress)


### PR DESCRIPTION
- S3 configurations now takes signing config for more control of the signing process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
