### PR TITLE
Remove deprecated `ByteString`

### DIFF
--- a/awscrt/eventstream/__init__.py
+++ b/awscrt/eventstream/__init__.py
@@ -5,9 +5,8 @@ event-stream library for `awscrt`.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from collections.abc import ByteString
 from enum import IntEnum
-from typing import Any
+from typing import Any, Union
 from uuid import UUID
 
 __all__ = ['HeaderType', 'Header']
@@ -135,7 +134,7 @@ class Header:
         return cls(name, value, HeaderType.INT64)
 
     @classmethod
-    def from_byte_buf(cls, name: str, value: ByteString) -> 'Header':
+    def from_byte_buf(cls, name: str, value: Union[bytes, bytearray]) -> 'Header':
         """Create a Header of type :attr:`~HeaderType.BYTE_BUF`
 
         The value must be a bytes-like object"""
@@ -246,7 +245,7 @@ class Header:
         Raises an exception if type is not :attr:`~HeaderType.INT64`"""
         return self._value_as(HeaderType.INT64)
 
-    def value_as_byte_buf(self) -> ByteString:
+    def value_as_byte_buf(self) -> Union[bytes, bytearray]:
         """Return value of bytes
 
         Raises an exception if type is not :attr:`~HeaderType.BYTE_BUF`"""

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -11,7 +11,7 @@ from awscrt import NativeResource
 import awscrt.exceptions
 from awscrt.eventstream import Header
 from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
-from collections.abc import ByteString, Callable
+from collections.abc import Callable, Union
 from concurrent.futures import Future
 from enum import IntEnum
 from functools import partial
@@ -381,7 +381,7 @@ class ClientConnection(NativeResource):
             self,
             *,
             headers: Optional[Sequence[Header]] = None,
-            payload: Optional[ByteString] = None,
+            payload: Optional[Union[bytes, bytearray]] = None,
             message_type: MessageType,
             flags: Optional[int] = None,
             on_flush: Callable = None) -> 'concurrent.futures.Future':
@@ -483,7 +483,7 @@ class ClientContinuation(NativeResource):
             *,
             operation: str,
             headers: Sequence[Header] = None,
-            payload: ByteString = None,
+            payload: Union[bytes, bytearray] = None,
             message_type: MessageType,
             flags: int = None,
             on_flush: Callable = None):
@@ -553,7 +553,7 @@ class ClientContinuation(NativeResource):
             self,
             *,
             headers: Sequence[Header] = None,
-            payload: ByteString = None,
+            payload: Union[bytes, bytearray] = None,
             message_type: MessageType,
             flags: int = None,
             on_flush: Callable = None) -> 'concurrent.futures.Future':

--- a/awscrt/eventstream/rpc.py
+++ b/awscrt/eventstream/rpc.py
@@ -11,11 +11,11 @@ from awscrt import NativeResource
 import awscrt.exceptions
 from awscrt.eventstream import Header
 from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
-from collections.abc import Callable, Union
+from collections.abc import Callable
 from concurrent.futures import Future
 from enum import IntEnum
 from functools import partial
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 __all__ = [
     'MessageType',


### PR DESCRIPTION
`ByteString` has been deprecated in Python 3.12 and will be removed in Python 3.14. Replace it with `Union[bytes, bytearray]`.

See: https://docs.python.org/dev/deprecations/pending-removal-in-3.14.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
