### PR TITLE
Finish dropping python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   PACKAGE_NAME: aws-crt-python
   LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
-  CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }} 
+  CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1
 
 jobs:
@@ -231,7 +231,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "C:\\hostedtoolcache\\windows\\Python\\3.7.9\\${{ matrix.arch }}\\python.exe"
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "C:\\hostedtoolcache\\windows\\Python\\3.8.10\\${{ matrix.arch }}\\python.exe"
 
 
   macos:
@@ -293,7 +293,7 @@ jobs:
           version: ${{ matrix.version }}
           cpu_count: 4
           shell: bash
-          environment_variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION 
+          environment_variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
           run: |
             sudo pkg_add awscli py3-pip py3-urllib3
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
@@ -321,7 +321,7 @@ jobs:
           version: '14.0'
           cpu_count: 4
           shell: bash
-          environment_variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION 
+          environment_variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
           run: |
             sudo pkg install -y python3 devel/py-pip net/py-urllib3 devel/py-awscli cmake
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
@@ -335,7 +335,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Run tests 
+      - name: Run tests
         run: |
           python3 -m pip install --upgrade --requirement requirements-dev.txt
           python3 -m pip install . --verbose

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is licensed under the Apache 2.0 License.
 
 ## Minimum Requirements:
 
-*   Python 3.7+
+*   Python 3.8+
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -466,7 +466,7 @@ setuptools.setup(
         "Operating System :: Unix",
         "Operating System :: MacOS",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     ext_modules=[awscrt_ext()],
     cmdclass={'build_ext': awscrt_build_ext, "bdist_wheel": bdist_wheel_abi3},
     test_suite='test',


### PR DESCRIPTION
When we dropped support for python 3.7 in https://github.com/awslabs/aws-crt-python/pull/598
we forgot to update setup.py, and the README


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
