### PR TITLE
AWS_CRT_BUILD_USE_SYSTEM_LIBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ To simplify installation, aws-crt-python has its own copy of libcrypto.
 This lets you install a wheel from PyPI without having OpenSSL installed.
 Unix wheels on PyPI come with libcrypto statically compiled in.
 Code to build libcrypto comes from [AWS-LC](https://github.com/aws/aws-lc).
-AWS-LC's code is included in the PyPI source package, 
+AWS-LC's code is included in the PyPI source package,
 and the git repository includes it as a submodule.
 
-If you need aws-crt-python to use the libcrypto included on your system, 
+If you need aws-crt-python to use the libcrypto included on your system,
 set environment variable `AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1` while building from source:
 
 ```sh
@@ -58,6 +58,19 @@ AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1 python3 -m pip install --no-binary :all: --
 
 You can ignore all this on Windows and Apple platforms, where aws-crt-python
 uses the OS's default libraries for TLS and cryptography math.
+
+### AWS_CRT_BUILD_USE_SYSTEM_LIBS ###
+
+aws-crt-python depends on several C libraries that make up the AWS Common Runtime (libaws-c-common, libaws-c-s3, etc).
+By default, these libraries are built along with aws-crt-python and statically compiled in
+(their source code is under [crt/](crt/)).
+
+To skip building these dependencies, because they're already available on your system,
+set environment variable `AWS_CRT_BUILD_USE_SYSTEM_LIBS=1` while building from source:
+
+```sh
+AWS_CRT_BUILD_USE_SYSTEM_LIBS=1 python3 -m pip install .
+```
 
 ## Mac-Only TLS Behavior
 

--- a/awscrt/auth.py
+++ b/awscrt/auth.py
@@ -507,7 +507,7 @@ class AwsSignedBodyHeaderType(IntEnum):
     """Do not add a header."""
 
     X_AMZ_CONTENT_SHA_256 = 1
-    """Add the "x-amz-content-sha-256" header with the canonical request's signed body value"""
+    """Add the "x-amz-content-sha256" header with the canonical request's signed body value"""
 
 
 class AwsSigningConfig(NativeResource):


### PR DESCRIPTION
*Issue #:* https://github.com/awslabs/aws-crt-python/issues/588

User wants explicit way to choose whether aws-crt-python builds its own dependencies (their source code is under `crt/`), or find them prebuilt on the system.

There's currently a secret way to do this (delete `crt/` folder, or don't sync submodules), but it's not documented.

*Description of changes:*
Set `AWS_CRT_BUILD_USE_SYSTEM_LIBS=1` to explicitly disable building dependencies


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
