### PR TITLE
Improved error-handling in S3 completion callback

### DIFF
--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -276,7 +276,6 @@ PyObject *aws_py_mqtt_client_connection_new(PyObject *self, PyObject *args) {
 
     struct aws_allocator *allocator = aws_py_get_allocator();
 
-    PyObject *self_proxy;
     PyObject *self_py;
     PyObject *client_py;
     PyObject *use_websocket_py;
@@ -307,6 +306,7 @@ PyObject *aws_py_mqtt_client_connection_new(PyObject *self, PyObject *args) {
     }
 
     /* From hereon, we need to clean up if errors occur */
+    PyObject *self_proxy = NULL;
 
     if (client_version == 3) {
         py_connection->native = aws_mqtt_client_connection_new(client);


### PR DESCRIPTION
**Issue:**
A user experienced random downloads hanging. I looked at their code and saw that an exception in their completion callback could lead to a hang, since later code was never executed. Then I looked at our code and saw a theoretical place where the same kinda thing could happen, an error could prevent us invoking the completion callback.

**Description of changes:**
- Always invoke the completion callback, even if we failed to turn the error_response_headers into PyObjects. These headers are optional anyway.
- Use nice new error code AWS_ERROR_FILE_WRITE_FAILURE if file write fails.
- Raise error if file close fails, because that probably means it failed to flush the buffers to disk.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
