### PR TITLE
Request response doc config

### DIFF
--- a/awscrt/__init__.py
+++ b/awscrt/__init__.py
@@ -9,6 +9,8 @@ __all__ = [
     'http',
     'io',
     'mqtt',
+    'mqtt5',
+    'mqtt_request_response',
     's3',
     'websocket',
 ]

--- a/awscrt/mqtt_request_response.py
+++ b/awscrt/mqtt_request_response.py
@@ -62,16 +62,15 @@ class IncomingPublishEvent:
     payload: 'Optional[bytes]' = None
 
 
+SubscriptionStatusListener = Callable[[SubscriptionStatusEvent], None]
 """
 Signature for a handler that listens to subscription status events.
 """
-SubscriptionStatusListener = Callable[[SubscriptionStatusEvent], None]
 
+IncomingPublishListener = Callable[[IncomingPublishEvent], None]
 """
 Signature for a handler that listens to incoming publish events.
 """
-IncomingPublishListener = Callable[[IncomingPublishEvent], None]
-
 
 @dataclass
 class StreamingOperationOptions:

--- a/awscrt/mqtt_request_response.py
+++ b/awscrt/mqtt_request_response.py
@@ -72,6 +72,7 @@ IncomingPublishListener = Callable[[IncomingPublishEvent], None]
 Signature for a handler that listens to incoming publish events.
 """
 
+
 @dataclass
 class StreamingOperationOptions:
     """

--- a/docsrc/source/api/mqtt_request_response.rst
+++ b/docsrc/source/api/mqtt_request_response.rst
@@ -1,0 +1,6 @@
+awscrt.mqtt_request_response
+============================
+
+.. automodule:: awscrt.mqtt_request_response
+    :members:
+    :exclude-members: IncomingPublishEvent, IncomingPublishListener, StreamingOperationOptions, Response, ResponsePath, RequestOptions, Client, StreamingOperation

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -21,6 +21,7 @@ API Reference
    api/io
    api/mqtt
    api/mqtt5
+   api/mqtt_request_response
    api/s3
    api/websocket
 


### PR DESCRIPTION
* Adds sphinx doc configuration for the mqtt_request_response module.
* Fixes a few doc string location issues

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
