### PR TITLE
Fix Release Pipeline for distutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           - x64
           - x86
         python:
-          - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
     permissions:
@@ -52,7 +51,6 @@ jobs:
           - x86
           - aarch64
         python:
-          - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
           - cp310-cp310
@@ -85,7 +83,6 @@ jobs:
           - x64
           - aarch64
         python:
-          - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
           - cp310-cp310

--- a/codebuild/cd/manylinux-x64-build.yml
+++ b/codebuild/cd/manylinux-x64-build.yml
@@ -12,8 +12,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
-      - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp37-cp37m-linux_x86_64.whl
       - /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_x86_64 dist/awscrt-*cp38-cp38-linux_x86_64.whl
       - /opt/python/cp39-cp39/bin/python setup.py sdist bdist_wheel

--- a/codebuild/cd/manylinux-x86-build.yml
+++ b/codebuild/cd/manylinux-x86-build.yml
@@ -12,8 +12,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - /opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
-      - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp37-cp37m-linux_i686.whl
       - /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel
       - auditwheel repair --plat manylinux1_i686 dist/awscrt-*cp38-cp38-linux_i686.whl
       - /opt/python/cp39-cp39/bin/python setup.py sdist bdist_wheel

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
-auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp37*.whl
-
 /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp38*.whl
 

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
@@ -20,6 +20,10 @@ auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp311*.whl
 # The 3.11 wheel uses the stable ABI, so it works with newer versions too.
 
 # We are using the Python 3.13 stable ABI from Python 3.13 onwards because of deprecated functions.
+# Manylinux images don't contain setuptools from Python 3.13, so we need to install it.
+# Install in a custom location due to access issues.
+/opt/python/cp313-cp313/bin/python -m pip install --target ./local -r requirements-dev.txt
+export PYTHONPATH=./local:$PYTHONPATH
 /opt/python/cp313-cp313/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp313*.whl
 

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
-auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp37*.whl
-
 /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp38*.whl
 

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
@@ -20,6 +20,10 @@ auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp311*.whl
 # The 3.11 wheel uses the stable ABI, so it works with newer versions too.
 
 # We are using the Python 3.13 stable ABI from Python 3.13 onwards because of deprecated functions.
+# Manylinux images don't contain setuptools from Python 3.13, so we need to install it.
+# Install in a custom location due to access issues.
+/opt/python/cp313-cp313/bin/python -m pip install --target ./local -r requirements-dev.txt
+export PYTHONPATH=./local:$PYTHONPATH
 /opt/python/cp313-cp313/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp313*.whl
 

--- a/continuous-delivery/build-wheels-musllinux-1-1-aarch64.sh
+++ b/continuous-delivery/build-wheels-musllinux-1-1-aarch64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
-auditwheel repair --plat musllinux_1_1_aarch64 dist/awscrt-*cp37*.whl
-
 /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat musllinux_1_1_aarch64 dist/awscrt-*cp38*.whl
 

--- a/continuous-delivery/build-wheels-musllinux-1-1-aarch64.sh
+++ b/continuous-delivery/build-wheels-musllinux-1-1-aarch64.sh
@@ -20,6 +20,10 @@ auditwheel repair --plat musllinux_1_1_aarch64 dist/awscrt-*cp311*.whl
 # The 3.11 wheel uses the stable ABI, so it works with newer versions too.
 
 # We are using the Python 3.13 stable ABI from Python 3.13 onwards because of deprecated functions.
+# Manylinux images don't contain setuptools from Python 3.13, so we need to install it.
+# Install in a custom location due to access issues.
+/opt/python/cp313-cp313/bin/python -m pip install --target ./local -r requirements-dev.txt
+export PYTHONPATH=./local:$PYTHONPATH
 /opt/python/cp313-cp313/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat musllinux_1_1_aarch64 dist/awscrt-*cp313*.whl
 

--- a/continuous-delivery/build-wheels-musllinux-1-1-x86_64.sh
+++ b/continuous-delivery/build-wheels-musllinux-1-1-x86_64.sh
@@ -20,6 +20,10 @@ auditwheel repair --plat musllinux_1_1_x86_64 dist/awscrt-*cp311*.whl
 # The 3.11 wheel uses the stable ABI, so it works with newer versions too.
 
 # We are using the Python 3.13 stable ABI from Python 3.13 onwards because of deprecated functions.
