### PR TITLE
When uploading release with twine, pass `--verbose`

### DIFF
--- a/codebuild/cd/publish_to_prod_pypi.yml
+++ b/codebuild/cd/publish_to_prod_pypi.yml
@@ -21,7 +21,7 @@ phases:
       - ls -la dist/
       - cd aws-crt-python
       - python3 continuous-delivery/pull-pypirc.py prod
-      - python3 -m twine upload -r pypi ../dist/*
+      - python3 -m twine upload --repository pypi --verbose ../dist/*
   post_build:
     commands:
       - echo Build completed on `date`

--- a/codebuild/cd/publish_to_test_pypi.yml
+++ b/codebuild/cd/publish_to_test_pypi.yml
@@ -21,7 +21,7 @@ phases:
       - ls -la dist/
       - cd aws-crt-python
       - python3 continuous-delivery/pull-pypirc.py alpha
-      - python3 -m twine upload -r testpypi ../dist/*
+      - python3 -m twine upload --repository testpypi --verbose ../dist/*
   post_build:
     commands:
       - echo Build completed on `date`


### PR DESCRIPTION
**Issue:**
We had a release fail, the `twine` error message said
> Error during upload. Retry with the --verbose option for more details

**Description of changes:**
Always run with `--verbose`. This runs in a pipeline. We definitely always want to know more details. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
