### PR TITLE
S3ResponseError

### DIFF
--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -464,6 +464,7 @@ class S3ResponseError(awscrt.exceptions.AwsCrtError):
         status_code (int): HTTP response status code.
         headers (list[tuple[str, str]]): Headers from HTTP response.
         body (Optional[bytes]): Body of HTTP response (if any).
+            This is usually XML. It may be None in the case of a HEAD response.
         code (int): CRT error code.
         name (str): CRT error name.
         message (str): CRT error message.
@@ -546,7 +547,8 @@ class _S3RequestCore:
         if error_code:
             error = awscrt.exceptions.from_code(error_code)
 
-            # Make this into an S3ResponseError, if possible
+            # If the failure was due to a response, make it into an S3ResponseError.
+            # When failure is due to a response, its headers are always included.
             if isinstance(error, awscrt.exceptions.AwsCrtError) \
                     and status_code is not None \
                     and error_headers is not None:

--- a/source/auth_credentials.c
+++ b/source/auth_credentials.c
@@ -618,7 +618,7 @@ done:
     PyGILState_Release(state);
 
     if (!native_credentials) {
-        return aws_raise_error(AWS_ERROR_CRT_CALLBACK_EXCEPTION);
+        return aws_raise_error(AWS_AUTH_CREDENTIALS_PROVIDER_DELEGATE_FAILURE);
     }
 
     callback(native_credentials, AWS_ERROR_SUCCESS, callback_user_data);

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -116,6 +116,8 @@ PyObject *aws_py_s3_cross_process_lock_acquire(PyObject *self, PyObject *args) {
 }
 
 PyObject *aws_py_s3_cross_process_lock_release(PyObject *self, PyObject *args) {
+    (void)self;
+
     PyObject *lock_capsule; /* O */
 
     if (!PyArg_ParseTuple(args, "O", &lock_capsule)) {


### PR DESCRIPTION
**Issue:**
The exceptions delivered from the S3Client were lacking information like the HTTP response code, headers, & body. You could get the extra information from the `on_done` callback, but it would be nice to get it from the exception, so you could use the `request.finished_future` instead of the `on_done` callback if you wanted.

**Description of changes:**
Add new error type: `awscrt.s3.S3ResponseError`, which inherits from `awscrt.exceptions.AwsCrtError`. If we have information about the failed request, then use an `S3ResponseError` instead.

Debatable:
- Should this live in `awscrt.exceptions` or `awscrt.s3`?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
