### PR TITLE
Add checksums to documentation

### DIFF
--- a/docsrc/source/api/checksums.rst
+++ b/docsrc/source/api/checksums.rst
@@ -1,0 +1,5 @@
+awscrt.checksums
+================
+
+.. automodule:: awscrt.checksums
+    :members:

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -12,6 +12,7 @@ API Reference
    :maxdepth: 2
 
    api/auth
+   api/checksums
    api/common
    api/crypto
    api/exceptions


### PR DESCRIPTION
### Overview
This PR updates the documentation for this package to include the functions in `awscrt/checksums.py`.

### Testing
> Note: Python 3.10 is used to match what is being used in the github action that publishes docs. The existing docs fail with Python 3.12. However, that is outside the scope of this PR.

```
# Setup a Python 3.10 virtual environment
python -m venv venv
. venv/bin/activate

# Install required dependencies
python -m pip install -r requirements-dev.txt
python -m pip install .

# Generate documentation for `awscrt`
cd docsrc
make html

# View the generated documentation
cd build/html
python -m http.server
# View HTML hosted locally. See screenshots below.
```
**Update:** I realized there is also a `make-docs.py` script. That also worked

<img width="1792" alt="Screenshot 2024-10-02 at 3 57 16 PM" src="https://github.com/user-attachments/assets/b19e3dc4-d1bc-4a90-98c5-b3f2159fe75e">
<img width="1791" alt="Screenshot 2024-10-02 at 3 57 25 PM" src="https://github.com/user-attachments/assets/2ffc37d4-6b32-4583-a7e4-5030baf96ffa">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
