### PR TITLE
Update the binding to use features from aws-c-s3

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -82,6 +82,7 @@ PyObject *aws_py_s3_client_new(PyObject *self, PyObject *args) {
     uint64_t part_size = 0;
     double throughput_target_gbps = 0;
     int tls_mode;
+    fprintf(stderr, "###### why???? 1 \n");
     if (!PyArg_ParseTuple(
             args,
             "OOOOOs#iKdO",
@@ -99,6 +100,7 @@ PyObject *aws_py_s3_client_new(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+    fprintf(stderr, "###### why???? 2 \n");
     struct aws_client_bootstrap *bootstrap = aws_py_get_client_bootstrap(bootstrap_py);
     if (!bootstrap) {
         return NULL;
@@ -106,11 +108,13 @@ PyObject *aws_py_s3_client_new(PyObject *self, PyObject *args) {
 
     struct aws_credentials_provider *credential_provider = NULL;
     if (credential_provider_py != Py_None) {
+        fprintf(stderr, "###### why???? 3 \n");
         credential_provider = aws_py_get_credentials_provider(credential_provider_py);
         if (!credential_provider) {
             return NULL;
         }
     }
+    fprintf(stderr, "###### why???? 4 \n");
     struct aws_signing_config_aws *signing_config = NULL;
     if (signing_config_py != Py_None) {
         signing_config = aws_py_get_signing_config(signing_config_py);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -169,21 +169,15 @@ static int s_s3_request_on_body(
     if (aws_py_gilstate_ensure(&state)) {
         return AWS_OP_ERR; /* Python has shut down. Nothing matters anymore, but don't crash */
     }
-    if (!request_binding->recv_file) {
-        result = PyObject_CallMethod(
-            request_binding->py_core,
-            "_on_body",
-            "(y#K)",
-            (const char *)(body->ptr),
-            (Py_ssize_t)body->len,
-            range_start);
 
-        if (!result) {
-            PyErr_WriteUnraisable(request_binding->py_core);
-            goto done;
-        }
-        Py_DECREF(result);
+    result = PyObject_CallMethod(
+        request_binding->py_core, "_on_body", "(y#K)", (const char *)(body->ptr), (Py_ssize_t)body->len, range_start);
+
+    if (!result) {
+        PyErr_WriteUnraisable(request_binding->py_core);
+        goto done;
     }
+    Py_DECREF(result);
     error = false;
 done:
     PyGILState_Release(state);
@@ -432,7 +426,7 @@ PyObject *aws_py_s3_client_make_meta_request(PyObject *self, PyObject *args) {
     Py_INCREF(meta_request->py_core);
 
     if (recv_filepath) {
-        meta_request->recv_file = aws_fopen(recv_filepath, "wb+");
+        meta_request->recv_file = aws_fopen(recv_filepath, "wb");
         if (!meta_request->recv_file) {
             aws_translate_and_raise_io_error(errno);
             PyErr_SetAwsLastError();

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -117,6 +117,7 @@ done:
     }
 }
 
+/* To avoid reporting progress to python too often. We cache it up and only report to python after at least 1 sec. */
 static int s_record_progress(struct s3_meta_request_binding *request_binding, uint64_t length, bool *report_progress) {
     if (aws_add_u64_checked(request_binding->size_transferred, length, &request_binding->size_transferred)) {
         /* Wow */

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
+from io import BytesIO
 import unittest
 import os
 import tempfile
@@ -147,8 +148,6 @@ class S3RequestTest(NativeResourceTest):
         self.data_len = 0
         self.progress_invoked = 0
 
-        self.put_body_stream = None
-
         self.files = FileCreator()
         self.temp_put_obj_file_path = self.files.create_file_with_size("temp_put_obj_10mb", 10 * MB)
         super().setUp()
@@ -165,16 +164,15 @@ class S3RequestTest(NativeResourceTest):
         request = HttpRequest("GET", object_path, headers)
         return request
 
-    def _put_object_request(self, file_name, path=None):
+    def _put_object_request(self, input_stream, content_len, path=None, unknown_content_length=False):
         # if send file path is set, the body_stream of http request will be ignored (using file handler from C instead)
-        self.put_body_stream = open(file_name, "r+b")
-        file_stats = os.stat(file_name)
-        self.data_len = file_stats.st_size
         headers = HttpHeaders([("host", self._build_endpoint_string(self.region, self.bucket_name)),
-                               ("Content-Type", "text/plain"), ("Content-Length", str(self.data_len))])
+                               ("Content-Type", "text/plain")])
+        if unknown_content_length is False:
+            headers.add("Content-Length", str(content_len))
         if path is None:
             path = self.put_test_object_path
-        request = HttpRequest("PUT", path, headers, self.put_body_stream)
+        request = HttpRequest("PUT", path, headers, input_stream)
         return request
 
     def _on_request_headers(self, status_code, headers, **kargs):
@@ -187,12 +185,12 @@ class S3RequestTest(NativeResourceTest):
     def _on_progress(self, progress):
         self.transferred_len += progress
 
-    def _validate_successful_get_response(self, put_object):
+    def _validate_successful_response(self, is_put_object):
         self.assertEqual(self.response_status_code, 200, "status code is not 200")
         headers = HttpHeaders(self.response_headers)
         self.assertIsNone(headers.get("Content-Range"))
         body_length = headers.get("Content-Length")
-        if not put_object:
+        if not is_put_object:
             self.assertIsNotNone(body_length, "Content-Length is missing from headers")
         if body_length:
             self.assertEqual(
@@ -200,12 +198,21 @@ class S3RequestTest(NativeResourceTest):
                 self.received_body_len,
                 "Received body length does not match the Content-Length header")
 
-    def _test_s3_put_get_object(self, request, request_type, exception_name=None):
+    def _test_s3_put_get_object(
+            self,
+            request,
+            request_type,
+            exception_name=None,
+            send_filepath=None,
+            recv_filepath=None):
+
         s3_client = s3_client_new(False, self.region, 5 * MB)
         s3_request = s3_client.make_request(
             request=request,
             type=request_type,
             on_headers=self._on_request_headers,
+            send_filepath=send_filepath,
+            recv_filepath=recv_filepath,
             on_body=self._on_request_body)
         finished_future = s3_request.finished_future
         try:
@@ -213,7 +220,7 @@ class S3RequestTest(NativeResourceTest):
         except Exception as e:
             self.assertEqual(e.name, exception_name)
         else:
-            self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
+            self._validate_successful_response(request_type is S3RequestType.PUT_OBJECT)
 
         shutdown_event = s3_request.shutdown_event
         s3_request = None
@@ -224,9 +231,25 @@ class S3RequestTest(NativeResourceTest):
         self._test_s3_put_get_object(request, S3RequestType.GET_OBJECT)
 
     def test_put_object(self):
-        request = self._put_object_request(self.temp_put_obj_file_path)
+        put_body_stream = open(self.temp_put_obj_file_path, "r+b")
+        content_length = os.stat(self.temp_put_obj_file_path).st_size
+        request = self._put_object_request(put_body_stream, content_length)
         self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT)
-        self.put_body_stream.close()
+        put_body_stream.close()
+
+    def test_put_object_unknown_content_length(self):
+        put_body_stream = open(self.temp_put_obj_file_path, "r+b")
+        content_length = os.stat(self.temp_put_obj_file_path).st_size
+        request = self._put_object_request(put_body_stream, content_length, unknown_content_length=True)
+        self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT)
+        put_body_stream.close()
+
+    def test_put_object_unknown_content_length_single_part(self):
+        data_bytes = "test crt python single part upload".encode(encoding='utf-8')
+        put_body_stream = BytesIO(data_bytes)
+        request = self._put_object_request(put_body_stream, len(data_bytes), unknown_content_length=True)
+        self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT)
+        put_body_stream.close()
 
     def test_put_object_multiple_times(self):
         s3_client = s3_client_new(False, self.region, 5 * MB)
@@ -234,8 +257,9 @@ class S3RequestTest(NativeResourceTest):
         for i in range(3):
             tempfile = self.files.create_file_with_size("temp_file_{}".format(str(i)), 10 * MB)
             path = "/put_object_test_py_10MB_{}.txt".format(str(i))
-            request = self._put_object_request(tempfile, path)
-            self.put_body_stream.close()
+            put_body_stream = open(path, "r+b")
+            content_length = os.stat(path).st_size
+            request = self._put_object_request(put_body_stream, content_length)
             s3_request = s3_client.make_request(
                 request=request,
                 type=S3RequestType.PUT_OBJECT,
@@ -243,6 +267,7 @@ class S3RequestTest(NativeResourceTest):
                 on_headers=self._on_request_headers,
                 on_body=self._on_request_body)
             finished_futures.append(s3_request.finished_future)
+            put_body_stream.close()
             # request keeps connection alive. delete pointer so connection can shut down
             del s3_request
         try:
@@ -255,9 +280,8 @@ class S3RequestTest(NativeResourceTest):
         client_shutdown_event = s3_client.shutdown_event
         del s3_client
         self.assertTrue(client_shutdown_event.wait(self.timeout))
-        self.put_body_stream.close()
 
-    def test_get_object_file_object(self):
+    def test_get_object_filepath(self):
         request = self._get_object_request(self.get_test_object_path)
         request_type = S3RequestType.GET_OBJECT
         s3_client = s3_client_new(False, self.region, 5 * MB)
@@ -295,33 +319,27 @@ class S3RequestTest(NativeResourceTest):
             # TODO verify the content of written file
             os.remove(file.name)
 
-    def test_put_object_file_object(self):
-        request = self._put_object_request(self.temp_put_obj_file_path)
-        request_type = S3RequestType.PUT_OBJECT
-        # close the stream, to test if the C FILE pointer as the input stream working well.
-        self.put_body_stream.close()
-        s3_client = s3_client_new(False, self.region, 5 * MB)
-        s3_request = s3_client.make_request(
-            request=request,
-            type=request_type,
-            send_filepath=self.temp_put_obj_file_path,
-            on_headers=self._on_request_headers,
-            on_progress=self._on_progress)
-        finished_future = s3_request.finished_future
-        finished_future.result(self.timeout)
+    def test_put_object_filepath(self):
+        put_body_stream = open(self.temp_put_obj_file_path, "r+b")
+        content_length = os.stat(self.temp_put_obj_file_path).st_size
+        request = self._put_object_request(put_body_stream, content_length)
+        self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT, send_filepath=self.temp_put_obj_file_path)
+        put_body_stream.close()
 
-        # check result
-        self.assertEqual(
-            self.data_len,
-            self.transferred_len,
-            "the transferred length reported does not match body we sent")
-        self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
+    def test_put_object_filepath_unknown_content_length(self):
+        put_body_stream = open(self.temp_put_obj_file_path, "r+b")
+        content_length = os.stat(self.temp_put_obj_file_path).st_size
+        request = self._put_object_request(put_body_stream, content_length, unknown_content_length=True)
+        self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT, send_filepath=self.temp_put_obj_file_path)
+        put_body_stream.close()
 
-    def test_put_object_file_object_move(self):
+    def test_put_object_filepath_move(self):
         # remove the input file when request done
         tempfile = self.files.create_file_with_size("temp_file", 10 * MB)
-        request = self._put_object_request(tempfile)
-        self.put_body_stream.close()
+        put_body_stream = open(tempfile, "r+b")
+        content_length = os.stat(tempfile).st_size
+        request = self._put_object_request(put_body_stream, content_length)
+        put_body_stream.close()
         s3_client = s3_client_new(False, self.region, 5 * MB)
         request_type = S3RequestType.PUT_OBJECT
         done_future = Future()
@@ -344,7 +362,7 @@ class S3RequestTest(NativeResourceTest):
             self.data_len,
             self.transferred_len,
             "the transferred length reported does not match body we sent")
-        self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
+        self._validate_successful_response(request_type is S3RequestType.PUT_OBJECT)
 
     def _on_progress_cancel_after_first_chunk(self, progress):
         self.transferred_len += progress
@@ -442,17 +460,22 @@ class S3RequestTest(NativeResourceTest):
         return self._put_object_cancel_helper(False)
 
     def test_multipart_upload_with_invalid_request(self):
-        request = self._put_object_request(self.temp_put_obj_file_path)
+        put_body_stream = open(self.temp_put_obj_file_path, "r+b")
+        content_length = os.stat(self.temp_put_obj_file_path).st_size
+        request = self._put_object_request(put_body_stream, content_length)
         request.headers.set("Content-MD5", "something")
         self._test_s3_put_get_object(request, S3RequestType.PUT_OBJECT, "AWS_ERROR_S3_INVALID_RESPONSE_STATUS")
-        self.put_body_stream.close()
+        put_body_stream.close()
 
     def test_special_filepath_upload(self):
         # remove the input file when request done
         with open(self.special_path, 'wb') as file:
             file.write(b"a" * 10 * MB)
-        request = self._put_object_request(self.special_path)
-        self.put_body_stream.close()
+
+        put_body_stream = open(self.special_path, "r+b")
+        content_length = os.stat(self.special_path).st_size
+        request = self._put_object_request(put_body_stream, content_length)
+        put_body_stream.close()
         s3_client = s3_client_new(False, self.region, 5 * MB)
         request_type = S3RequestType.PUT_OBJECT
 
@@ -488,15 +511,18 @@ class S3RequestTest(NativeResourceTest):
             self.data_len,
             self.transferred_len,
             "the transferred length reported does not match body we sent")
-        self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
+        self._validate_successful_response(request_type is S3RequestType.PUT_OBJECT)
         os.remove(self.special_path)
 
     def test_non_ascii_filepath_upload(self):
         # remove the input file when request done
         with open(self.non_ascii_file_name, 'wb') as file:
             file.write(b"a" * 10 * MB)
-        request = self._put_object_request(self.non_ascii_file_name)
-        self.put_body_stream.close()
+
+        put_body_stream = open(self.non_ascii_file_name, "r+b")
+        content_length = os.stat(self.non_ascii_file_name).st_size
+        request = self._put_object_request(put_body_stream, content_length)
+        put_body_stream.close()
         s3_client = s3_client_new(False, self.region, 5 * MB)
         request_type = S3RequestType.PUT_OBJECT
 
@@ -514,7 +540,7 @@ class S3RequestTest(NativeResourceTest):
             self.data_len,
             self.transferred_len,
             "the transferred length reported does not match body we sent")
-        self._validate_successful_get_response(request_type is S3RequestType.PUT_OBJECT)
+        self._validate_successful_response(request_type is S3RequestType.PUT_OBJECT)
         os.remove(self.non_ascii_file_name)
 
     def test_non_ascii_filepath_download(self):


### PR DESCRIPTION
- Remove the hack we did in the bindings for progress callback and filepath
- We still haven't support recv_filepath from aws-c-s3 yet, so keep that
- Refactor the tests to be a bit nicer, as it was really confusing (sorry I wrote the old code, and I don't like it anymore. And it may still be confusing, I only updated the code around put object.)
- add tests fro unknown content length


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
