### PR TITLE
Improve log init

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -80,8 +80,7 @@ PyObject *aws_py_init_logging(PyObject *self, PyObject *args) {
         aws_logger_set(&s_logger);
         s_logger_init = true;
     } else {
-        PyErr_SetNone(PyExc_ValueError);
-        return NULL;
+        return PyErr_AwsLastError();
     }
 
     Py_RETURN_NONE;

--- a/source/module.c
+++ b/source/module.c
@@ -70,10 +70,10 @@ PyObject *aws_py_init_logging(PyObject *self, PyObject *args) {
         log_options.filename = file_path;
     }
 
+    /* It is not safe to clean up a running logger */
     if (s_logger_init) {
-        aws_logger_set(NULL);
-        aws_logger_clean_up(&s_logger);
-        s_logger_init = false;
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return PyErr_AwsLastError();
     }
 
     if (aws_logger_init_standard(&s_logger, allocator, &log_options) == AWS_OP_SUCCESS) {


### PR DESCRIPTION
Prevent some crashes when misusing the logging setup API.  It is still not safe to multi-init from different threads, but this is an incremental improvement over the previous state.

https://github.com/awslabs/aws-crt-python/issues/685


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
