### PR TITLE
Fix macos universal2 detection in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def is_macos_universal2():
         return False
 
     cflags = sysconfig.get_config_var('CFLAGS')
-    return '-arch x86_64' in cflags and '-arch x86_64' in cflags
+    return '-arch x86_64' in cflags and '-arch arm64' in cflags
 
 
 def determine_cross_compile_args():


### PR DESCRIPTION
Thanks @TingDaoK for discovering this copy/paste bug.

This wasn't causing any actual problems (other than longer-than-necessary build times on macos-but-not-universal2 builds of python ... which are exceedingly rare these days), but it's fixed now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
