### PR TITLE
reduce the package size

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,7 +21,7 @@ global-exclude crt/aws-lc/**/crypto_test_data*
 global-include crt/aws-lc/**/trampoline-*
 global-exclude README*
 prune crt/**/AWSCRTAndroidTestRunner
-prune crt/aws-c-auth/tests/
+prune crt/aws-c-auth/tests
 prune crt/aws-c-cal/tests
 prune crt/aws-c-common/tests
 prune crt/aws-c-compression/tests
@@ -34,7 +34,7 @@ prune crt/aws-c-s3/benchmarks
 prune crt/s2n/tests
 # s2n's cmake relies on a some files under test/ for compile time feature tests
 graft crt/s2n/tests/features
-prune crt/s2n/compliance/specs/
+prune crt/s2n/compliance/specs
 exclude crt/aws-lc/**/*test*.go
 exclude crt/aws-lc/**/*test*.json
 exclude crt/aws-lc/**/*test*.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,23 +4,39 @@ global-exclude .git*
 global-exclude .git*/**
 global-exclude .travis*
 global-exclude .travis/**
+global-exclude .builder/**
+global-exclude format-check.py
+global-exclude builder.json
 global-exclude codebuild/**
+global-exclude .clang-format
+global-exclude .clang-tidy
 global-exclude crt/*/verification/**
 global-exclude crt/*/docs/**
+global-exclude crt/*/bin/**
+global-exclude crt/*/scripts/**
 global-exclude docker-images/**
+global-exclude crt/aws-lc/**/test/**
+global-exclude crt/aws-lc/**/crypto_test_data*
+# aws-lc includes some files from tests during build
+global-include crt/aws-lc/**/trampoline-*
+global-exclude README*
 prune crt/**/AWSCRTAndroidTestRunner
-prune crt/aws-c-auth/tests/aws-sig-v4-test-suite
-prune crt/aws-c-auth/tests/fuzz/corpus
+prune crt/aws-c-auth/tests/
+prune crt/aws-c-cal/tests
+prune crt/aws-c-common/tests
+prune crt/aws-c-compression/tests
+prune crt/aws-c-io/tests
+prune crt/aws-c-mqtt/tests
+prune crt/aws-c-s3/tests
+prune crt/aws-c-sdkutils/tests
 prune crt/aws-c-cal/ecdsa-fuzz-corpus
 prune crt/aws-c-s3/benchmarks
 prune crt/s2n/tests
-# s2n's cmake relies on a some files under test/ for compile time feature tests
-graft crt/s2n/tests/features
+prune crt/s2n/compliance/specs/
 exclude crt/aws-lc/**/*test*.go
 exclude crt/aws-lc/**/*test*.json
 exclude crt/aws-lc/**/*test*.py
 exclude crt/aws-lc/**/*test*.txt
-prune crt/aws-lc/crypto/cipher_extra/test
 prune crt/aws-lc/fuzz
 prune crt/aws-lc/ssl
 prune crt/aws-lc/tests
@@ -32,5 +48,4 @@ prune crt/aws-lc/tool
 prune crt/aws-lc/util
 include crt/aws-lc/util/fipstools/CMakeLists.txt
 include crt/aws-lc/util/fipstools/acvp/modulewrapper/CMakeLists.txt
-# by default only test/test*.py are included, include the entire test suite
 graft test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,6 +32,8 @@ prune crt/aws-c-sdkutils/tests
 prune crt/aws-c-cal/ecdsa-fuzz-corpus
 prune crt/aws-c-s3/benchmarks
 prune crt/s2n/tests
+# s2n's cmake relies on a some files under test/ for compile time feature tests
+graft crt/s2n/tests/features
 prune crt/s2n/compliance/specs/
 exclude crt/aws-lc/**/*test*.go
 exclude crt/aws-lc/**/*test*.json
@@ -48,4 +50,5 @@ prune crt/aws-lc/tool
 prune crt/aws-lc/util
 include crt/aws-lc/util/fipstools/CMakeLists.txt
 include crt/aws-lc/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+# by default only test/test*.py are included, include the entire test suite
 graft test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,8 +32,6 @@ prune crt/aws-c-sdkutils/tests
 prune crt/aws-c-cal/ecdsa-fuzz-corpus
 prune crt/aws-c-s3/benchmarks
 prune crt/s2n/tests
-# s2n's cmake relies on a some files under test/ for compile time feature tests
-graft crt/s2n/tests/features
 prune crt/s2n/compliance/specs
 exclude crt/aws-lc/**/*test*.go
 exclude crt/aws-lc/**/*test*.json

--- a/continuous-delivery/update-version.py
+++ b/continuous-delivery/update-version.py
@@ -4,9 +4,12 @@ import os
 import re
 import subprocess
 
