### PR TITLE
Remove clang-3 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,6 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - clang-3
           - clang-6
           - clang-8
           - clang-9


### PR DESCRIPTION
Remove clang-3 from CI

CI uses aws-crt-builder, which when instructed to use clang-3, has failed to find it and has been falling back on GNU 7.5 for the past year+. This means while clang-3 is listed in our CI as having been tested, it isn't. Fixing aws-crt-builder to use clang-3 has revealed a large number of build failures across aws-c-* libraries. Lack of issues related to this implies that clang-3 is not in use and can be removed from CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
