### PR TITLE
Store Exception for on headers and onbody callback

### DIFF
--- a/awscrt/s3.py
+++ b/awscrt/s3.py
@@ -557,7 +557,6 @@ class _S3RequestCore:
 
         error = None
         if error_code:
-
             error = awscrt.exceptions.from_code(error_code)
 
             if isinstance(error, awscrt.exceptions.AwsCrtError):

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -106,6 +106,7 @@ static int s_s3_request_on_headers(
     } else if (result == Py_False) {
         /* _on_headers stored the exception to throw later, so we don't have to do anything */
         PyErr_Clear();
+        Py_DECREF(result);
         goto done;
     }
     Py_DECREF(result);
@@ -183,6 +184,7 @@ static int s_s3_request_on_body(
     } else if (result == Py_False) {
         /* _on_body stored the exception to throw later, so we don't have to do anything */
         PyErr_Clear();
+        Py_DECREF(result);
         goto done;
     }
     Py_DECREF(result);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -101,7 +101,8 @@ static int s_s3_request_on_headers(
     PyObject *result =
         PyObject_CallMethod(request_binding->py_core, "_on_headers", "(iO)", response_status, header_list);
     if (!result) {
-        PyErr_WriteUnraisable(request_binding->py_core);
+        /* _on_body stores the exception to throw later, so we don't have to anything */
+        PyErr_Clear();
         goto done;
     }
     Py_DECREF(result);
@@ -174,7 +175,8 @@ static int s_s3_request_on_body(
         request_binding->py_core, "_on_body", "(y#K)", (const char *)(body->ptr), (Py_ssize_t)body->len, range_start);
 
     if (!result) {
-        PyErr_WriteUnraisable(request_binding->py_core);
+        /* _on_body stores the exception to throw later, so we don't have to anything */
+        PyErr_Clear();
         goto done;
     }
     Py_DECREF(result);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -178,14 +178,11 @@ static int s_s3_request_on_body(
     if (!result) {
         PyErr_WriteUnraisable(request_binding->py_core);
         goto done;
-    } else if (result == Py_False) {
-        /* _on_body stored the exception to throw later, so we don't have to do anything */
-        PyErr_Clear();
-        Py_DECREF(result);
-        goto done;
     }
+    /* If user's callback raises an exception, _S3RequestCore._on_body
+     * stores it to throw later and returns False */
+    error = (result == Py_False);
     Py_DECREF(result);
-    error = false;
 done:
     PyGILState_Release(state);
     /*************** GIL RELEASE ***************/

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -101,7 +101,7 @@ static int s_s3_request_on_headers(
     PyObject *result =
         PyObject_CallMethod(request_binding->py_core, "_on_headers", "(iO)", response_status, header_list);
     if (!result) {
-        /* _on_body stores the exception to throw later, so we don't have to anything */
+        /* _on_headers stores the exception to throw later, so we don't have to anything */
         PyErr_Clear();
         goto done;
     }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -103,14 +103,11 @@ static int s_s3_request_on_headers(
     if (!result) {
         PyErr_WriteUnraisable(request_binding->py_core);
         goto done;
-    } else if (result == Py_False) {
-        /* _on_headers stored the exception to throw later, so we don't have to do anything */
-        PyErr_Clear();
-        Py_DECREF(result);
-        goto done;
     }
+    /* If user's callback raises an exception, _S3RequestCore._on_headers
+     * stores it to throw later and returns False */
+    error = (result == Py_False);
     Py_DECREF(result);
-    error = false;
 done:
     Py_XDECREF(header_list);
     PyGILState_Release(state);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -100,8 +100,12 @@ static int s_s3_request_on_headers(
     /* Deliver the built up list of (name,value) tuples */
     PyObject *result =
         PyObject_CallMethod(request_binding->py_core, "_on_headers", "(iO)", response_status, header_list);
+
     if (!result) {
-        /* _on_headers stores the exception to throw later, so we don't have to anything */
+        PyErr_WriteUnraisable(request_binding->py_core);
+        goto done;
+    } else if (result == Py_False) {
+        /* _on_headers stored the exception to throw later, so we don't have to do anything */
         PyErr_Clear();
         goto done;
     }
@@ -175,10 +179,14 @@ static int s_s3_request_on_body(
         request_binding->py_core, "_on_body", "(y#K)", (const char *)(body->ptr), (Py_ssize_t)body->len, range_start);
 
     if (!result) {
-        /* _on_body stores the exception to throw later, so we don't have to anything */
+        PyErr_WriteUnraisable(request_binding->py_core);
+        goto done;
+    } else if (result == Py_False) {
+        /* _on_body stored the exception to throw later, so we don't have to do anything */
         PyErr_Clear();
         goto done;
     }
+
     Py_DECREF(result);
     error = false;
 done:

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -100,7 +100,6 @@ static int s_s3_request_on_headers(
     /* Deliver the built up list of (name,value) tuples */
     PyObject *result =
         PyObject_CallMethod(request_binding->py_core, "_on_headers", "(iO)", response_status, header_list);
-
     if (!result) {
         PyErr_WriteUnraisable(request_binding->py_core);
         goto done;
@@ -186,7 +185,6 @@ static int s_s3_request_on_body(
         PyErr_Clear();
         goto done;
     }
-
     Py_DECREF(result);
     error = false;
 done:

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -9,6 +9,7 @@ import tempfile
 import math
 import shutil
 import time
+
 from test import NativeResourceTest
 from concurrent.futures import Future
 from multiprocessing import Process
@@ -610,6 +611,52 @@ class S3RequestTest(NativeResourceTest):
         self.assertEqual(self.done_error_body, self.done_error.body)
 
         put_body_stream.close()
+
+    def test_on_headers_callback_failure(self):
+        request = self._get_object_request(self.get_test_object_path)
+
+        s3_client = s3_client_new(False, self.region, 5 * MB)
+        s3_request = s3_client.make_request(
+            request=request,
+            type=S3RequestType.GET_OBJECT,
+            on_headers=lambda status_code, headers: (_ for _ in ()).throw(RuntimeError("Error in on_headers")),
+            on_body=self._on_request_body,
+        )
+
+        finished_future = s3_request.finished_future
+        shutdown_event = s3_request.shutdown_event
+        s3_request = None
+        self.assertTrue(shutdown_event.wait(self.timeout))
+
+        e = finished_future.exception()
+        # check that data from on_done callback came through correctly
+        self.assertIsInstance(e, RuntimeError)
+        self.assertEqual(str(e), "Error in on_headers")
+
+    def test_on_body_callback_failure(self):
+        io.init_logging(io.LogLevel.Trace, "logs.txt")
+
+        request = self._get_object_request(self.get_test_object_path)
+
+        s3_client = s3_client_new(False, self.region, 5 * MB)
+        s3_request = s3_client.make_request(
+            request=request,
+            type=S3RequestType.GET_OBJECT,
+            on_headers=self._on_request_headers,
+            on_body=lambda chunk, offset: (_ for _ in ()).throw(RuntimeError("Error in on_body"))
+        )
+
+        finished_future = s3_request.finished_future
+        shutdown_event = s3_request.shutdown_event
+        s3_request = None
+        self.assertTrue(shutdown_event.wait(self.timeout))
+
+        e = finished_future.exception()
+        # check that data from on_done callback came through correctly
+        self.assertIsInstance(e, RuntimeError)
+        self.assertEqual(str(e), "Error in on_body")
+
+
 
     def test_special_filepath_upload(self):
         # remove the input file when request done

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -618,13 +618,15 @@ class S3RequestTest(NativeResourceTest):
         put_body_stream.close()
 
     def test_on_headers_callback_failure(self):
-        request = self._get_object_request(self.get_test_object_path)
+        def _explode(**kwargs):
+            raise RuntimeError("Error in on_headers callback")
 
+        request = self._get_object_request(self.get_test_object_path)
         s3_client = s3_client_new(False, self.region, 5 * MB)
         s3_request = s3_client.make_request(
             request=request,
             type=S3RequestType.GET_OBJECT,
-            on_headers=lambda status_code, headers: (_ for _ in ()).throw(RuntimeError("Error in on_headers")),
+            on_headers=_explode,
             on_body=self._on_request_body,
         )
 
@@ -636,17 +638,19 @@ class S3RequestTest(NativeResourceTest):
         e = finished_future.exception()
         # check that data from on_done callback came through correctly
         self.assertIsInstance(e, RuntimeError)
-        self.assertEqual(str(e), "Error in on_headers")
+        self.assertEqual(str(e), "Error in on_headers callback")
 
     def test_on_body_callback_failure(self):
-        request = self._get_object_request(self.get_test_object_path)
+        def _explode(**kwargs):
+            raise RuntimeError("Error in on_body callback")
 
+        request = self._get_object_request(self.get_test_object_path)
         s3_client = s3_client_new(False, self.region, 5 * MB)
         s3_request = s3_client.make_request(
             request=request,
             type=S3RequestType.GET_OBJECT,
             on_headers=self._on_request_headers,
-            on_body=lambda chunk, offset: (_ for _ in ()).throw(RuntimeError("Error in on_body"))
+            on_body=_explode,
         )
 
         finished_future = s3_request.finished_future
@@ -657,7 +661,7 @@ class S3RequestTest(NativeResourceTest):
         e = finished_future.exception()
         # check that data from on_done callback came through correctly
         self.assertIsInstance(e, RuntimeError)
-        self.assertEqual(str(e), "Error in on_body")
+        self.assertEqual(str(e), "Error in on_body callback")
 
     def test_special_filepath_upload(self):
         # remove the input file when request done

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -656,8 +656,6 @@ class S3RequestTest(NativeResourceTest):
         self.assertIsInstance(e, RuntimeError)
         self.assertEqual(str(e), "Error in on_body")
 
-
-
     def test_special_filepath_upload(self):
         # remove the input file when request done
         content_length = 10 * MB

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -9,7 +9,6 @@ import tempfile
 import math
 import shutil
 import time
-
 from test import NativeResourceTest
 from concurrent.futures import Future
 from multiprocessing import Process

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -634,8 +634,6 @@ class S3RequestTest(NativeResourceTest):
         self.assertEqual(str(e), "Error in on_headers")
 
     def test_on_body_callback_failure(self):
-        io.init_logging(io.LogLevel.Trace, "logs.txt")
-
         request = self._get_object_request(self.get_test_object_path)
 
         s3_client = s3_client_new(False, self.region, 5 * MB)


### PR DESCRIPTION
*Description of changes:*
- Store callback exceptions in S3 on_headers and on_body callback so that we rethrow it in the on_done callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
