### PR TITLE
CI checks for C compiler warnings

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -3,6 +3,9 @@
     "!cmake_args": [
         "-DS2N_NO_PQ_ASM=ON"
     ],
+    "env": {
+        "AWS_CRT_BUILD_WARNINGS_ARE_ERRORS": "1"
+    },
     "hosts": {
         "manylinux": {
             "_comment": "Use existing compiler on manylinux. These are the images we use for release. We want to be sure things work with the defaults.",

--- a/setup.py
+++ b/setup.py
@@ -360,8 +360,10 @@ def awscrt_ext():
             # a proper MacOS Universal2 binary. The linker warns us about this,
             # but WHATEVER. Building everything twice (x86_64 and arm64) takes too long.
             if not is_macos_universal2():
-                if sys.platform == 'darwin' or 'bsd' in sys.platform:
+                if sys.platform == 'darwin':
                     extra_link_args += ['-Wl,-fatal_warnings']
+                elif 'bsd' in sys.platform:
+                    extra_link_args += ['-Wl,-fatal-warnings']
                 else:
                     extra_link_args += ['-Wl,--fatal-warnings']
 

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ def awscrt_ext():
             # a proper MacOS Universal2 binary. The linker warns us about this,
             # but WHATEVER. Building everything twice (x86_64 and arm64) takes too long.
             if not is_macos_universal2():
-                extra_link_args += ['-Wl,-fatal_warnings']
+                extra_link_args += ['-Wl,--fatal-warnings']
 
     if sys.version_info >= (3, 11):
         define_macros.append(('Py_LIMITED_API', '0x030B0000'))

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,10 @@ def awscrt_ext():
             # a proper MacOS Universal2 binary. The linker warns us about this,
             # but WHATEVER. Building everything twice (x86_64 and arm64) takes too long.
             if not is_macos_universal2():
-                extra_link_args += ['-Wl,--fatal-warnings']
+                if sys.platform == 'darwin' or sys.platform.contains('bsd'):
+                    extra_link_args += ['-Wl,-fatal_warnings']
+                else:
+                    extra_link_args += ['-Wl,--fatal-warnings']
 
     if sys.version_info >= (3, 11):
         define_macros.append(('Py_LIMITED_API', '0x030B0000'))

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ def awscrt_ext():
             # a proper MacOS Universal2 binary. The linker warns us about this,
             # but WHATEVER. Building everything twice (x86_64 and arm64) takes too long.
             if not is_macos_universal2():
-                if sys.platform == 'darwin' or sys.platform.contains('bsd'):
+                if sys.platform == 'darwin' or 'bsd' in sys.platform:
                     extra_link_args += ['-Wl,-fatal_warnings']
                 else:
                     extra_link_args += ['-Wl,--fatal-warnings']

--- a/setup.py
+++ b/setup.py
@@ -353,7 +353,7 @@ def awscrt_ext():
         extra_compile_args += ['-Wno-strict-aliasing', '-std=gnu99']
 
         # treat warnings as errors in development mode
-        if is_development_mode():
+        if is_development_mode() or os.getenv('AWS_CRT_BUILD_WARNINGS_ARE_ERRORS') == '1':
             extra_compile_args += ['-Wextra', '-Werror']
 
             # ...except when we take shortcuts in development mode and don't make

--- a/source/mqtt5_client.c
+++ b/source/mqtt5_client.c
@@ -746,7 +746,7 @@ static bool s_py_topic_aliasing_options_init(
                                             py_outbound_behavior,
                                             "TopicAliasingOptions",
                                             "outbound_behavior",
-                                            &topic_aliasing_options->outbound_topic_alias_behavior)) {
+                                            (int *)&topic_aliasing_options->outbound_topic_alias_behavior)) {
         if (PyErr_Occurred()) {
             goto done;
         }
@@ -766,7 +766,7 @@ static bool s_py_topic_aliasing_options_init(
                                            py_inbound_behavior,
                                            "TopicAliasingOptions",
                                            "inbound_behavior",
-                                           &topic_aliasing_options->inbound_topic_alias_behavior)) {
+                                           (int *)&topic_aliasing_options->inbound_topic_alias_behavior)) {
         if (PyErr_Occurred()) {
             goto done;
         }
@@ -1204,7 +1204,6 @@ PyObject *aws_py_mqtt5_client_new(PyObject *self, PyObject *args) {
     int will_payload_format_tmp = 0;
     enum aws_mqtt5_payload_format_indicator will_payload_format_enum_tmp = 0;
     uint32_t will_message_expiry_interval_seconds_tmp = 0;
-    uint16_t will_topic_alias_tmp = 0;
     struct aws_byte_cursor will_correlation_data_tmp;
     if (!PyObject_IsTrue(is_will_none_py)) {
         will.qos = PyObject_GetIntEnum(will_qos_val_py, AWS_PYOBJECT_KEY_QOS);


### PR DESCRIPTION
Previously, we only checked for C compiler warnings when doing a local "development" build (`pip install --editable .`). Now, we also check in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
