### PR TITLE
Fix UnsubackPacket typing for reason_codes

### DIFF
--- a/awscrt/mqtt5.py
+++ b/awscrt/mqtt5.py
@@ -1088,7 +1088,7 @@ class UnsubackPacket:
     """
     reason_string: str = None
     user_properties: 'Sequence[UserProperty]' = None
-    reason_codes: 'Sequence[DisconnectReasonCode]' = None
+    reason_codes: 'Sequence[UnsubackReasonCode]' = None
 
 
 @dataclass

--- a/awscrt/mqtt5.py
+++ b/awscrt/mqtt5.py
@@ -1083,7 +1083,7 @@ class UnsubackPacket:
     Args:
         reason_string (str): Additional diagnostic information about the result of the UNSUBSCRIBE attempt.
         user_properties (Sequence[UserProperty]): List of MQTT5 user properties included with the packet.
-        reason_codes (Sequence[DisconnectReasonCode]): A list of reason codes indicating the result of unsubscribing from each individual topic filter entry in the associated UNSUBSCRIBE packet.
+        reason_codes (Sequence[UnsubackReasonCode]): A list of reason codes indicating the result of unsubscribing from each individual topic filter entry in the associated UNSUBSCRIBE packet.
 
     """
     reason_string: str = None


### PR DESCRIPTION
`reason_codes` should be a sequence of `UnsubackReasonCode`, not `DisconnectReasonCode`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
