### PR TITLE
Update python version in windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,9 +258,9 @@ jobs:
       id-token: write # This is required for requesting the JWT
     steps:
       - uses: actions/setup-python@v5
-        id: python310
+        id: python38
         with:
-          python-version: '3.10.11'
+          python-version: '3.8.10'
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
       - name: configure AWS credentials (containers)
@@ -271,7 +271,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "${{ steps.python310.outputs.python-path }}"
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "${{ steps.python38.outputs.python-path }}"
 
   macos:
     runs-on: macos-14 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "C:\\hostedtoolcache\\windows\\Python\\3.8.10\\${{ matrix.arch }}\\python.exe"
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "C:\\hostedtoolcache\\windows\\Python\\3.9.13\\${{ matrix.arch }}\\python.exe"
 
   macos:
     runs-on: macos-14 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
 
 
   windows:
-    runs-on: windows-2025 # latest
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [x86, x64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,13 +250,18 @@ jobs:
 
 
   windows:
-    runs-on: windows-2022 # latest
+    runs-on: windows-2025 # latest
     strategy:
       matrix:
         arch: [x86, x64]
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+      - uses: actions/setup-python@v5
+        id: python310
+        with:
+          python-version: '3.10.11'
+          architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
@@ -266,7 +271,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "C:\\hostedtoolcache\\windows\\Python\\3.9.13\\${{ matrix.arch }}\\python.exe"
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "${{ steps.python310.outputs.python-path }}"
 
   macos:
     runs-on: macos-14 # latest


### PR DESCRIPTION
*Issue #, if available:*

Currently, Windows CI jobs are failing with error:
```
Failed to run C:\\hostedtoolcache\\windows\\Python\\3.8.10\\x64\\python.exe -m venv D:\a\aws-crt-python\aws-crt-python\aws-crt-python\.venv-builder: Command exited with code 1
```

This is caused by recent changes in GitHub runner images: https://github.com/actions/runner-images/pull/12356

*Description of changes:*

- Use Python 3.10.11 in Windows CI jobs.
- Ensure Python is installed with `actions/setup-python` (windows-2025 doesn't have x86 Python by default)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
