### PR TITLE
Fix aarch64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
       # set arm arch
       - name: Install qemu/docker
-        run: docker run --privileged --rm tonistiigi/binfmt --install arm/v7
+        run: docker run --privileged --rm tonistiigi/binfmt --install armv7
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.11
+          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.12
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
       # set arm arch
       - name: Install qemu/docker
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: docker run --privileged --rm tonistiigi/binfmt --install arm/v7
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -186,7 +186,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
 
   use-system-libcrypto:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.10
+          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.11
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
             sudo pkg_add awscli py3-pip py3-urllib3
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
-            ./builder build -p ${{ env.PACKAGE_NAME }}
+            ./builder build -p ${{ env.PACKAGE_NAME }} --variant=current_python
 
   freebsd:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }}
+          ./builder build -p ${{ env.PACKAGE_NAME }} --variant=current_python
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so
@@ -298,7 +298,7 @@ jobs:
             sudo pkg_add awscli py3-pip py3-urllib3
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
-            ./builder build -p ${{ env.PACKAGE_NAME }} --variant=current_python
+            ./builder build -p ${{ env.PACKAGE_NAME }}
 
   freebsd:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
 
   # check that docs can still build
   check-docs:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
 
   use-system-libcrypto:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       # Only aarch64 needs this, but it doesn't hurt anything
       - name: Install qemu/docker
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: docker run --privileged --rm tonistiigi/binfmt --install aarch64
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -100,7 +100,7 @@ jobs:
 
       # Only aarch64 needs this, but it doesn't hurt anything
       - name: Install qemu/docker
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: docker run --privileged --rm tonistiigi/binfmt --install aarch64
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -133,7 +133,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
 
   linux-compat:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
         image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
       # set arm arch
       - name: Install qemu/docker
-        run: docker run --privileged --rm tonistiigi/binfmt --install armv7
+        run: docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.74
+  BUILDER_VERSION: v0.9.67
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-python
@@ -42,7 +42,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-manylinux1-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --python /opt/python/${{ matrix.python }}/bin/python
 
   manylinux2014:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-20.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       # Only aarch64 needs this, but it doesn't hurt anything
       - name: Install qemu/docker
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -137,6 +137,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - al2-x64
           - fedora-34-x64
           - opensuse-leap
           - rhel8-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   manylinux1:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-musllinux-1-1-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --python /opt/python/${{ matrix.python }}/bin/python
 
   raspberry:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +125,7 @@ jobs:
 
       # set arm arch
       - name: Install qemu/docker
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -155,7 +155,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
 
   linux-compiler-compat:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
         compiler:
@@ -268,7 +268,7 @@ jobs:
 
 
   openbsd:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -301,7 +301,7 @@ jobs:
             ./builder build -p ${{ env.PACKAGE_NAME }}
 
   freebsd:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
@@ -330,7 +330,7 @@ jobs:
 
   # check that tests requiring custom env-vars or AWS credentials are simply skipped
   tests-ok-without-creds:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -342,7 +342,7 @@ jobs:
           python3 -m unittest discover --failfast --verbose
 
   package-source:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
@@ -363,7 +363,7 @@ jobs:
 
   # check that docs can still build
   check-docs:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -375,7 +375,7 @@ jobs:
           ./scripts/make-docs.py
 
   check-submodules:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     steps:
     - name: Checkout Source
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --python=3.11
+          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.11
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-manylinux1-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --python /opt/python/${{ matrix.python }}/bin/python
 
   manylinux2014:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       # Only aarch64 needs this, but it doesn't hurt anything
       - name: Install qemu/docker
-        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
@@ -75,7 +75,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-manylinux2014-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --python /opt/python/${{ matrix.python }}/bin/python
 
   musllinux-1-1:
-    runs-on: ubuntu-22.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -100,7 +100,7 @@ jobs:
 
       # Only aarch64 needs this, but it doesn't hurt anything
       - name: Install qemu/docker
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --variant=current_python
+          ./builder build -p ${{ env.PACKAGE_NAME }} --python=3.11
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.11
+          ./builder build -p ${{ env.PACKAGE_NAME }} --python=python3.10
       - name: Assert libcrypto.so used
         run: |
           # assert it's linked against the system's libcrypto.so

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         ./format-check.py
 
   autopep8:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-24.04 # latest
 
     steps:
     - name: Checkout Source

--- a/builder.json
+++ b/builder.json
@@ -27,17 +27,5 @@
         "aws-crt-python"
     ],
     "upstream": [],
-    "downstream": [],
-
-    "variants": {
-        "current_python": {
-            "hosts": {
-                "ubuntu": {
-                    "!variables": {
-                        "python": "python3.11"
-                    }
-                }
-            }
-        }
-    }
+    "downstream": []
 }

--- a/builder.json
+++ b/builder.json
@@ -27,5 +27,17 @@
         "aws-crt-python"
     ],
     "upstream": [],
-    "downstream": []
+    "downstream": [],
+
+    "variants": {
+        "current_python": {
+            "hosts": {
+                "ubuntu": {
+                    "!variables": {
+                        "python": "python3.11"
+                    }
+                }
+            }
+        }
+    }
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 autopep8 # for code formatting
 setuptools # for installing from source
+packaging # for setuptools, which will fail otherwise with system installed one
 sphinx>=7.2.6,<7.3; python_version >= '3.9' # for building docs
 websockets # for tests
 wheel # for building wheels


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We rely on qemu to test aarch64 on x86-64 github runners. 
Qemu had a bug where they had a bug with incorrectly mapping address space. That mostly worked fine until kernel patch that increased entropy in their address randomization. TLDR; qemu likes to segfault a lot against new kernels on our aarch64 test. Solution is to switch to a different github qemu user static image that forces a latest version of qemu, that has the bug fixed.
if you want to read more - https://github.com/tonistiigi/binfmt/issues/240

in a separate issue setuptools now prefers systems version of packages, which breaks against packaging thats on the ubuntu runners by defaults, so add packaging to our deps to ensure its getting the latest version. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