-tag = subprocess.check_output(['git', 'describe', '--tags'])
-# strip the leading v
-version = str(tag[1:].strip(), 'utf8')
+tag = subprocess.run(['git', 'describe', '--tags'],
+                     capture_output=True, check=True,
+                     text=True).stdout.strip()
+# convert v0.2.12-2-g50254a9 to 0.2.12
+# test-version-exists will ensure to not include non-tagged commits
+version = tag.split('-', 1)[0]
 init_path = os.path.join(os.path.dirname(__file__), '..', 'awscrt', '__init__.py')
 print("Updating awscrt.__version__ to version {}".format(version))
 contents = None

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -79,7 +79,6 @@ if(UNIX AND NOT APPLE)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
-            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
     )
 endif()
 

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -45,6 +45,7 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
             -DDISABLE_PERL=ON  # Build without using Perl, we don't want the extra dependency
             -DBUILD_LIBSSL=OFF  # Don't need libssl, only need libcrypto
             -DBUILD_TESTING=OFF
+            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
         )
 
         if (APPLE OR WIN32)
@@ -79,6 +80,8 @@ if(UNIX AND NOT APPLE)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
+            -DS2N_LTO=ON
+            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
     )
 endif()
 

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -45,7 +45,6 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
             -DDISABLE_PERL=ON  # Build without using Perl, we don't want the extra dependency
             -DBUILD_LIBSSL=OFF  # Don't need libssl, only need libcrypto
             -DBUILD_TESTING=OFF
-            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
         )
 
         if (APPLE OR WIN32)
@@ -80,8 +79,6 @@ if(UNIX AND NOT APPLE)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
-            -DS2N_LTO=ON
-            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
     )
 endif()
 

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -28,7 +28,7 @@ include(CTest)
 
 option(AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE "Set this if you want to use libcrypto to support ed25519 on Window/Apple" ON)
 
-# Use minimal debug info
+# Use minimal debug info to reduce binary size.
 string(REPLACE "-g" "-g1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-g" "-g1" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
@@ -45,6 +45,7 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
             -DDISABLE_PERL=ON  # Build without using Perl, we don't want the extra dependency
             -DBUILD_LIBSSL=OFF  # Don't need libssl, only need libcrypto
             -DBUILD_TESTING=OFF
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo  # Use the same build type as the rest of the project
         )
 
         if (APPLE OR WIN32)

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -80,7 +80,6 @@ if(UNIX AND NOT APPLE)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
-            -DS2N_LTO=ON
             -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
     )
 endif()

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -45,7 +45,6 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
             -DDISABLE_PERL=ON  # Build without using Perl, we don't want the extra dependency
             -DBUILD_LIBSSL=OFF  # Don't need libssl, only need libcrypto
             -DBUILD_TESTING=OFF
-            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
         )
 
         if (APPLE OR WIN32)

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -28,6 +28,10 @@ include(CTest)
 
 option(AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE "Set this if you want to use libcrypto to support ed25519 on Window/Apple" ON)
 
+# Use minimal debug info
+string(REPLACE "-g" "-g1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+string(REPLACE "-g" "-g1" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+
 # On Unix we use S2N for TLS and AWS-LC crypto.
 # (On Windows and Apple we use the default OS libraries)
 if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
@@ -41,11 +45,12 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
             -DDISABLE_PERL=ON  # Build without using Perl, we don't want the extra dependency
             -DBUILD_LIBSSL=OFF  # Don't need libssl, only need libcrypto
             -DBUILD_TESTING=OFF
+            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
         )
 
         if (APPLE OR WIN32)
             # Libcrypto implementations typically have several chunky pregenerated tables that add a lot
-            # to artifact size. We dont really need them for ed25519 case on win/mac, so favor 
+            # to artifact size. We dont really need them for ed25519 case on win/mac, so favor
             # smaller binary over perf here.
             # In future if there is more usage of lc on win/mac consider removing this
             list(APPEND AWSLC_CMAKE_ARGUMENTS -DOPENSSL_SMALL=1)
@@ -75,6 +80,8 @@ if(UNIX AND NOT APPLE)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
+            -DS2N_LTO=ON
+            -DCMAKE_BUILD_TYPE=Release # Don't include debug symbols in the library
     )
 endif()
 


### PR DESCRIPTION
*Issue #, if available:*
- To reduce the package size as much as possible.

