### PR TITLE
Use on_connection_* callbacks from aws-c-mqtt

### DIFF
--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -400,18 +400,18 @@ class MqttConnectionTest(NativeResourceTest):
         test_tls_opts = TlsContextOptions.create_client_with_mtls_from_path(test_input_cert, test_input_key)
         test_tls = ClientTlsContext(test_tls_opts)
 
-        onConnectionSuccessFuture = Future()
-        onConnectionClosedFuture = Future()
+        on_connection_success_future = Future()
+        on_connection_closed_future = Future()
 
         def on_connection_success_callback(connection, callback_data: OnConnectionSuccessData):
-            onConnectionSuccessFuture.set_result(
+            on_connection_success_future.set_result(
                 {'return_code': callback_data.return_code, "session_present": callback_data.session_present})
 
         def on_connection_failure_callback(connection, callback_data: OnConnectionFailureData):
             pass
 
         def on_connection_closed_callback(connection, callback_data: OnConnectionClosedData):
-            onConnectionClosedFuture.set_result({})
+            on_connection_closed_future.set_result({})
 
         connection = self._create_connection(
             endpoint=test_input_endpoint,
@@ -420,11 +420,11 @@ class MqttConnectionTest(NativeResourceTest):
             on_connection_failure_callback=on_connection_failure_callback,
             on_connection_closed_callback=on_connection_closed_callback)
         connection.connect().result(TIMEOUT)
-        successData = onConnectionSuccessFuture.result(TIMEOUT)
-        self.assertEqual(successData['return_code'], ConnectReturnCode.ACCEPTED)
-        self.assertEqual(successData['session_present'], False)
+        success_data = on_connection_success_future.result(TIMEOUT)
+        self.assertEqual(success_data['return_code'], ConnectReturnCode.ACCEPTED)
+        self.assertEqual(success_data['session_present'], False)
         connection.disconnect().result(TIMEOUT)
-        onConnectionClosedFuture.result(TIMEOUT)
+        on_connection_closed_future.result(TIMEOUT)
 
     def test_connect_disconnect_with_callbacks_unhappy(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -504,6 +504,7 @@ class MqttConnectionTest(NativeResourceTest):
         self.assertEqual(success_data['return_code'], ConnectReturnCode.ACCEPTED)
         self.assertEqual(success_data['session_present'], False)
 
+        # Reset the future for the reconnect attempt.
         on_connection_success_future = Future()
 
         on_connection_success_future_dup = Future()

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -436,13 +436,13 @@ class MqttConnectionTest(NativeResourceTest):
         test_tls_opts = TlsContextOptions.create_client_with_mtls_from_path(test_input_cert, test_input_key)
         test_tls = ClientTlsContext(test_tls_opts)
 
-        onConnectionFailureFuture = Future()
+        on_onnection_failure_future = Future()
 
         def on_connection_success_callback(connection, callback_data: OnConnectionSuccessData):
             pass
 
         def on_connection_failure_callback(connection, callback_data: OnConnectionFailureData):
-            onConnectionFailureFuture.set_result({'error': callback_data.error})
+            on_onnection_failure_future.set_result({'error': callback_data.error})
 
         def on_connection_closed_callback(connection, callback_data: OnConnectionClosedData):
             pass
@@ -462,15 +462,15 @@ class MqttConnectionTest(NativeResourceTest):
             exception_occurred = True
         self.assertTrue(exception_occurred, "Exception did not occur when connecting with invalid arguments!")
 
-        failureData = onConnectionFailureFuture.result(TIMEOUT)
-        self.assertTrue(failureData['error'] is not None)
+        failure_data = on_onnection_failure_future.result(TIMEOUT)
+        self.assertTrue(failure_data['error'] is not None)
 
     def test_connect_disconnect_with_callbacks_happy_on_resume(self):
         # Check that an on_connection_success callback fires on a resumed connection.
 
-        # NOTE Since there is no mocked server available on this level, the only sensible approach is to interrupt
-        # a connection, and wait for it to be resumed automatically. For that, another connection with the same
-        # client_id connects to the server and then immediately disconnects.
+        # NOTE Since there is no mocked server available on this abstraction level, the only sensible approach
+        # is to interrupt a connection, and wait for it to be resumed automatically. For that, another client
+        # with the same client_id connects to the server and then immediately disconnects.
 
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
@@ -511,7 +511,7 @@ class MqttConnectionTest(NativeResourceTest):
         def on_connection_success_callback_dup(connection, callback_data: OnConnectionSuccessData):
             on_connection_success_future_dup.set_result({})
 
-        # Reuse the same client_id to displace the first connection.
+        # Reuse the same client_id to displace the first client.
         connection_dup = self._create_connection(
             endpoint=test_input_endpoint,
             tls_context=test_tls,


### PR DESCRIPTION
*Description of changes:*

Expose the new on_connection_success and on_connection_failure aws-c-mqtt callbacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
