### PR TITLE
Attempt to fix flaky resume connection test

### DIFF
--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -539,7 +539,7 @@ class MqttConnectionTest(NativeResourceTest):
                 on_connection_success_future_dup.result(TIMEOUT)
                 dup_success = True
                 connection_dup.disconnect().result(TIMEOUT)
-            except BaseException :
+            except BaseException:
                 time.sleep(2)
 
         # After the second client disconnects, the first one should reconnect,


### PR DESCRIPTION
The connection resume test is based on some assumptions that don't always hold when using IoT Core.  At times, the interrupting (via duplicate client id) connection is terminated rather than the original connection.  Retry the interruption to work around this.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