*Description of changes:*
1. strip more unneeded source from sdist, the specially one is `crt/aws-lc/**/crypto_test_data*`, which is [here](https://github.com/aws/aws-lc/blob/main/generated-src/crypto_test_data.cc.tar.bz2), a 40MB zip file used for tests :) 
2. use `g1` for debug symbol, which reduces the size to almost half

#### Before this change:
```
total 323.6 MB

drwxr-xr-x 2 root root    4.0 KB Apr 28 20:02 .
drwxr-xr-x 4 root root   40.0  B Apr 28 20:02 ..
-rw-r--r-- 1 root root    3.1 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    8.3 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    8.5 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    8.4 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    8.7 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-win32.whl
-rw-r--r-- 1 root root    3.7 MB Apr 28 20:02 awscrt-0.27.0-cp310-cp310-win_amd64.whl
-rw-r--r-- 1 root root    3.1 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    8.2 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    8.5 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    8.3 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    8.7 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-win32.whl
-rw-r--r-- 1 root root    3.7 MB Apr 28 20:02 awscrt-0.27.0-cp311-abi3-win_amd64.whl
-rw-r--r-- 1 root root    3.1 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    8.2 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    8.5 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    8.3 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    8.7 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-win32.whl
-rw-r--r-- 1 root root    3.7 MB Apr 28 20:02 awscrt-0.27.0-cp313-abi3-win_amd64.whl
-rw-r--r-- 1 root root    1.7 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-macosx_10_15_x86_64.whl
-rw-r--r-- 1 root root    8.3 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    8.5 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    7.3 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl
-rw-r--r-- 1 root root    7.7 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r--r-- 1 root root    8.4 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    8.7 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-win32.whl
-rw-r--r-- 1 root root    3.7 MB Apr 28 20:02 awscrt-0.27.0-cp38-cp38-win_amd64.whl
-rw-r--r-- 1 root root    3.1 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    8.3 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    8.5 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    7.3 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl
-rw-r—r— 1 root root    7.7 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r—r— 1 root root    8.4 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-musllinux_1_1_aarch64.whl
-rw-r—r— 1 root root    8.7 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-musllinux_1_1_x86_64.whl
-rw-r—r— 1 root root    3.6 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-win32.whl
-rw-r—r— 1 root root    3.7 MB Apr 28 20:02 awscrt-0.27.0-cp39-cp39-win_amd64.whl
-rw-r—r— 1 root root   73.7 MB Apr 28 20:02 awscrt-0.27.0.tar.gz
```

after this change:
```
total 168.0 MB

drwxr-xr-x 2 root root    4.0 KB May  2 20:41 .
drwxr-xr-x 5 root root   56.0  B May  2 20:41 ..
-rw-r--r-- 1 root root    3.1 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.8 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-win32.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp310-cp310-win_amd64.whl
-rw-r--r-- 1 root root    3.1 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    3.4 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-win32.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp311-abi3-win_amd64.whl
-rw-r--r-- 1 root root    3.1 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    3.4 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-win32.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp313-abi3-win_amd64.whl
-rw-r--r-- 1 root root    1.7 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-macosx_10_15_x86_64.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.8 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    2.5 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl
-rw-r--r-- 1 root root    2.7 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-win32.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp38-cp38-win_amd64.whl
-rw-r--r-- 1 root root    3.1 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.8 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    2.5 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl
-rw-r--r-- 1 root root    2.7 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r--r-- 1 root root    3.5 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    3.6 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-win32.whl
-rw-r--r-- 1 root root    3.7 MB May  2 20:41 awscrt-0.27.0-cp39-cp39-win_amd64.whl
-rw-r--r-- 1 root root   35.2 MB May  2 20:41 awscrt-0.27.0.tar.gz

```


### TODO:
- We can remove manylinux1 now, CLI already dropped it
- maybe fully strip the debug symbol
   - in other CRTs, like aws-crt-java, https://github.com/awslabs/aws-crt-java/blob/main/CMakeLists.txt#L236
   - We strip the debug symbol and try to include it separately, however, the .dbg is not in the distributed package. So, people don't really have access to it.
   - aws-lc failed to build with `Release` on manylinux1-32bit. 
    
With fully stripping the debug symbol, it reduces the size by another 20MB, but arguably right or not. So, leave it as the TODO in the future.
```
total 143.9 MB

drwxr-xr-x 2 root root    4.0 KB May  5 18:51 .
drwxr-xr-x 5 root root   56.0  B May  5 18:51 ..
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.1 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.2 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    2.3 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-win32.whl
-rw-r--r-- 1 root root    2.5 MB May  5 18:51 awscrt-0.27.0-cp310-cp310-win_amd64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    2.9 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.1 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.1 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    2.3 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-win32.whl
-rw-r--r-- 1 root root    2.5 MB May  5 18:51 awscrt-0.27.0-cp311-abi3-win_amd64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    2.9 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.1 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.1 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    2.3 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-win32.whl
-rw-r--r-- 1 root root    2.5 MB May  5 18:51 awscrt-0.27.0-cp313-abi3-win_amd64.whl
-rw-r--r-- 1 root root    1.6 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-macosx_10_15_x86_64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.2 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    2.4 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl
-rw-r--r-- 1 root root    2.6 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.2 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    2.3 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-win32.whl
-rw-r--r-- 1 root root    2.5 MB May  5 18:51 awscrt-0.27.0-cp38-cp38-win_amd64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-macosx_10_15_universal2.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 root root    3.1 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 root root    2.4 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl
-rw-r--r-- 1 root root    2.6 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r--r-- 1 root root    3.0 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-musllinux_1_1_aarch64.whl
-rw-r--r-- 1 root root    3.2 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-musllinux_1_1_x86_64.whl
-rw-r--r-- 1 root root    2.3 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-win32.whl
-rw-r--r-- 1 root root    2.5 MB May  5 18:51 awscrt-0.27.0-cp39-cp39-win_amd64.whl
-rw-r--r-- 1 root root   35.2 MB May  5 18:51 awscrt-0.27.0.tar.gz

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
