### PR TITLE
AWS_CRT_BUILD_FORCE_STATIC_LIBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ set environment variable `AWS_CRT_BUILD_USE_SYSTEM_LIBS=1` while building from s
 AWS_CRT_BUILD_USE_SYSTEM_LIBS=1 python3 -m pip install .
 ```
 
+If these dependencies are available as both static and shared libs, you can force the static ones to be used by setting: `AWS_CRT_BUILD_FORCE_STATIC_LIBS=1`
+
 ## Mac-Only TLS Behavior
 
 Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically. Beginning in v0.6.2, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:


### PR DESCRIPTION
**Issue:**
https://github.com/awslabs/aws-crt-python/pull/593 introduced env-var, `AWS_CRT_BUILD_USE_SYSTEM_LIBS=1`, but it didn't work unless those system libs were built statically.

**Diagnosis:**
The reason it didn't work is: there's a hack in [setup.py](https://github.com/awslabs/aws-crt-python/blob/2dae492d57b40c68839f2ecd7867bea34e6f9f1a/setup.py#L339-L348) that forces dependencies to be linked statically on Unix variants (excluding macOS). It worked when I tested on macOS because the hack isn't applied there.

The reason for the hack is: in Brazil (internal AWS build system), dependencies are available as both static and dynamic libs. But we prefer to link the static ones so that, if a python application is packaged for AWS lambda, the developer has fewer files they need to chase down and copy into their .zip package.

**Description of changes:**
Don't force static libs to be used unless `AWS_CRT_BUILD_FORCE_STATIC_LIBS=1` (new env-var).  Otherwise (by default), the linker will use whatever version of the lib is available (if both are available, linkers generally prefer dynamic). This only applies to non-OS dependencies, we won't force libc to be linked statically.

It's unlikely this env-var will be used anywhere except Brazil.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