+# Manylinux images don't contain setuptools from Python 3.13, so we need to install it.
+# Install in a custom location due to access issues.
+/opt/python/cp313-cp313/bin/python -m pip install --target ./local -r requirements-dev.txt
+export PYTHONPATH=./local:$PYTHONPATH
 /opt/python/cp313-cp313/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat musllinux_1_1_x86_64 dist/awscrt-*cp313*.whl
 

--- a/continuous-delivery/build-wheels-musllinux-1-1-x86_64.sh
+++ b/continuous-delivery/build-wheels-musllinux-1-1-x86_64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp37-cp37m/bin/python setup.py sdist bdist_wheel
-auditwheel repair --plat musllinux_1_1_x86_64 dist/awscrt-*cp37*.whl
-
 /opt/python/cp38-cp38/bin/python setup.py sdist bdist_wheel
 auditwheel repair --plat musllinux_1_1_x86_64 dist/awscrt-*cp38*.whl
 

--- a/continuous-delivery/build-wheels-osx.sh
+++ b/continuous-delivery/build-wheels-osx.sh
@@ -5,7 +5,6 @@ set -ex
 
 /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 ./continuous-delivery/update-version.py
 
-/Library/Frameworks/Python.framework/Versions/3.7/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 setup.py sdist bdist_wheel
 /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 setup.py sdist bdist_wheel

--- a/continuous-delivery/build-wheels-win32.bat
+++ b/continuous-delivery/build-wheels-win32.bat
@@ -1,7 +1,6 @@
 
 "C:\Program Files (x86)\Python39-32\python.exe" .\continuous-delivery\update-version.py || goto error
 
-"C:\Program Files (x86)\Python37-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python38-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python39-32\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files (x86)\Python310-32\python.exe" setup.py sdist bdist_wheel || goto error

--- a/continuous-delivery/build-wheels-win64.bat
+++ b/continuous-delivery/build-wheels-win64.bat
@@ -1,6 +1,5 @@
 "C:\Program Files\Python39\python.exe" continuous-delivery\update-version.py || goto error
 
-"C:\Program Files\Python37\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python38\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python39\python.exe" setup.py sdist bdist_wheel || goto error
 "C:\Program Files\Python310\python.exe" setup.py sdist bdist_wheel || goto error

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ def determine_generator_args():
     if sys.platform == 'win32':
         try:
             # See which compiler python picks
+            from setuptools._distutils import ccompiler  # We use ccompiler on windows to determine the msvc version
             compiler = ccompiler.new_compiler()
             compiler.initialize()
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,9 @@ def determine_generator_args():
     if sys.platform == 'win32':
         try:
             # See which compiler python picks
-            compiler = setuptools._distutils.ccompiler.new_compiler()
+            from setuptools._distutils import ccompiler  # We use ccompiler on windows to determine the msvc version
+            compiler = ccompiler.new_compiler()
+            compiler.initialize()
 
             # Look at compiler path to divine the Visual Studio version.
             # This technique may not work with customized VS install paths.
@@ -322,6 +324,7 @@ def awscrt_ext():
     libraries.reverse()
 
     if sys.platform == 'win32':
+        from setuptools._distutils import ccompiler # We use ccompiler on windows to determine the msvc version
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']
         # Ensure that debug info is in the obj files, and that it is linked into the .pyd so that
@@ -370,7 +373,7 @@ def awscrt_ext():
         # rare cases where that didn't happen, so let's be explicit.
         extra_link_args += ['-pthread']
 
-    if sys.platform != 'win32' or setuptools._distutils.ccompiler.get_default_compiler() != 'msvc':
+    if sys.platform != 'win32' or ccompiler.get_default_compiler() != 'msvc':
         extra_compile_args += ['-Wno-strict-aliasing', '-std=gnu99']
 
         # treat warnings as errors in development mode

--- a/setup.py
+++ b/setup.py
@@ -304,11 +304,10 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
 class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
         python, abi, plat = super().get_tag()
+        # on CPython, our wheels are abi3 and compatible back to 3.11
         if python.startswith("cp") and sys.version_info >= (3, 13):
-            # on CPython, our wheels are abi3 and compatible back to 3.11
             return "cp313", "abi3", plat
         elif python.startswith("cp") and sys.version_info >= (3, 11):
-            # on CPython, our wheels are abi3 and compatible back to 3.11
             return "cp311", "abi3", plat
 
         return python, abi, plat

