### PR TITLE
Prebuild aws-lc

### DIFF
--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -47,7 +47,7 @@ if(UNIX AND NOT APPLE)
         endif()
 
         # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.
-        prebuild_dependency(
+        aws_prebuild_dependency(
             DEPENDENCY_NAME AWSLC
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/aws-lc
             CMAKE_ARGUMENTS ${AWSLC_CMAKE_ARGUMENTS}

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -32,15 +32,23 @@ if(UNIX AND NOT APPLE)
     option(USE_OPENSSL "Set this if you want to use your system's OpenSSL compatible libcrypto" OFF)
 
     if(NOT USE_OPENSSL)
-        set(DISABLE_GO ON CACHE BOOL "Build without using Go, we don't want the extra dependency")
-        set(BUILD_LIBSSL OFF CACHE BOOL "Don't need libssl, only need libcrypto")
-
-        set(DISABLE_PERL ON CACHE BOOL "Build without using Perl, we don't want the extra dependency")
         if(CMAKE_C_COMPILER_ID MATCHES "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS "5.0")
-            set(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX ON CACHE BOOL "Disable AVX512 on old GCC that not supports it")
+            set(AWSLC_MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX ON CACHE BOOL "Disable AVX512 on old GCC that not supports it")
+        else()
+            set(AWSLC_MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX OFF CACHE BOOL "Disable AVX512 on old GCC that not supports it")
         endif()
 
-        add_subdirectory(aws-lc)
+        # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.
+        prebuild_dependency(
+            DEPENDENCY_NAME AWSLC
+            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/crt/aws-lc
+            CMAKE_ARGUMENTS
+                -DDISABLE_GO=ON
+                -DDISABLE_PERL=ON
+                -DBUILD_LIBSSL=OFF
+                -DBUILD_TESTING=OFF
+                -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=${AWSLC_MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX}
+        )
     endif()
 
     set(UNSAFE_TREAT_WARNINGS_AS_ERRORS OFF CACHE BOOL "")

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -32,22 +32,25 @@ if(UNIX AND NOT APPLE)
     option(USE_OPENSSL "Set this if you want to use your system's OpenSSL compatible libcrypto" OFF)
 
     if(NOT USE_OPENSSL)
+        include(AwsPrebuildDependency)
+
+        set(AWSLC_CMAKE_ARGUMENTS
+            -DDISABLE_GO=ON  # Build without using Go, we don't want the extra dependency
+            -DDISABLE_PERL=ON  # Build without using Perl, we don't want the extra dependency
+            -DBUILD_LIBSSL=OFF  # Don't need libssl, only need libcrypto
+            -DBUILD_TESTING=OFF
+        )
+
         if(CMAKE_C_COMPILER_ID MATCHES "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS "5.0")
-            set(AWSLC_MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX ON CACHE BOOL "Disable AVX512 on old GCC that not supports it")
-        else()
-            set(AWSLC_MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX OFF CACHE BOOL "Disable AVX512 on old GCC that not supports it")
+            # Disable AVX512 on old GCC that not supports it.
+            list(APPEND AWSLC_CMAKE_ARGUMENTS -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON)
         endif()
 
         # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.
         prebuild_dependency(
             DEPENDENCY_NAME AWSLC
-            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/crt/aws-lc
-            CMAKE_ARGUMENTS
-                -DDISABLE_GO=ON
-                -DDISABLE_PERL=ON
-                -DBUILD_LIBSSL=OFF
-                -DBUILD_TESTING=OFF
-                -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=${AWSLC_MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX}
+            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/aws-lc
+            CMAKE_ARGUMENTS ${AWSLC_CMAKE_ARGUMENTS}
         )
     endif()
 


### PR DESCRIPTION
This PR is the same as https://github.com/awslabs/aws-crt-cpp/pull/648

*Issue #, if available:*

At configuration time, `s2n-tls` performs a number of feature probes against libcrypto in order to configure itself. In the current implementation of aws-crt-python build system, the correct libcrypto does not yet exist (nor are aws-lc's headers visible to the feature check, for that matter). This results in a misconfigured s2n-tls.

Unfortunately, there is no easy way to change s2n-tls to be configured at build time, because CMake standard functionality for this (`try_compile` function) can be used only at configuration time.

*Description of changes:*

Build and install aws-lc into a build directory at configuration time, so libcrypto can be used by `s2n-tls`.

This PR depends on https://github.com/awslabs/aws-c-common/pull/1144 and https://github.com/awslabs/aws-c-cal/pull/197

I checked this PR by using the following build command:
```
python3 -m pip install --no-binary :all: --verbose .
```

<details>
    <summary>Prior to this PR, s2n-tls feature probes looked like this</summary>

  -- S2N found target: crypto
  -- CMAKE_AR found: /usr/bin/ar
  -- CMAKE_RANLIB found: /usr/bin/ranlib
  -- CMAKE_OBJCOPY found: /usr/bin/objcopy
  -- feature S2N_ATOMIC_SUPPORTED: FALSE
  -- feature S2N_CLOEXEC_SUPPORTED: FALSE
  -- feature S2N_CLOEXEC_XOPEN_SUPPORTED: FALSE
  -- feature S2N_CLONE_SUPPORTED: FALSE
  -- feature S2N_CPUID_AVAILABLE: FALSE
  -- feature S2N_DIAGNOSTICS_POP_SUPPORTED: FALSE
  -- feature S2N_DIAGNOSTICS_PUSH_SUPPORTED: FALSE
  -- feature S2N_EXECINFO_AVAILABLE: FALSE
  -- feature S2N_FALL_THROUGH_SUPPORTED: FALSE
  -- feature S2N_FEATURES_AVAILABLE: FALSE
  -- feature S2N_KTLS_SUPPORTED: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EC_KEY_CHECK_FIPS: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_AEAD_TLS: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_RC4: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_FLAG_NO_CHECK_TIME: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_HKDF: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_KYBER: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_RSA_PSS_SIGNING: FALSE
  -- feature S2N_LIBCRYPTO_SUPPORTS_X509_STORE_LIST: FALSE
  -- feature S2N_LINUX_SENDFILE: FALSE
  -- feature S2N_MADVISE_SUPPORTED: FALSE
  -- feature S2N_MINHERIT_SUPPORTED: FALSE
  -- feature S2N_STACKTRACE: FALSE
 </details>

<details>
    <summary>Now s2n feature probes look like this</summary>
    
  -- FOUND AWS-LC CRYPTO cmake config - static
  -- Using libcrypto from the cmake path
  -- CMAKE_AR found: /usr/bin/ar
  -- CMAKE_RANLIB found: /usr/bin/ranlib
  -- CMAKE_OBJCOPY found: /usr/bin/objcopy
  -- feature S2N_ATOMIC_SUPPORTED: TRUE
  -- feature S2N_CLOEXEC_SUPPORTED: TRUE
  -- feature S2N_CLOEXEC_XOPEN_SUPPORTED: TRUE
  -- feature S2N_CLONE_SUPPORTED: TRUE
  -- feature S2N_CPUID_AVAILABLE: TRUE
  -- feature S2N_DIAGNOSTICS_POP_SUPPORTED: TRUE
  -- feature S2N_DIAGNOSTICS_PUSH_SUPPORTED: TRUE
  -- feature S2N_EXECINFO_AVAILABLE: TRUE
  -- feature S2N_FALL_THROUGH_SUPPORTED: TRUE
  -- feature S2N_FEATURES_AVAILABLE: TRUE
  -- feature S2N_KTLS_SUPPORTED: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EC_KEY_CHECK_FIPS: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_AEAD_TLS: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_EVP_RC4: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_FLAG_NO_CHECK_TIME: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_HKDF: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_KYBER: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_RSA_PSS_SIGNING: TRUE
  -- feature S2N_LIBCRYPTO_SUPPORTS_X509_STORE_LIST: TRUE
  -- feature S2N_LINUX_SENDFILE: TRUE
  -- feature S2N_MADVISE_SUPPORTED: TRUE
  -- feature S2N_MINHERIT_SUPPORTED: FALSE
  -- feature S2N_STACKTRACE: TRUE

</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
