### PR TITLE
fix docs.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
 
   # check that docs can still build
   check-docs:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,14 +265,14 @@ jobs:
 
   # check that docs can still build
   check-docs:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Check docs
         run: |
-          python3 -m pip install sphinx==7.2.6
+          python3 -m pip install -r requirements-dev.txt
           python3 -m pip install --verbose .
           ./scripts/make-docs.py
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-docs-branch:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-24.04 # latest
     permissions:
       contents: write # allow push
     steps:
@@ -20,7 +20,7 @@ jobs:
 
       - name: Update docs branch
         run: |
-          python3 -m pip install sphinx==7.2.6
+          python3 -m pip install -r requirements-dev.txt
           python3 -m pip install --verbose .
           ./scripts/make-docs.py
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-docs-branch:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-22.04 # latest
     permissions:
       contents: write # allow push
     steps:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 autopep8 # for code formatting
 setuptools # for installing from source
-sphinx # for building docs
+sphinx>=7.2.6,<7.3; python_version >= '3.9' # for building docs
 websockets # for tests
 wheel # for building wheels


### PR DESCRIPTION
**Issue:**

the docs.yml job that runs on mainline has been broken for a while

**Description of changes:**

- Put the required sphinx version in 1 place (requirements-dev.txt)
    - sphinx 7.3+ breaks our docs, not sure why, don't have time to look into it...
- Update docs jobs to run on latest ubuntu22.04
    - sphinx requires python3.9+ now, but ubuntu20.04 has python3.8

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