--- a/setup.py
+++ b/setup.py
@@ -326,7 +326,7 @@ def awscrt_ext():
 
     if sys.platform == 'win32':
         # distutils is deprecated in Python 3.10 and removed in 3.12. However, it still works because Python defines a compatibility interface as long as setuptools is installed.
-        # We don't have an official alternative for distutils.ccompiler as of September 2024. See: https://github.com/pypa/setuptools/pull/3445
+        # We don't have an official alternative for distutils.ccompiler as of September 2024. See: https://github.com/pypa/setuptools/issues/2806
         # Once that issue is resolved, we can migrate to the official solution.
         # For now, restrict distutils to Windows only, where it's needed.
         import distutils.ccompiler

--- a/setup.py
+++ b/setup.py
@@ -325,6 +325,7 @@ def awscrt_ext():
     libraries.reverse()
 
     if sys.platform == 'win32':
+        from setuptools._distutils import ccompiler  # We use ccompiler on windows to determine the msvc version
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']
         # Ensure that debug info is in the obj files, and that it is linked into the .pyd so that

--- a/setup.py
+++ b/setup.py
@@ -304,7 +304,10 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
 class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
         python, abi, plat = super().get_tag()
-        if python.startswith("cp") and sys.version_info >= (3, 11):
+        if python.startswith("cp") and sys.version_info >= (3, 13):
+            # on CPython, our wheels are abi3 and compatible back to 3.11
+            return "cp313", "abi3", plat
+        elif python.startswith("cp") and sys.version_info >= (3, 11):
             # on CPython, our wheels are abi3 and compatible back to 3.11
             return "cp311", "abi3", plat
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def determine_generator_args():
         try:
             # See which compiler python picks
             import distutils.ccompiler
-            compiler = ccompiler.new_compiler()
+            compiler = distutils.ccompiler.new_compiler()
             compiler.initialize()
 
             # Look at compiler path to divine the Visual Studio version.
@@ -377,7 +377,7 @@ def awscrt_ext():
         # rare cases where that didn't happen, so let's be explicit.
         extra_link_args += ['-pthread']
 
-    if sys.platform != 'win32' or ccompiler.get_default_compiler() != 'msvc':
+    if sys.platform != 'win32' or distutils.ccompiler.get_default_compiler() != 'msvc':
         extra_compile_args += ['-Wno-strict-aliasing', '-std=gnu99']
 
         # treat warnings as errors in development mode

--- a/setup.py
+++ b/setup.py
@@ -306,8 +306,10 @@ class bdist_wheel_abi3(bdist_wheel):
         python, abi, plat = super().get_tag()
         # on CPython, our wheels are abi3 and compatible back to 3.11
         if python.startswith("cp") and sys.version_info >= (3, 13):
+            # 3.13 deprecates PyWeakref_GetObject(), adds alternative
             return "cp313", "abi3", plat
         elif python.startswith("cp") and sys.version_info >= (3, 11):
+            # 3.11 is the first stable ABI that has everything we need
             return "cp311", "abi3", plat
 
         return python, abi, plat

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def determine_generator_args():
     if sys.platform == 'win32':
         try:
             # See which compiler python picks
-            from setuptools._distutils import ccompiler  # We use ccompiler on windows to determine the msvc version
+            import distutils.ccompiler
             compiler = ccompiler.new_compiler()
             compiler.initialize()
 
@@ -325,7 +325,10 @@ def awscrt_ext():
     libraries.reverse()
 
     if sys.platform == 'win32':
-        from setuptools._distutils import ccompiler  # We use ccompiler on windows to determine the msvc version
+        # distutils is deprecated in Python 3.10 and removed in 3.12. However, it still works because Python defines a compatibility interface as long as setuptools is installed.
+        # We don't have an official alternative for distutils.ccompiler as of September 2024. See: https://github.com/pypa/setuptools/pull/3445
+        # Once that issue is resolved, we can migrate to the official solution. For now, restrict distutils to Windows only, where it's needed.
+        import distutils.ccompiler
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']
         # Ensure that debug info is in the obj files, and that it is linked into the .pyd so that

--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,7 @@ def determine_generator_args():
     if sys.platform == 'win32':
         try:
             # See which compiler python picks
-            from setuptools._distutils import ccompiler  # We use ccompiler on windows to determine the msvc version
-            compiler = ccompiler.new_compiler()
-            compiler.initialize()
+            compiler = setuptools._distutils.ccompiler.new_compiler()
 
             # Look at compiler path to divine the Visual Studio version.
             # This technique may not work with customized VS install paths.
@@ -324,7 +322,6 @@ def awscrt_ext():
     libraries.reverse()
 
     if sys.platform == 'win32':
-        from setuptools._distutils import ccompiler # We use ccompiler on windows to determine the msvc version
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']
         # Ensure that debug info is in the obj files, and that it is linked into the .pyd so that
@@ -373,7 +370,7 @@ def awscrt_ext():
         # rare cases where that didn't happen, so let's be explicit.
         extra_link_args += ['-pthread']
 
-    if sys.platform != 'win32' or ccompiler.get_default_compiler() != 'msvc':
+    if sys.platform != 'win32' or setuptools._distutils.ccompiler.get_default_compiler() != 'msvc':
         extra_compile_args += ['-Wno-strict-aliasing', '-std=gnu99']
 
         # treat warnings as errors in development mode

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
-
 import codecs
-import distutils.ccompiler
 import glob
 import os
 import os.path
@@ -15,7 +13,6 @@ import subprocess
 import sys
 import sysconfig
 from wheel.bdist_wheel import bdist_wheel
-
 
 def is_64bit():
     return sys.maxsize > 2 ** 32
@@ -78,7 +75,7 @@ def determine_generator_args():
     if sys.platform == 'win32':
         try:
             # See which compiler python picks
-            compiler = distutils.ccompiler.new_compiler()
+            compiler = ccompiler.new_compiler()
             compiler.initialize()
 
             # Look at compiler path to divine the Visual Studio version.
@@ -326,6 +323,7 @@ def awscrt_ext():
     libraries.reverse()
 
     if sys.platform == 'win32':
+        from setuptools._distutils import ccompiler # We use ccompiler on windows to determine the msvc version
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']
         # Ensure that debug info is in the obj files, and that it is linked into the .pyd so that
@@ -374,7 +372,7 @@ def awscrt_ext():
         # rare cases where that didn't happen, so let's be explicit.
         extra_link_args += ['-pthread']
 
-    if distutils.ccompiler.get_default_compiler() != 'msvc':
+    if sys.platform != 'win32' or ccompiler.get_default_compiler() != 'msvc':
         extra_compile_args += ['-Wno-strict-aliasing', '-std=gnu99']
 
         # treat warnings as errors in development mode

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ import sys
 import sysconfig
 from wheel.bdist_wheel import bdist_wheel
 
+
 def is_64bit():
     return sys.maxsize > 2 ** 32
 
@@ -324,7 +325,6 @@ def awscrt_ext():
     libraries.reverse()
 
     if sys.platform == 'win32':
-        from setuptools._distutils import ccompiler # We use ccompiler on windows to determine the msvc version
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']
         # Ensure that debug info is in the obj files, and that it is linked into the .pyd so that

--- a/setup.py
+++ b/setup.py
@@ -327,7 +327,8 @@ def awscrt_ext():
     if sys.platform == 'win32':
         # distutils is deprecated in Python 3.10 and removed in 3.12. However, it still works because Python defines a compatibility interface as long as setuptools is installed.
         # We don't have an official alternative for distutils.ccompiler as of September 2024. See: https://github.com/pypa/setuptools/pull/3445
-        # Once that issue is resolved, we can migrate to the official solution. For now, restrict distutils to Windows only, where it's needed.
+        # Once that issue is resolved, we can migrate to the official solution.
+        # For now, restrict distutils to Windows only, where it's needed.
         import distutils.ccompiler
         # the windows apis being used under the hood. Since we're static linking we have to follow the entire chain down
         libraries += ['Secur32', 'Crypt32', 'Advapi32', 'NCrypt', 'BCrypt', 'Kernel32', 'Ws2_32', 'Shlwapi']


### PR DESCRIPTION
*Description of changes:*
- Disutils is deprecated, however, currently there is no alternative see: https://github.com/pypa/setuptools/issues/2806
- This PR restricts disutils dependency to Windows only
- Drop Python 3.7 as it is EOL 
- Install requirements-dev.txt in Python 3.13 since manylinux images removed it see: https://github.com/pypa/manylinux/pull/1564/files#diff-de469cc9cf8992ffaec661b4e087cfded3ec6da722072ec1fdf11f61690fd1b8R3
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
