### PR TITLE
Retry timeouts

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -57,11 +57,14 @@ class NativeResourceTest(unittest.TestCase):
             NativeResourceTest._previous_test_failed = True
             raise
 
+
 MAX_RETRIES = 5
+
 
 def _is_retryable_exception(e):
     exception_text = str(e)
     return "AWS_IO_TLS_NEGOTIATION_TIMEOUT" in exception_text or "AWS_IO_SOCKET_TIMEOUT" in exception_text
+
 
 def test_retry_wrapper(test_function):
     for i in range(MAX_RETRIES):

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -60,17 +60,21 @@ class MqttConnectionTest(NativeResourceTest):
             on_connection_resumed=on_connection_resumed_callback)
         return connection
 
+    @staticmethod
+    def _is_retryable_exception(e):
+        exception_text = str(e)
+        return "AWS_IO_TLS_NEGOTIATION_TIMEOUT" in exception_text or "AWS_IO_SOCKET_TIMEOUT" in exception_text
+
     def _test_retry_wrapper(self, test_function):
         for i in range(MAX_RETRIES):
             try:
                 test_function()
                 return
             except Exception as e:
-                exception_text = str(e)
-                if "AWS_IO_TLS_NEGOTIATION_TIMEOUT" in exception_text or "AWS_IO_SOCKET_TIMEOUT" in exception_text:
-                    raise
-                else:
+                if self._is_retryable_exception(e) and i + 1 < MAX_RETRIES:
                     time.sleep(1)
+                else:
+                    raise
 
     def _test_connect_disconnect(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
@@ -87,7 +91,7 @@ class MqttConnectionTest(NativeResourceTest):
     def test_connect_disconnect(self):
         self._test_retry_wrapper(self._test_connect_disconnect)
 
-    def test_ecc_connect_disconnect(self):
+    def _test_ecc_connect_disconnect(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_ECC_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_ECC_KEY")
@@ -99,7 +103,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_pkcs11(self):
+    def test_ecc_connect_disconnect(self):
+        self._test_retry_wrapper(self._test_ecc_connect_disconnect)
+
+    def _test_pkcs11(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_pkcs11_lib = _get_env_variable("AWS_TEST_PKCS11_LIB")
         test_input_pkcs11_pin = _get_env_variable("AWS_TEST_PKCS11_PIN")
@@ -121,7 +128,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_pub_sub(self):
+    def test_pkcs11(self):
+        self._test_retry_wrapper(self._test_pkcs11)
+
+    def _test_pub_sub(self):
         self.TEST_TOPIC = '/test/me/senpai/' + str(uuid.uuid4())
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
@@ -164,7 +174,10 @@ class MqttConnectionTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
-    def test_will(self):
+    def test_pub_sub(self):
+        self._test_retry_wrapper(self._test_pub_sub)
+
+    def _test_will(self):
         self.TEST_TOPIC = '/test/me/senpai/' + str(uuid.uuid4())
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
@@ -255,7 +268,10 @@ class MqttConnectionTest(NativeResourceTest):
         # disconnect
         subscriber.disconnect().result(TIMEOUT)
 
-    def test_on_message(self):
+    def test_will(self):
+        self._test_retry_wrapper(self._test_will)
+
+    def _test_on_message(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
@@ -291,7 +307,10 @@ class MqttConnectionTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
-    def test_on_message_old_fn_signature(self):
+    def test_on_message(self):
+        self._test_retry_wrapper(self._test_on_message)
+
+    def _test_on_message_old_fn_signature(self):
         # ensure that message-received callbacks with the old function signature still work
 
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
@@ -336,7 +355,10 @@ class MqttConnectionTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
-    def test_connect_disconnect_with_default_singletons(self):
+    def test_on_message_old_fn_signature(self):
+        self._test_retry_wrapper(self._test_on_message_old_fn_signature)
+
+    def _test_connect_disconnect_with_default_singletons(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
@@ -353,7 +375,10 @@ class MqttConnectionTest(NativeResourceTest):
         EventLoopGroup.release_static_default()
         DefaultHostResolver.release_static_default()
 
-    def test_connect_publish_wait_statistics_disconnect(self):
+    def test_connect_disconnect_with_default_singletons(self):
+        self._test_retry_wrapper(self._test_connect_disconnect_with_default_singletons)
+
+    def _test_connect_publish_wait_statistics_disconnect(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
@@ -385,7 +410,10 @@ class MqttConnectionTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
-    def test_connect_publish_statistics_wait_disconnect(self):
+    def test_connect_publish_wait_statistics_disconnect(self):
+        self._test_retry_wrapper(self._test_connect_publish_wait_statistics_disconnect)
+
+    def _test_connect_publish_statistics_wait_disconnect(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
@@ -425,7 +453,10 @@ class MqttConnectionTest(NativeResourceTest):
         # disconnect
         connection.disconnect().result(TIMEOUT)
 
-    def test_connect_disconnect_with_callbacks_happy(self):
+    def test_connect_publish_statistics_wait_disconnect(self):
+        self._test_retry_wrapper(self._test_connect_publish_statistics_wait_disconnect)
+
+    def _test_connect_disconnect_with_callbacks_happy(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
@@ -458,7 +489,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.disconnect().result(TIMEOUT)
         on_connection_closed_future.result(TIMEOUT)
 
-    def test_connect_disconnect_with_callbacks_unhappy(self):
+    def test_connect_disconnect_with_callbacks_happy(self):
+        self._test_retry_wrapper(self._test_connect_disconnect_with_callbacks_happy)
+
+    def _test_connect_disconnect_with_callbacks_unhappy(self):
         test_input_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
         test_input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         test_input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
@@ -494,7 +528,10 @@ class MqttConnectionTest(NativeResourceTest):
         failure_data = on_onnection_failure_future.result(TIMEOUT)
         self.assertTrue(failure_data['error'] is not None)
 
-    def test_connect_disconnect_with_callbacks_happy_on_resume(self):
+    def test_connect_disconnect_with_callbacks_unhappy(self):
+        self._test_retry_wrapper(self._test_connect_disconnect_with_callbacks_unhappy)
+
+    def _test_connect_disconnect_with_callbacks_happy_on_resume(self):
         # Check that an on_connection_success callback fires on a resumed connection.
 
         # NOTE Since there is no mocked server available on this abstraction level, the only sensible approach
@@ -563,11 +600,14 @@ class MqttConnectionTest(NativeResourceTest):
         connection.disconnect().result(TIMEOUT)
         on_connection_closed_future.result(TIMEOUT)
 
+    def test_connect_disconnect_with_callbacks_happy_on_resume(self):
+        self._test_retry_wrapper(self._test_connect_disconnect_with_callbacks_happy_on_resume)
+
     # ==============================================================
     #             MOSQUITTO CONNECTION TESTS
     # ==============================================================
 
-    def test_mqtt311_direct_connect_minimum(self):
+    def _test_mqtt311_direct_connect_minimum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_PORT"))
 
@@ -583,7 +623,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_direct_connect_basic_auth(self):
+    def test_mqtt311_direct_connect_minimum(self):
+        self._test_retry_wrapper(self._test_mqtt311_direct_connect_minimum)
+
+    def _test_mqtt311_direct_connect_basic_auth(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT"))
         input_username = _get_env_variable("AWS_TEST_MQTT311_BASIC_AUTH_USERNAME")
@@ -603,7 +646,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_direct_connect_tls(self):
+    def test_mqtt311_direct_connect_basic_auth(self):
+        self._test_retry_wrapper(self._test_mqtt311_direct_connect_basic_auth)
+
+    def _test_mqtt311_direct_connect_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT"))
 
@@ -621,7 +667,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_direct_connect_mutual_tls(self):
+    def test_mqtt311_direct_connect_tls(self):
+        self._test_retry_wrapper(self._test_mqtt311_direct_connect_tls)
+
+    def _test_mqtt311_direct_connect_mutual_tls(self):
         input_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY")
         input_host = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
@@ -642,7 +691,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_direct_connect_http_proxy_tls(self):
+    def test_mqtt311_direct_connect_mutual_tls(self):
+        self._test_retry_wrapper(self._test_mqtt311_direct_connect_mutual_tls)
+
+    def _test_mqtt311_direct_connect_http_proxy_tls(self):
         input_proxy_host = _get_env_variable("AWS_TEST_MQTT311_PROXY_HOST")
         input_proxy_port = int(_get_env_variable("AWS_TEST_MQTT311_PROXY_PORT"))
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST")
@@ -671,7 +723,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_websocket_connect_minimum(self):
+    def test_mqtt311_direct_connect_http_proxy_tls(self):
+        self._test_retry_wrapper(self._test_mqtt311_direct_connect_http_proxy_tls)
+
+    def _test_mqtt311_websocket_connect_minimum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_WS_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT311_WS_MQTT_PORT"))
 
@@ -693,7 +748,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_websocket_connect_basic_auth(self):
+    def test_mqtt311_websocket_connect_minimum(self):
+        self._test_retry_wrapper(self._test_mqtt311_websocket_connect_minimum)
+
+    def _test_mqtt311_websocket_connect_basic_auth(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT"))
         input_username = _get_env_variable("AWS_TEST_MQTT311_BASIC_AUTH_USERNAME")
@@ -719,7 +777,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_websocket_connect_tls(self):
+    def test_mqtt311_websocket_connect_basic_auth(self):
+        self._test_retry_wrapper(self._test_mqtt311_websocket_connect_basic_auth)
+
+    def _test_mqtt311_websocket_connect_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_WS_MQTT_TLS_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT311_WS_MQTT_TLS_PORT"))
 
@@ -743,7 +804,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_websocket_connect_http_proxy_tls(self):
+    def test_mqtt311_websocket_connect_tls(self):
+        self._test_retry_wrapper(self._test_mqtt311_websocket_connect_tls)
+
+    def _test_mqtt311_websocket_connect_http_proxy_tls(self):
         input_proxy_host = _get_env_variable("AWS_TEST_MQTT311_PROXY_HOST")
         input_proxy_port = int(_get_env_variable("AWS_TEST_MQTT311_PROXY_PORT"))
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_WS_MQTT_TLS_HOST")
@@ -777,6 +841,8 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
+    def test_mqtt311_websocket_connect_http_proxy_tls(self):
+        self._test_retry_wrapper(self._test_mqtt311_websocket_connect_http_proxy_tls)
 
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -827,5 +827,6 @@ class MqttConnectionTest(NativeResourceTest):
     def test_mqtt311_websocket_connect_http_proxy_tls(self):
         test_retry_wrapper(self._test_mqtt311_websocket_connect_http_proxy_tls)
 
+
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -553,6 +553,10 @@ class MqttConnectionTest(NativeResourceTest):
         self.assertEqual(success_data['return_code'], ConnectReturnCode.ACCEPTED)
         self.assertEqual(success_data['session_present'], False)
 
+        # Putting a sleep here helps prevent a "race" condition in IoT Core where the second connection can get
+        # rejected rather than the first disconnected.
+        time.sleep(5)
+
         # Reset the future for the reconnect attempt.
         on_connection_success_future = Future()
 

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -105,6 +105,8 @@ class Mqtt5TestCallbacks():
             self.future_disconnection.set_result(lifecycle_disconnect_data)
 
 
+MAX_RETRIES = 5
+
 class Mqtt5ClientTest(NativeResourceTest):
 
     def _create_client(
@@ -132,6 +134,22 @@ class Mqtt5ClientTest(NativeResourceTest):
 
         client = mqtt5.Client(client_options)
         return client
+
+    @staticmethod
+    def _is_retryable_exception(e):
+        exception_text = str(e)
+        return "AWS_IO_TLS_NEGOTIATION_TIMEOUT" in exception_text or "AWS_IO_SOCKET_TIMEOUT" in exception_text
+
+    def _test_retry_wrapper(self, test_function):
+        for i in range(MAX_RETRIES):
+            try:
+                test_function()
+                return
+            except Exception as e:
+                if self._is_retryable_exception(e) and i + 1 < MAX_RETRIES:
+                    time.sleep(1)
+                else:
+                    raise
 
     # ==============================================================
     #             CREATION TEST CASES
@@ -195,7 +213,7 @@ class Mqtt5ClientTest(NativeResourceTest):
     #             DIRECT CONNECT TEST CASES
     # ==============================================================
 
-    def test_direct_connect_minimum(self):
+    def _test_direct_connect_minimum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -210,7 +228,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_direct_connect_basic_auth(self):
+    def test_direct_connect_minimum(self):
+        self._test_retry_wrapper(self._test_direct_connect_minimum)
+
+    def _test_direct_connect_basic_auth(self):
         input_username = _get_env_variable("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME")
         input_password = _get_env_variable("AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD")
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST")
@@ -233,7 +254,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_direct_connect_tls(self):
+    def test_direct_connect_basic_auth(self):
+        self._test_retry_wrapper(self._test_direct_connect_basic_auth)
+
+    def _test_direct_connect_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT"))
 
@@ -252,7 +276,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_direct_connect_mutual_tls(self):
+    def test_direct_connect_tls(self):
+        self._test_retry_wrapper(self._test_direct_connect_tls)
+
+    def _test_direct_connect_mutual_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -274,7 +301,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_direct_connect_http_proxy_tls(self):
+    def test_direct_connect_mutual_tls(self):
+        self._test_retry_wrapper(self._test_direct_connect_mutual_tls)
+
+    def _test_direct_connect_http_proxy_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT"))
         input_proxy_host = _get_env_variable("AWS_TEST_MQTT5_PROXY_HOST")
@@ -303,7 +333,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_direct_connect_maximum(self):
+    def test_direct_connect_http_proxy_tls(self):
+        self._test_retry_wrapper(self._test_direct_connect_http_proxy_tls)
+
+    def _test_direct_connect_maximum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -358,11 +391,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_direct_connect_maximum(self):
+        self._test_retry_wrapper(self._test_direct_connect_maximum)
+
     # ==============================================================
     #             WEBSOCKET CONNECT TEST CASES
     # ==============================================================
 
-    def test_websocket_connect_minimum(self):
+    def _test_websocket_connect_minimum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_WS_MQTT_PORT"))
 
@@ -379,7 +415,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_websocket_connect_basic_auth(self):
+    def test_websocket_connect_minimum(self):
+        self._test_retry_wrapper(self._test_websocket_connect_minimum)
+
+    def _test_websocket_connect_basic_auth(self):
         input_username = _get_env_variable("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME")
         input_password = _get_env_variable("AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD")
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST")
@@ -404,7 +443,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_websocket_connect_tls(self):
+    def test_websocket_connect_basic_auth(self):
+        self._test_retry_wrapper(self._test_websocket_connect_basic_auth)
+
+    def _test_websocket_connect_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_WS_MQTT_TLS_PORT"))
 
@@ -424,9 +466,12 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_websocket_connect_tls(self):
+        self._test_retry_wrapper(self._test_websocket_connect_tls)
+
     #  test_websocket_connect_sigv4 against IoT Core : tested in the SDK
 
-    def test_websocket_connect_http_proxy_tls(self):
+    def _test_websocket_connect_http_proxy_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_WS_MQTT_TLS_PORT"))
         input_proxy_host = _get_env_variable("AWS_TEST_MQTT5_PROXY_HOST")
@@ -457,7 +502,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_websocket_connect_maximum(self):
+    def test_websocket_connect_http_proxy_tls(self):
+        self._test_retry_wrapper(self._test_websocket_connect_http_proxy_tls)
+
+    def _test_websocket_connect_maximum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_WS_MQTT_PORT"))
 
@@ -511,6 +559,9 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_connection_success.result(TIMEOUT)
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
+
+    def test_websocket_connect_maximum(self):
+        self._test_retry_wrapper(self._test_websocket_connect_maximum)
 
     # ==============================================================
     #             NEGATIVE CONNECT TEST CASES
@@ -611,6 +662,8 @@ class Mqtt5ClientTest(NativeResourceTest):
 
         client1.start()
         callbacks.future_connection_success.result(TIMEOUT)
+
+        time.sleep(5)
 
         client2.start()
 
@@ -760,7 +813,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         with self.assertRaises(OverflowError) as cm:
             self._create_client(client_options=client_options)
 
-    def test_negative_disconnect_packet_properties(self):
+    def _test_negative_disconnect_packet_properties(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -787,7 +840,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_negative_publish_packet_properties(self):
+    def test_negative_disconnect_packet_properties(self):
+        self._test_retry_wrapper(self._test_negative_disconnect_packet_properties)
+
+    def _test_negative_publish_packet_properties(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -813,7 +869,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_negative_subscribe_packet_properties(self):
+    def test_negative_publish_packet_properties(self):
+        self._test_retry_wrapper(self._test_negative_publish_packet_properties)
+
+    def _test_negative_subscribe_packet_properties(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -842,11 +901,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_negative_subscribe_packet_properties(self):
+        self._test_retry_wrapper(self._test_negative_subscribe_packet_properties)
+
     # ==============================================================
     #             NEGOTIATED SETTINGS TEST CASES
     # ==============================================================
 
-    def test_negotiated_settings_minimal_settings(self):
+    def _test_negotiated_settings_minimal_settings(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -869,7 +931,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_negotiated_settings_maximum_settings(self):
+    def test_negotiated_settings_minimal_settings(self):
+        self._test_retry_wrapper(self._test_negotiated_settings_minimal_settings)
+
+    def _test_negotiated_settings_maximum_settings(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -910,7 +975,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_negotiated_settings_server_limit(self):
+    def test_negotiated_settings_maximum_settings(self):
+        self._test_retry_wrapper(self._test_negotiated_settings_maximum_settings)
+
+    def _test_negotiated_settings_server_limit(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -943,11 +1011,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_negotiated_settings_server_limit(self):
+        self._test_retry_wrapper(self._test_negotiated_settings_server_limit)
+
     # ==============================================================
     #             OPERATION TEST CASES
     # ==============================================================
 
-    def test_operation_sub_unsub(self):
+    def _test_operation_sub_unsub(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1009,7 +1080,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_operation_will(self):
+    def test_operation_sub_unsub(self):
+        self._test_retry_wrapper(self._test_operation_sub_unsub)
+
+    def _test_operation_will(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1072,7 +1146,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client2.stop()
         callbacks2.future_stopped.result(TIMEOUT)
 
-    def do_will_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
+    def test_operation_will(self):
+        self._test_retry_wrapper(self._test_operation_will)
+
+    def _do_will_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
                                       expected_correlation_data_bytes, expected_correlation_data):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
@@ -1142,29 +1219,44 @@ class Mqtt5ClientTest(NativeResourceTest):
         client2.stop()
         callbacks2.future_stopped.result(TIMEOUT)
 
-    def test_will_correlation_data_bytes_binary(self):
+    def _test_will_correlation_data_bytes_binary(self):
         correlation_data = bytearray(os.urandom(64))
-        self.do_will_correlation_data_test(correlation_data, None, correlation_data, None)
+        self._do_will_correlation_data_test(correlation_data, None, correlation_data, None)
+
+    def test_will_correlation_data_bytes_binary(self):
+        self._test_retry_wrapper(self._test_will_correlation_data_bytes_binary)
+
+    def _test_will_correlation_data_bytes_string(self):
+        correlation_data = "CorrelationData"
+        correlation_data_as_bytes = correlation_data.encode('utf-8')
+        self._do_will_correlation_data_test(correlation_data, None, correlation_data_as_bytes, correlation_data)
 
     def test_will_correlation_data_bytes_string(self):
-        correlation_data = "CorrelationData"
-        correlation_data_as_bytes = correlation_data.encode('utf-8')
-        self.do_correlation_data_test(correlation_data, None, correlation_data_as_bytes, correlation_data)
+        self._test_retry_wrapper(self._test_will_correlation_data_bytes_string)
+
+    def _test_will_correlation_data_binary(self):
+        correlation_data = bytearray(os.urandom(64))
+        self._do_will_correlation_data_test(None, correlation_data, correlation_data, None)
 
     def test_will_correlation_data_binary(self):
-        correlation_data = bytearray(os.urandom(64))
-        self.do_correlation_data_test(None, correlation_data, correlation_data, None)
+        self._test_retry_wrapper(self._test_will_correlation_data_binary)
 
-    def test_will_correlation_data_string(self):
+    def _test_will_correlation_data_string(self):
         correlation_data = "CorrelationData"
         correlation_data_as_bytes = correlation_data.encode('utf-8')
-        self.do_correlation_data_test(None, correlation_data, correlation_data_as_bytes, correlation_data)
+        self._do_will_correlation_data_test(None, correlation_data, correlation_data_as_bytes, correlation_data)
+
+    def test_will_correlation_data_string(self):
+        self._test_retry_wrapper(self._test_will_correlation_data_string)
+
+    def _test_will_correlation_data_bytes_binary_precedence(self):
+        correlation_data = bytearray(os.urandom(64))
+        self._do_will_correlation_data_test(correlation_data, "Ignored", correlation_data, None)
 
     def test_will_correlation_data_bytes_binary_precedence(self):
-        correlation_data = bytearray(os.urandom(64))
-        self.do_correlation_data_test(correlation_data, "Ignored", correlation_data, None)
+        self._test_retry_wrapper(self._test_will_correlation_data_bytes_binary_precedence)
 
-    def test_operation_binary_publish(self):
+    def _test_operation_binary_publish(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1226,7 +1318,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def do_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
+    def test_operation_binary_publish(self):
+        self._test_retry_wrapper(self._test_operation_binary_publish)
+
+    def _do_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
                                  expected_correlation_data_bytes, expected_correlation_data):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
@@ -1279,33 +1374,48 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_operation_publish_correlation_data_bytes_binary(self):
+    def _test_operation_publish_correlation_data_bytes_binary(self):
         correlation_data = bytearray(os.urandom(64))
-        self.do_correlation_data_test(correlation_data, None, correlation_data, None)
+        self._do_correlation_data_test(correlation_data, None, correlation_data, None)
+
+    def test_operation_publish_correlation_data_bytes_binary(self):
+        self._test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_binary)
+
+    def _test_operation_publish_correlation_data_bytes_string(self):
+        correlation_data = "CorrelationData"
+        correlation_data_as_bytes = correlation_data.encode('utf-8')
+        self._do_correlation_data_test(correlation_data, None, correlation_data_as_bytes, correlation_data)
 
     def test_operation_publish_correlation_data_bytes_string(self):
-        correlation_data = "CorrelationData"
-        correlation_data_as_bytes = correlation_data.encode('utf-8')
-        self.do_correlation_data_test(correlation_data, None, correlation_data_as_bytes, correlation_data)
+        self._test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_string)
+
+    def _test_operation_publish_correlation_data_binary(self):
+        correlation_data = bytearray(os.urandom(64))
+        self._do_correlation_data_test(None, correlation_data, correlation_data, None)
 
     def test_operation_publish_correlation_data_binary(self):
-        correlation_data = bytearray(os.urandom(64))
-        self.do_correlation_data_test(None, correlation_data, correlation_data, None)
+        self._test_retry_wrapper(self._test_operation_publish_correlation_data_binary)
 
-    def test_operation_publish_correlation_data_string(self):
+    def _test_operation_publish_correlation_data_string(self):
         correlation_data = "CorrelationData"
         correlation_data_as_bytes = correlation_data.encode('utf-8')
-        self.do_correlation_data_test(None, correlation_data, correlation_data_as_bytes, correlation_data)
+        self._do_correlation_data_test(None, correlation_data, correlation_data_as_bytes, correlation_data)
+
+    def test_operation_publish_correlation_data_string(self):
+        self._test_retry_wrapper(self._test_operation_publish_correlation_data_string)
+
+    def _test_operation_publish_correlation_data_bytes_binary_precedence(self):
+        correlation_data = bytearray(os.urandom(64))
+        self._do_correlation_data_test(correlation_data, "Ignored", correlation_data, None)
 
     def test_operation_publish_correlation_data_bytes_binary_precedence(self):
-        correlation_data = bytearray(os.urandom(64))
-        self.do_correlation_data_test(correlation_data, "Ignored", correlation_data, None)
+        self._test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_binary_precedence)
 
     # ==============================================================
     #             OPERATION ERROR TEST CASES
     # ==============================================================
 
-    def test_operation_error_null_publish(self):
+    def _test_operation_error_null_publish(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -1324,7 +1434,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_operation_error_null_subscribe(self):
+    def test_operation_error_null_publish(self):
+        self._test_retry_wrapper(self._test_operation_error_null_publish)
+
+    def _test_operation_error_null_subscribe(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -1343,7 +1456,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_operation_error_null_unsubscribe(self):
+    def test_operation_error_null_subscribe(self):
+        self._test_retry_wrapper(self._test_operation_error_null_subscribe)
+
+    def _test_operation_error_null_unsubscribe(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -1362,7 +1478,10 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_operation_rejoin_always(self):
+    def test_operation_error_null_unsubscribe(self):
+        self._test_retry_wrapper(self._test_operation_error_null_unsubscribe)
+
+    def _test_operation_rejoin_always(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1398,11 +1517,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         client2.stop()
         callbacks2.future_stopped.result(TIMEOUT)
 
+    def test_operation_rejoin_always(self):
+        self._test_retry_wrapper(self._test_operation_rejoin_always)
+
     # ==============================================================
     #             QOS1 TEST CASES
     # ==============================================================
 
-    def test_qos1_happy_path(self):
+    def _test_qos1_happy_path(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1467,11 +1589,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         client2.stop()
         callbacks2.future_stopped.result(TIMEOUT)
 
+    def test_qos1_happy_path(self):
+        self._test_retry_wrapper(self._test_qos1_happy_path)
+
     # ==============================================================
     #             RETAIN TEST CASES
     # ==============================================================
 
-    def test_retain_set_and_clear(self):
+    def _test_retain_set_and_clear(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1556,11 +1681,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         client3.stop()
         callbacks3.future_stopped.result(TIMEOUT)
 
+    def test_retain_set_and_clear(self):
+        self._test_retry_wrapper(self._test_retain_set_and_clear)
+
     # ==============================================================
     #             INTERRUPTION TEST CASES
     # ==============================================================
 
-    def test_interruption_sub(self):
+    def _test_interruption_sub(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1595,7 +1723,10 @@ class Mqtt5ClientTest(NativeResourceTest):
 
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_interruption_unsub(self):
+    def test_interruption_sub(self):
+        self._test_retry_wrapper(self._test_interruption_sub)
+
+    def _test_interruption_unsub(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1629,7 +1760,10 @@ class Mqtt5ClientTest(NativeResourceTest):
 
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_interruption_qos1_publish(self):
+    def test_interruption_unsub(self):
+        self._test_retry_wrapper(self._test_interruption_unsub)
+
+    def _test_interruption_qos1_publish(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1666,11 +1800,14 @@ class Mqtt5ClientTest(NativeResourceTest):
 
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_interruption_qos1_publish(self):
+        self._test_retry_wrapper(self._test_interruption_qos1_publish)
+
     # ==============================================================
     #             MISC TEST CASES
     # ==============================================================
 
-    def test_operation_statistics_uc1(self):
+    def _test_operation_statistics_uc1(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1721,6 +1858,8 @@ class Mqtt5ClientTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_operation_statistics_uc1(self):
+        self._test_retry_wrapper(self._test_operation_statistics_uc1)
 
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -3,8 +3,7 @@
 
 from concurrent.futures import Future
 from awscrt import mqtt5, io, http, exceptions
-from test import NativeResourceTest
-from threading import Lock
+from test import test_retry_wrapper, NativeResourceTest
 import os
 import unittest
 import uuid
@@ -135,22 +134,6 @@ class Mqtt5ClientTest(NativeResourceTest):
         client = mqtt5.Client(client_options)
         return client
 
-    @staticmethod
-    def _is_retryable_exception(e):
-        exception_text = str(e)
-        return "AWS_IO_TLS_NEGOTIATION_TIMEOUT" in exception_text or "AWS_IO_SOCKET_TIMEOUT" in exception_text
-
-    def _test_retry_wrapper(self, test_function):
-        for i in range(MAX_RETRIES):
-            try:
-                test_function()
-                return
-            except Exception as e:
-                if self._is_retryable_exception(e) and i + 1 < MAX_RETRIES:
-                    time.sleep(1)
-                else:
-                    raise
-
     # ==============================================================
     #             CREATION TEST CASES
     # ==============================================================
@@ -229,7 +212,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_direct_connect_minimum(self):
-        self._test_retry_wrapper(self._test_direct_connect_minimum)
+        test_retry_wrapper(self._test_direct_connect_minimum)
 
     def _test_direct_connect_basic_auth(self):
         input_username = _get_env_variable("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME")
@@ -255,7 +238,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_direct_connect_basic_auth(self):
-        self._test_retry_wrapper(self._test_direct_connect_basic_auth)
+        test_retry_wrapper(self._test_direct_connect_basic_auth)
 
     def _test_direct_connect_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST")
@@ -277,7 +260,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_direct_connect_tls(self):
-        self._test_retry_wrapper(self._test_direct_connect_tls)
+        test_retry_wrapper(self._test_direct_connect_tls)
 
     def _test_direct_connect_mutual_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -302,7 +285,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_direct_connect_mutual_tls(self):
-        self._test_retry_wrapper(self._test_direct_connect_mutual_tls)
+        test_retry_wrapper(self._test_direct_connect_mutual_tls)
 
     def _test_direct_connect_http_proxy_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST")
@@ -334,7 +317,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_direct_connect_http_proxy_tls(self):
-        self._test_retry_wrapper(self._test_direct_connect_http_proxy_tls)
+        test_retry_wrapper(self._test_direct_connect_http_proxy_tls)
 
     def _test_direct_connect_maximum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
@@ -392,7 +375,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_direct_connect_maximum(self):
-        self._test_retry_wrapper(self._test_direct_connect_maximum)
+        test_retry_wrapper(self._test_direct_connect_maximum)
 
     # ==============================================================
     #             WEBSOCKET CONNECT TEST CASES
@@ -416,7 +399,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_websocket_connect_minimum(self):
-        self._test_retry_wrapper(self._test_websocket_connect_minimum)
+        test_retry_wrapper(self._test_websocket_connect_minimum)
 
     def _test_websocket_connect_basic_auth(self):
         input_username = _get_env_variable("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME")
@@ -444,7 +427,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_websocket_connect_basic_auth(self):
-        self._test_retry_wrapper(self._test_websocket_connect_basic_auth)
+        test_retry_wrapper(self._test_websocket_connect_basic_auth)
 
     def _test_websocket_connect_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST")
@@ -467,7 +450,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_websocket_connect_tls(self):
-        self._test_retry_wrapper(self._test_websocket_connect_tls)
+        test_retry_wrapper(self._test_websocket_connect_tls)
 
     #  test_websocket_connect_sigv4 against IoT Core : tested in the SDK
 
@@ -503,7 +486,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_websocket_connect_http_proxy_tls(self):
-        self._test_retry_wrapper(self._test_websocket_connect_http_proxy_tls)
+        test_retry_wrapper(self._test_websocket_connect_http_proxy_tls)
 
     def _test_websocket_connect_maximum(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_WS_MQTT_HOST")
@@ -561,7 +544,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_websocket_connect_maximum(self):
-        self._test_retry_wrapper(self._test_websocket_connect_maximum)
+        test_retry_wrapper(self._test_websocket_connect_maximum)
 
     # ==============================================================
     #             NEGATIVE CONNECT TEST CASES
@@ -841,7 +824,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_negative_disconnect_packet_properties(self):
-        self._test_retry_wrapper(self._test_negative_disconnect_packet_properties)
+        test_retry_wrapper(self._test_negative_disconnect_packet_properties)
 
     def _test_negative_publish_packet_properties(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -870,7 +853,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_negative_publish_packet_properties(self):
-        self._test_retry_wrapper(self._test_negative_publish_packet_properties)
+        test_retry_wrapper(self._test_negative_publish_packet_properties)
 
     def _test_negative_subscribe_packet_properties(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -902,7 +885,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_negative_subscribe_packet_properties(self):
-        self._test_retry_wrapper(self._test_negative_subscribe_packet_properties)
+        test_retry_wrapper(self._test_negative_subscribe_packet_properties)
 
     # ==============================================================
     #             NEGOTIATED SETTINGS TEST CASES
@@ -932,7 +915,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_negotiated_settings_minimal_settings(self):
-        self._test_retry_wrapper(self._test_negotiated_settings_minimal_settings)
+        test_retry_wrapper(self._test_negotiated_settings_minimal_settings)
 
     def _test_negotiated_settings_maximum_settings(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
@@ -976,7 +959,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_negotiated_settings_maximum_settings(self):
-        self._test_retry_wrapper(self._test_negotiated_settings_maximum_settings)
+        test_retry_wrapper(self._test_negotiated_settings_maximum_settings)
 
     def _test_negotiated_settings_server_limit(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
@@ -1012,7 +995,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_negotiated_settings_server_limit(self):
-        self._test_retry_wrapper(self._test_negotiated_settings_server_limit)
+        test_retry_wrapper(self._test_negotiated_settings_server_limit)
 
     # ==============================================================
     #             OPERATION TEST CASES
@@ -1081,7 +1064,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_operation_sub_unsub(self):
-        self._test_retry_wrapper(self._test_operation_sub_unsub)
+        test_retry_wrapper(self._test_operation_sub_unsub)
 
     def _test_operation_will(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -1147,7 +1130,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks2.future_stopped.result(TIMEOUT)
 
     def test_operation_will(self):
-        self._test_retry_wrapper(self._test_operation_will)
+        test_retry_wrapper(self._test_operation_will)
 
     def _do_will_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
                                       expected_correlation_data_bytes, expected_correlation_data):
@@ -1224,7 +1207,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         self._do_will_correlation_data_test(correlation_data, None, correlation_data, None)
 
     def test_will_correlation_data_bytes_binary(self):
-        self._test_retry_wrapper(self._test_will_correlation_data_bytes_binary)
+        test_retry_wrapper(self._test_will_correlation_data_bytes_binary)
 
     def _test_will_correlation_data_bytes_string(self):
         correlation_data = "CorrelationData"
@@ -1232,14 +1215,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         self._do_will_correlation_data_test(correlation_data, None, correlation_data_as_bytes, correlation_data)
 
     def test_will_correlation_data_bytes_string(self):
-        self._test_retry_wrapper(self._test_will_correlation_data_bytes_string)
+        test_retry_wrapper(self._test_will_correlation_data_bytes_string)
 
     def _test_will_correlation_data_binary(self):
         correlation_data = bytearray(os.urandom(64))
         self._do_will_correlation_data_test(None, correlation_data, correlation_data, None)
 
     def test_will_correlation_data_binary(self):
-        self._test_retry_wrapper(self._test_will_correlation_data_binary)
+        test_retry_wrapper(self._test_will_correlation_data_binary)
 
     def _test_will_correlation_data_string(self):
         correlation_data = "CorrelationData"
@@ -1247,14 +1230,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         self._do_will_correlation_data_test(None, correlation_data, correlation_data_as_bytes, correlation_data)
 
     def test_will_correlation_data_string(self):
-        self._test_retry_wrapper(self._test_will_correlation_data_string)
+        test_retry_wrapper(self._test_will_correlation_data_string)
 
     def _test_will_correlation_data_bytes_binary_precedence(self):
         correlation_data = bytearray(os.urandom(64))
         self._do_will_correlation_data_test(correlation_data, "Ignored", correlation_data, None)
 
     def test_will_correlation_data_bytes_binary_precedence(self):
-        self._test_retry_wrapper(self._test_will_correlation_data_bytes_binary_precedence)
+        test_retry_wrapper(self._test_will_correlation_data_bytes_binary_precedence)
 
     def _test_operation_binary_publish(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -1319,7 +1302,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_operation_binary_publish(self):
-        self._test_retry_wrapper(self._test_operation_binary_publish)
+        test_retry_wrapper(self._test_operation_binary_publish)
 
     def _do_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
                                  expected_correlation_data_bytes, expected_correlation_data):
@@ -1379,7 +1362,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         self._do_correlation_data_test(correlation_data, None, correlation_data, None)
 
     def test_operation_publish_correlation_data_bytes_binary(self):
-        self._test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_binary)
+        test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_binary)
 
     def _test_operation_publish_correlation_data_bytes_string(self):
         correlation_data = "CorrelationData"
@@ -1387,14 +1370,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         self._do_correlation_data_test(correlation_data, None, correlation_data_as_bytes, correlation_data)
 
     def test_operation_publish_correlation_data_bytes_string(self):
-        self._test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_string)
+        test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_string)
 
     def _test_operation_publish_correlation_data_binary(self):
         correlation_data = bytearray(os.urandom(64))
         self._do_correlation_data_test(None, correlation_data, correlation_data, None)
 
     def test_operation_publish_correlation_data_binary(self):
-        self._test_retry_wrapper(self._test_operation_publish_correlation_data_binary)
+        test_retry_wrapper(self._test_operation_publish_correlation_data_binary)
 
     def _test_operation_publish_correlation_data_string(self):
         correlation_data = "CorrelationData"
@@ -1402,14 +1385,14 @@ class Mqtt5ClientTest(NativeResourceTest):
         self._do_correlation_data_test(None, correlation_data, correlation_data_as_bytes, correlation_data)
 
     def test_operation_publish_correlation_data_string(self):
-        self._test_retry_wrapper(self._test_operation_publish_correlation_data_string)
+        test_retry_wrapper(self._test_operation_publish_correlation_data_string)
 
     def _test_operation_publish_correlation_data_bytes_binary_precedence(self):
         correlation_data = bytearray(os.urandom(64))
         self._do_correlation_data_test(correlation_data, "Ignored", correlation_data, None)
 
     def test_operation_publish_correlation_data_bytes_binary_precedence(self):
-        self._test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_binary_precedence)
+        test_retry_wrapper(self._test_operation_publish_correlation_data_bytes_binary_precedence)
 
     # ==============================================================
     #             OPERATION ERROR TEST CASES
@@ -1435,7 +1418,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_operation_error_null_publish(self):
-        self._test_retry_wrapper(self._test_operation_error_null_publish)
+        test_retry_wrapper(self._test_operation_error_null_publish)
 
     def _test_operation_error_null_subscribe(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
@@ -1457,7 +1440,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_operation_error_null_subscribe(self):
-        self._test_retry_wrapper(self._test_operation_error_null_subscribe)
+        test_retry_wrapper(self._test_operation_error_null_subscribe)
 
     def _test_operation_error_null_unsubscribe(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
@@ -1479,7 +1462,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_operation_error_null_unsubscribe(self):
-        self._test_retry_wrapper(self._test_operation_error_null_unsubscribe)
+        test_retry_wrapper(self._test_operation_error_null_unsubscribe)
 
     def _test_operation_rejoin_always(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -1518,7 +1501,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks2.future_stopped.result(TIMEOUT)
 
     def test_operation_rejoin_always(self):
-        self._test_retry_wrapper(self._test_operation_rejoin_always)
+        test_retry_wrapper(self._test_operation_rejoin_always)
 
     # ==============================================================
     #             QOS1 TEST CASES
@@ -1590,7 +1573,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks2.future_stopped.result(TIMEOUT)
 
     def test_qos1_happy_path(self):
-        self._test_retry_wrapper(self._test_qos1_happy_path)
+        test_retry_wrapper(self._test_qos1_happy_path)
 
     # ==============================================================
     #             RETAIN TEST CASES
@@ -1682,7 +1665,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks3.future_stopped.result(TIMEOUT)
 
     def test_retain_set_and_clear(self):
-        self._test_retry_wrapper(self._test_retain_set_and_clear)
+        test_retry_wrapper(self._test_retain_set_and_clear)
 
     # ==============================================================
     #             INTERRUPTION TEST CASES
@@ -1724,7 +1707,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_interruption_sub(self):
-        self._test_retry_wrapper(self._test_interruption_sub)
+        test_retry_wrapper(self._test_interruption_sub)
 
     def _test_interruption_unsub(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -1761,7 +1744,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_interruption_unsub(self):
-        self._test_retry_wrapper(self._test_interruption_unsub)
+        test_retry_wrapper(self._test_interruption_unsub)
 
     def _test_interruption_qos1_publish(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
@@ -1801,7 +1784,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_interruption_qos1_publish(self):
-        self._test_retry_wrapper(self._test_interruption_qos1_publish)
+        test_retry_wrapper(self._test_interruption_qos1_publish)
 
     # ==============================================================
     #             MISC TEST CASES
@@ -1859,7 +1842,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         callbacks.future_stopped.result(TIMEOUT)
 
     def test_operation_statistics_uc1(self):
-        self._test_retry_wrapper(self._test_operation_statistics_uc1)
+        test_retry_wrapper(self._test_operation_statistics_uc1)
 
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -106,6 +106,7 @@ class Mqtt5TestCallbacks():
 
 MAX_RETRIES = 5
 
+
 class Mqtt5ClientTest(NativeResourceTest):
 
     def _create_client(
@@ -1133,7 +1134,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         test_retry_wrapper(self._test_operation_will)
 
     def _do_will_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
-                                      expected_correlation_data_bytes, expected_correlation_data):
+                                       expected_correlation_data_bytes, expected_correlation_data):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1305,7 +1306,7 @@ class Mqtt5ClientTest(NativeResourceTest):
         test_retry_wrapper(self._test_operation_binary_publish)
 
     def _do_correlation_data_test(self, outbound_correlation_data_bytes, outbound_correlation_data,
-                                 expected_correlation_data_bytes, expected_correlation_data):
+                                  expected_correlation_data_bytes, expected_correlation_data):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
@@ -1843,6 +1844,7 @@ class Mqtt5ClientTest(NativeResourceTest):
 
     def test_operation_statistics_uc1(self):
         test_retry_wrapper(self._test_operation_statistics_uc1)
+
 
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt5_credentials.py
+++ b/test/test_mqtt5_credentials.py
@@ -3,7 +3,7 @@
 
 from concurrent.futures import Future
 from awscrt import mqtt5, io, auth
-from test import NativeResourceTest
+from test import test_retry_wrapper, NativeResourceTest
 import os
 import unittest
 import uuid
@@ -108,7 +108,7 @@ class MqttConnectionTest(NativeResourceTest):
         client = mqtt5.Client(client_options)
         return client
 
-    def test_mqtt5_cred_pkcs12(self):
+    def _test_mqtt5_cred_pkcs12(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY")
         input_key_password = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD")
@@ -130,7 +130,10 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_mqtt5_cred_windows_cert(self):
+    def test_mqtt5_cred_pkcs12(self):
+        test_retry_wrapper(self._test_mqtt5_cred_pkcs12)
+
+    def _test_mqtt5_cred_windows_cert(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_windows = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE")
 
@@ -150,7 +153,10 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_mqtt5_cred_pkcs11(self):
+    def test_mqtt5_cred_windows_cert(self):
+        test_retry_wrapper(self._test_mqtt5_cred_windows_cert)
+
+    def _test_mqtt5_cred_pkcs11(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_pkcs11_lib = _get_env_variable("AWS_TEST_PKCS11_LIB")
         input_pkcs11_pin = _get_env_variable("AWS_TEST_PKCS11_PIN")
@@ -181,7 +187,10 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_mqtt5_ws_cred_static(self):
+    def test_mqtt5_cred_pkcs11(self):
+        test_retry_wrapper(self._test_mqtt5_cred_pkcs11)
+
+    def _test_mqtt5_ws_cred_static(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_role_access_key = _get_env_variable("AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY")
         input_role_secret_access_key = _get_env_variable("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY")
@@ -221,7 +230,10 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_mqtt5_ws_cred_cognito(self):
+    def test_mqtt5_ws_cred_static(self):
+        test_retry_wrapper(self._test_mqtt5_ws_cred_static)
+
+    def _test_mqtt5_ws_cred_cognito(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cognito_endpoint = _get_env_variable("AWS_TEST_MQTT5_COGNITO_ENDPOINT")
         input_cognito_identity = _get_env_variable("AWS_TEST_MQTT5_COGNITO_IDENTITY")
@@ -260,7 +272,10 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_mqtt5_ws_cred_x509(self):
+    def test_mqtt5_ws_cred_cognito(self):
+        test_retry_wrapper(self._test_mqtt5_ws_cred_cognito)
+
+    def _test_mqtt5_ws_cred_x509(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_X509_CERT")
         input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_X509_KEY")
@@ -307,7 +322,10 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
-    def test_mqtt5_ws_cred_profile(self):
+    def test_mqtt5_ws_cred_x509(self):
+        test_retry_wrapper(self._test_mqtt5_ws_cred_x509)
+
+    def _test_mqtt5_ws_cred_profile(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_profile_config = _get_env_variable("AWS_TEST_MQTT5_IOT_PROFILE_CONFIG")
         input_profile_cred = _get_env_variable("AWS_TEST_MQTT5_IOT_PROFILE_CREDENTIALS")
@@ -345,13 +363,22 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    def test_mqtt5_ws_cred_profile(self):
+        test_retry_wrapper(self._test_mqtt5_ws_cred_profile)
+
+    def _test_mqtt5_ws_cred_environment(self):
+        self._test_mqtt5_ws_cred_environment_aux(use_default_chain=False)
+
     def test_mqtt5_ws_cred_environment(self):
-        self._test_mqtt5_ws_cred_environment(use_default_chain=False)
+        test_retry_wrapper(self._test_mqtt5_ws_cred_environment)
+
+    def _test_mqtt5_ws_cred_default_chain(self):
+        self._test_mqtt5_ws_cred_environment_aux(use_default_chain=True)
 
     def test_mqtt5_ws_cred_default_chain(self):
-        self._test_mqtt5_ws_cred_environment(use_default_chain=True)
+        test_retry_wrapper(self._test_mqtt5_ws_cred_default_chain)
 
-    def _test_mqtt5_ws_cred_environment(self, use_default_chain):
+    def _test_mqtt5_ws_cred_environment_aux(self, use_default_chain):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_HOST")
         input_access_key = _get_env_variable("AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY")
         input_secret_access_key = _get_env_variable("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY")

--- a/test/test_mqtt5to3_adapter.py
+++ b/test/test_mqtt5to3_adapter.py
@@ -580,5 +580,6 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
     def test_multiple_adapters(self):
         test_retry_wrapper(self._test_multiple_adapters)
 
+
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt5to3_adapter.py
+++ b/test/test_mqtt5to3_adapter.py
@@ -4,7 +4,7 @@
 from concurrent.futures import Future
 from awscrt import mqtt5, io, http, exceptions
 from awscrt.mqtt import Connection, ConnectReturnCode, OnConnectionSuccessData, OnConnectionFailureData, OnConnectionClosedData, QoS
-from test import NativeResourceTest
+from test import test_retry_wrapper, NativeResourceTest
 from test.test_mqtt5 import Mqtt5TestCallbacks, _get_env_variable, create_client_id
 import unittest
 import uuid
@@ -220,20 +220,6 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
 
         return self._create_client(client_options=client_options, callbacks=callbacks), callbacks
 
-    def _test_with_mqtt3_connect(self, setup_client: callable):
-        client, callbacks = setup_client()
-        connection = client.new_connection()
-        connection.connect().result(TIMEOUT)
-        connection.disconnect().result(TIMEOUT)
-
-    def _test_with_mqtt5_connect(self, setup_client: callable):
-        client, callbacks = setup_client()
-        connection = client.new_connection()
-        client.start()
-        callbacks.future_connection_success.result(TIMEOUT)
-        client.stop()
-        callbacks.future_stopped.result(TIMEOUT)
-
     # ==============================================================
     #             CONNECTION TEST HELPER FUNCTIONS
     # ==============================================================
@@ -315,14 +301,20 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
     # ==============================================================
     #         CONNECT THROUGH MQTT311 INTERFACE TEST CASES
     # ==============================================================
-    def test_direct_connect_through_mqtt311_minimum(self):
+    def _test_direct_connect_through_mqtt311_minimum(self):
         self._test_with_mqtt3_connect(self._setup_direct_connect_minimum)
+
+    def test_direct_connect_through_mqtt311_minimum(self):
+        test_retry_wrapper(self._test_direct_connect_through_mqtt311_minimum)
 
     # def test_direct_connect_through_mqtt311_basic_auth(self):
     #     self._test_with_mqtt3_connect(self._setup_direct_connect_basic_auth)
 
-    def test_direct_connect_through_mqtt311_mutual_tls(self):
+    def _test_direct_connect_through_mqtt311_mutual_tls(self):
         self._test_with_mqtt3_connect(self._setup_direct_connect_mutual_tls)
+
+    def test_direct_connect_through_mqtt311_mutual_tls(self):
+        test_retry_wrapper(self._test_direct_connect_through_mqtt311_mutual_tls)
 
     # def test_direct_connect_through_mqtt311_websocket_minimum(self):
     #     self._test_with_mqtt3_connect(self._setup_websocket_connect_minimum)
@@ -334,14 +326,20 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
     #         CONNECT THROUGH MQTT5 INTERFACE TEST CASES
     # ==============================================================
 
-    def test_direct_connect_through_mqtt5_minimum(self):
+    def _test_direct_connect_through_mqtt5_minimum(self):
         self._test_with_mqtt5_connect(self._setup_direct_connect_minimum)
+
+    def test_direct_connect_through_mqtt5_minimum(self):
+        test_retry_wrapper(self._test_direct_connect_through_mqtt5_minimum)
 
     # def test_direct_connect_through_mqtt5_basic_auth(self):
     #     self._test_with_mqtt5_connect(self._setup_direct_connect_basic_auth)
 
-    def test_direct_connect_through_mqtt5_mutual_tls(self):
+    def _test_direct_connect_through_mqtt5_mutual_tls(self):
         self._test_with_mqtt5_connect(self._setup_direct_connect_mutual_tls)
+
+    def test_direct_connect_through_mqtt5_mutual_tls(self):
+        test_retry_wrapper(self._test_direct_connect_through_mqtt5_mutual_tls)
 
     # def test_direct_connect_through_mqtt5_websocket_minimum(self):
     #     self._test_with_mqtt5_connect(self._setup_websocket_connect_minimum)
@@ -353,7 +351,7 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
     #             OPERATION TEST CASES
     # ==============================================================
 
-    def test_operation_sub_unsub(self):
+    def _test_operation_sub_unsub(self):
         TEST_TOPIC = '/test/topic/adapter' + str(uuid.uuid4())
 
         client, mqtt5_callbacks = self._setup_direct_connect_mutual_tls()
@@ -397,7 +395,10 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
 
         connection.disconnect().result(TIMEOUT)
 
-    def test_operation_null_ack(self):
+    def test_operation_sub_unsub(self):
+        test_retry_wrapper(self._test_operation_sub_unsub)
+
+    def _test_operation_null_ack(self):
         TEST_TOPIC = '/test/topic/adapter' + str(uuid.uuid4())
         exception_occurred = False
 
@@ -420,10 +421,13 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
 
         assert (exception_occurred)
 
+    def test_operation_null_ack(self):
+        test_retry_wrapper(self._test_operation_null_ack)
+
     # ==============================================================
     #                 MQTT311 CALLBACK TEST CASES
     # ==============================================================
-    def test_connection_success_callback(self):
+    def _test_connection_success_callback(self):
         client, _ = self._setup_direct_connect_minimum()
         mqtt311_callbacks = Mqtt311TestCallbacks()
         connection = self._create_connection(client, mqtt311_callbacks)
@@ -432,7 +436,10 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
         mqtt311_callbacks.future_connection_success.result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_connection_failure_callback(self):
+    def test_connection_success_callback(self):
+        test_retry_wrapper(self._test_connection_success_callback)
+
+    def _test_connection_failure_callback(self):
         client_options = mqtt5.ClientOptions(
             host_name="badhost",
             port=1883
@@ -451,7 +458,10 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
         failure_data = mqtt311_callbacks.future_connection_failure.result(TIMEOUT)
         self.assertTrue(failure_data['error'] is not None)
 
-    def test_connection_interrupted_and_resumed_callback(self):
+    def test_connection_failure_callback(self):
+        test_retry_wrapper(self._test_connection_failure_callback)
+
+    def _test_connection_interrupted_and_resumed_callback(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_HOST")
         input_port = int(_get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_PORT"))
 
@@ -487,10 +497,13 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
         connection1.disconnect().result(TIMEOUT)
         connection2.disconnect().result(TIMEOUT)
 
+    def test_connection_interrupted_and_resumed_callback(self):
+        test_retry_wrapper(self._test_connection_interrupted_and_resumed_callback)
+
     # ==============================================================
     #                 ADAPTER TEST CASES
     # ==============================================================
-    def test_multiple_adapters(self):
+    def _test_multiple_adapters(self):
         TEST_TOPIC1 = '/test/topic/adapter1' + str(uuid.uuid4())
         TEST_TOPIC2 = '/test/topic/adapter2' + str(uuid.uuid4())
         TEST_TOPIC3 = '/test/topic/adapter3' + str(uuid.uuid4())
@@ -564,6 +577,8 @@ class Mqtt5to3AdapterTest(NativeResourceTest):
         client.stop()
         mqtt5_callbacks.future_stopped.result(TIMEOUT)
 
+    def test_multiple_adapters(self):
+        test_retry_wrapper(self._test_multiple_adapters)
 
 if __name__ == 'main':
     unittest.main()

--- a/test/test_mqtt_credentials.py
+++ b/test/test_mqtt_credentials.py
@@ -4,7 +4,7 @@
 from awscrt.io import ClientBootstrap, ClientTlsContext, DefaultHostResolver, EventLoopGroup, Pkcs11Lib, TlsContextOptions
 from awscrt import auth
 from awscrt.mqtt import Client, Connection
-from test import NativeResourceTest
+from test import test_retry_wrapper, NativeResourceTest
 import os
 import unittest
 import uuid
@@ -25,7 +25,7 @@ def create_client_id():
 
 class MqttConnectionTest(NativeResourceTest):
 
-    def test_mqtt311_cred_pkcs12(self):
+    def _test_mqtt311_cred_pkcs12(self):
         input_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY")
         input_key_password = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD")
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
@@ -46,7 +46,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_cred_windows_cert(self):
+    def test_mqtt311_cred_pkcs12(self):
+        test_retry_wrapper(self._test_mqtt311_cred_pkcs12)
+
+    def _test_mqtt311_cred_windows_cert(self):
         input_windows = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE")
         input_host_name = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_HOST")
 
@@ -65,7 +68,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_cred_pkcs11(self):
+    def test_mqtt311_cred_windows_cert(self):
+        test_retry_wrapper(self._test_mqtt311_cred_windows_cert)
+
+    def _test_mqtt311_cred_pkcs11(self):
         input_pkcs11_lib = _get_env_variable("AWS_TEST_PKCS11_LIB")
         input_pkcs11_pin = _get_env_variable("AWS_TEST_PKCS11_PIN")
         input_pkcs11_token_label = _get_env_variable("AWS_TEST_PKCS11_TOKEN_LABEL")
@@ -95,7 +101,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_ws_cred_static(self):
+    def test_mqtt311_cred_pkcs11(self):
+        test_retry_wrapper(self._test_mqtt311_cred_pkcs11)
+
+    def _test_mqtt311_ws_cred_static(self):
         input_role_access_key = _get_env_variable("AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY")
         input_role_secret_key = _get_env_variable("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY")
         input_role_session_token = _get_env_variable("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN")
@@ -136,7 +145,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_ws_cred_cognito(self):
+    def test_mqtt311_ws_cred_static(self):
+        test_retry_wrapper(self._test_mqtt311_ws_cred_static)
+
+    def _test_mqtt311_ws_cred_cognito(self):
         input_cognito_endpoint = _get_env_variable("AWS_TEST_MQTT311_COGNITO_ENDPOINT")
         input_cognito_identity = _get_env_variable("AWS_TEST_MQTT311_COGNITO_IDENTITY")
         input_region = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_REGION")
@@ -178,7 +190,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_ws_cred_x509(self):
+    def test_mqtt311_ws_cred_cognito(self):
+        test_retry_wrapper(self._test_mqtt311_ws_cred_cognito)
+
+    def _test_mqtt311_ws_cred_x509(self):
         input_x509_cert = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_X509_CERT")
         input_x509_key = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_X509_KEY")
         input_x509_endpoint = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT")
@@ -226,7 +241,10 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
-    def test_mqtt311_ws_cred_profile(self):
+    def test_mqtt311_ws_cred_x509(self):
+        test_retry_wrapper(self._test_mqtt311_ws_cred_x509)
+
+    def _test_mqtt311_ws_cred_profile(self):
         input_profile_config = _get_env_variable("AWS_TEST_MQTT311_IOT_PROFILE_CONFIG")
         input_profile_cred = _get_env_variable("AWS_TEST_MQTT311_IOT_PROFILE_CREDENTIALS")
         input_region = _get_env_variable("AWS_TEST_MQTT311_IOT_CORE_REGION")
@@ -265,13 +283,22 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
+    def test_mqtt311_ws_cred_profile(self):
+        test_retry_wrapper(self._test_mqtt311_ws_cred_profile)
+
+    def _test_mqtt311_ws_cred_environment(self):
+        self._test_mqtt311_ws_cred_environment_aux(use_default_chain=False)
+
     def test_mqtt311_ws_cred_environment(self):
-        self._test_mqtt311_ws_cred_environment(use_default_chain=False)
+        test_retry_wrapper(self._test_mqtt311_ws_cred_environment)
+
+    def _test_mqtt311_ws_cred_default(self):
+        self._test_mqtt311_ws_cred_environment_aux(use_default_chain=True)
 
     def test_mqtt311_ws_cred_default(self):
-        self._test_mqtt311_ws_cred_environment(use_default_chain=True)
+        test_retry_wrapper(self._test_mqtt311_ws_cred_default)
 
-    def _test_mqtt311_ws_cred_environment(self, use_default_chain):
+    def _test_mqtt311_ws_cred_environment_aux(self, use_default_chain):
         input_access_key = _get_env_variable("AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY")
         input_secret_access_key = _get_env_variable("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY")
         input_session_token = _get_env_variable("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN")

--- a/test/test_mqtt_request_response.py
+++ b/test/test_mqtt_request_response.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 from awscrt.mqtt_request_response import StreamingOperationOptions
-from test import NativeResourceTest
+from test import test_retry_wrapper, NativeResourceTest
 from awscrt import io, mqtt5, mqtt_request_response, mqtt
 
 from concurrent.futures import Future
@@ -436,11 +436,17 @@ class MqttRequestResponseClientTest(NativeResourceTest):
     #             CREATION SUCCESS TEST CASES
     # ==============================================================
 
-    def test_client_creation_success5(self):
+    def _test_client_creation_success5(self):
         self._do_mqtt5_test(lambda protocol_client: self._create_rr_client(protocol_client, 2, 2, 30))
 
-    def test_client_creation_success311(self):
+    def test_client_creation_success5(self):
+        test_retry_wrapper(self._test_client_creation_success5)
+
+    def _test_client_creation_success311(self):
         self._do_mqtt311_test(lambda protocol_client: self._create_rr_client(protocol_client, 2, 2, 30))
+
+    def test_client_creation_success311(self):
+        test_retry_wrapper(self._test_client_creation_success311)
 
     # ==============================================================
     #             CREATION FAILURE TEST CASES
@@ -545,210 +551,354 @@ class MqttRequestResponseClientTest(NativeResourceTest):
     #             make_request SUCCESS TEST CASES
     # ==============================================================
 
-    def test_get_shadow_success_no_such_shadow5(self):
+    def _test_get_shadow_success_no_such_shadow5(self):
         self._do_mqtt5_test(
+            lambda protocol_client: self._do_get_shadow_success_no_such_shadow_test(
+                protocol_client, True))
+
+    def test_get_shadow_success_no_such_shadow5(self):
+        test_retry_wrapper(self._test_get_shadow_success_no_such_shadow5)
+
+    def _test_get_shadow_success_no_such_shadow311(self):
+        self._do_mqtt311_test(
             lambda protocol_client: self._do_get_shadow_success_no_such_shadow_test(
                 protocol_client, True))
 
     def test_get_shadow_success_no_such_shadow311(self):
-        self._do_mqtt311_test(
-            lambda protocol_client: self._do_get_shadow_success_no_such_shadow_test(
-                protocol_client, True))
+        test_retry_wrapper(self._test_get_shadow_success_no_such_shadow311)
 
-    def test_get_shadow_success_no_such_shadow_no_correlation_token5(self):
+    def _test_get_shadow_success_no_such_shadow_no_correlation_token5(self):
         self._do_mqtt5_test(
             lambda protocol_client: self._do_get_shadow_success_no_such_shadow_test(
                 protocol_client, False))
 
-    def test_get_shadow_success_no_such_shadow_no_correlation_token311(self):
+    def test_get_shadow_success_no_such_shadow_no_correlation_token5(self):
+        test_retry_wrapper(self._test_get_shadow_success_no_such_shadow_no_correlation_token5)
+
+    def _test_get_shadow_success_no_such_shadow_no_correlation_token311(self):
         self._do_mqtt311_test(
             lambda protocol_client: self._do_get_shadow_success_no_such_shadow_test(
                 protocol_client, False))
 
-    def test_update_delete_shadow_success5(self):
+    def test_get_shadow_success_no_such_shadow_no_correlation_token311(self):
+        test_retry_wrapper(self._test_get_shadow_success_no_such_shadow_no_correlation_token311)
+
+    def _test_update_delete_shadow_success5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_update_delete_shadow_success_test(protocol_client, True))
 
-    def test_update_delete_shadow_success311(self):
+    def test_update_delete_shadow_success5(self):
+        test_retry_wrapper(self._test_update_delete_shadow_success5)
+
+    def _test_update_delete_shadow_success311(self):
         self._do_mqtt311_test(lambda protocol_client: self._do_update_delete_shadow_success_test(protocol_client, True))
 
-    def test_update_delete_shadow_success_no_correlation_token5(self):
+    def test_update_delete_shadow_success311(self):
+        test_retry_wrapper(self._test_update_delete_shadow_success311)
+
+    def _test_update_delete_shadow_success_no_correlation_token5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_update_delete_shadow_success_test(protocol_client, False))
 
-    def test_update_delete_shadow_success_no_correlation_token311(self):
+    def test_update_delete_shadow_success_no_correlation_token5(self):
+        test_retry_wrapper(self._test_update_delete_shadow_success_no_correlation_token5)
+
+    def _test_update_delete_shadow_success_no_correlation_token311(self):
         self._do_mqtt311_test(
             lambda protocol_client: self._do_update_delete_shadow_success_test(
                 protocol_client, False))
+
+    def test_update_delete_shadow_success_no_correlation_token311(self):
+        test_retry_wrapper(self._test_update_delete_shadow_success_no_correlation_token311)
 
     # ==============================================================
     #             make_request FAILURE TEST CASES
     # ==============================================================
 
-    def test_get_shadow_failure_no_response_paths5(self):
+    def _test_get_shadow_failure_no_response_paths5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _empty_response_paths(options)))
+
+    def test_get_shadow_failure_no_response_paths5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_no_response_paths5)
+
+    def _test_get_shadow_failure_no_response_paths311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _empty_response_paths(options)))
 
     def test_get_shadow_failure_no_response_paths311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _empty_response_paths(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_no_response_paths311)
+
+    def _test_get_shadow_failure_invalid_response_path_topic5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
+            protocol_client, lambda options: _invalidate_response_path_topic(options)))
 
     def test_get_shadow_failure_invalid_response_path_topic5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_invalid_response_path_topic5)
+
+    def _test_get_shadow_failure_invalid_response_path_topic311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
             protocol_client, lambda options: _invalidate_response_path_topic(options)))
 
     def test_get_shadow_failure_invalid_response_path_topic311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
-            protocol_client, lambda options: _invalidate_response_path_topic(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_invalid_response_path_topic311)
+
+    def _test_get_shadow_failure_none_response_path_topic5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _none_response_path_topic(options)))
 
     def test_get_shadow_failure_none_response_path_topic5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_none_response_path_topic5)
+
+    def _test_get_shadow_failure_none_response_path_topic311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _none_response_path_topic(options)))
 
     def test_get_shadow_failure_none_response_path_topic311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _none_response_path_topic(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_none_response_path_topic311)
+
+    def _test_get_shadow_failure_missing_response_path_topic5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _missing_response_path_topic(options)))
 
     def test_get_shadow_failure_missing_response_path_topic5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_missing_response_path_topic5)
+
+    def _test_get_shadow_failure_missing_response_path_topic311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _missing_response_path_topic(options)))
 
     def test_get_shadow_failure_missing_response_path_topic311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _missing_response_path_topic(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_missing_response_path_topic311)
+
+    def _test_get_shadow_failure_response_path_topic_type_mismatch5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _type_mismatch_response_path_topic(options)))
 
     def test_get_shadow_failure_response_path_topic_type_mismatch5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_response_path_topic_type_mismatch5)
+
+    def _test_get_shadow_failure_response_path_topic_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_response_path_topic(options)))
 
     def test_get_shadow_failure_response_path_topic_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _type_mismatch_response_path_topic(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_response_path_topic_type_mismatch311)
+
+    def _test_get_shadow_failure_response_path_correlation_token_json_path_type_mismatch5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _type_mismatch_response_path_correlation_token_json_path(options)))
 
     def test_get_shadow_failure_response_path_correlation_token_json_path_type_mismatch5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_response_path_correlation_token_json_path_type_mismatch5)
+
+    def _test_get_shadow_failure_response_path_correlation_token_json_path_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_response_path_correlation_token_json_path(options)))
 
     def test_get_shadow_failure_response_path_correlation_token_json_path_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _type_mismatch_response_path_correlation_token_json_path(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_response_path_correlation_token_json_path_type_mismatch311)
+
+    def _test_get_shadow_failure_response_paths_type_mismatch5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _type_mismatch_response_paths(options)))
 
     def test_get_shadow_failure_response_paths_type_mismatch5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_response_paths_type_mismatch5)
+
+    def _test_get_shadow_failure_response_paths_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_response_paths(options)))
 
     def test_get_shadow_failure_response_paths_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _type_mismatch_response_paths(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_response_paths_type_mismatch311)
 
-    def test_get_shadow_failure_invalid_subscription_topic5(self):
+    def _test_get_shadow_failure_invalid_subscription_topic5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
             protocol_client, lambda options: _invalidate_subscription_topic_filter(options)))
 
-    def test_get_shadow_failure_invalid_subscription_topic311(self):
+    def test_get_shadow_failure_invalid_subscription_topic5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_invalid_subscription_topic5)
+
+    def _test_get_shadow_failure_invalid_subscription_topic311(self):
         self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
             protocol_client, lambda options: _invalidate_subscription_topic_filter(options)))
 
-    def test_get_shadow_failure_subscription_topic_type_mismatch5(self):
+    def test_get_shadow_failure_invalid_subscription_topic311(self):
+        test_retry_wrapper(self._test_get_shadow_failure_invalid_subscription_topic311)
+
+    def _test_get_shadow_failure_subscription_topic_type_mismatch5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _type_mismatch_subscription_topic_filter(options)))
+
+    def test_get_shadow_failure_subscription_topic_type_mismatch5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_subscription_topic_type_mismatch5)
+
+    def _test_get_shadow_failure_subscription_topic_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_subscription_topic_filter(options)))
 
     def test_get_shadow_failure_subscription_topic_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _type_mismatch_subscription_topic_filter(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_subscription_topic_type_mismatch311)
+
+    def _test_get_shadow_failure_subscriptions_type_mismatch5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _type_mismatch_subscriptions(options)))
 
     def test_get_shadow_failure_subscriptions_type_mismatch5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_subscriptions_type_mismatch5)
+
+    def _test_get_shadow_failure_subscriptions_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_subscriptions(options)))
 
     def test_get_shadow_failure_subscriptions_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _type_mismatch_subscriptions(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_subscriptions_type_mismatch311)
+
+    def _test_get_shadow_failure_empty_subscriptions5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _empty_subscription_topic_filters(options)))
 
     def test_get_shadow_failure_empty_subscriptions5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+        test_retry_wrapper(self._test_get_shadow_failure_empty_subscriptions5)
+
+    def _test_get_shadow_failure_empty_subscriptions311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _empty_subscription_topic_filters(options)))
 
     def test_get_shadow_failure_empty_subscriptions311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _empty_subscription_topic_filters(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_empty_subscriptions311)
 
-    def test_get_shadow_failure_none_publish_topic5(self):
+    def _test_get_shadow_failure_none_publish_topic5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _none_publish_topic(options)))
 
-    def test_get_shadow_failure_none_publish_topic311(self):
+    def test_get_shadow_failure_none_publish_topic5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_none_publish_topic5)
+
+    def _test_get_shadow_failure_none_publish_topic311(self):
         self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _none_publish_topic(options)))
 
-    def test_get_shadow_failure_bad_publish_topic5(self):
+    def test_get_shadow_failure_none_publish_topic311(self):
+        test_retry_wrapper(self._test_get_shadow_failure_none_publish_topic311)
+
+    def _test_get_shadow_failure_bad_publish_topic5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_future_failure_test(
             protocol_client, lambda options: _bad_publish_topic(options)))
 
-    def test_get_shadow_failure_bad_publish_topic311(self):
+    def test_get_shadow_failure_bad_publish_topic5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_bad_publish_topic5)
+
+    def _test_get_shadow_failure_bad_publish_topic311(self):
         self._do_mqtt311_test(
             lambda protocol_client: self._do_get_shadow_future_failure_test(
                 protocol_client,
                 lambda options: _bad_publish_topic(options)))
 
-    def test_get_shadow_failure_publish_topic_type_mismatch5(self):
+    def test_get_shadow_failure_bad_publish_topic311(self):
+        test_retry_wrapper(self._test_get_shadow_failure_bad_publish_topic311)
+
+    def _test_get_shadow_failure_publish_topic_type_mismatch5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
+            protocol_client, lambda options: _type_mismatch_publish_topic(options)))
+
+    def test_get_shadow_failure_publish_topic_type_mismatch5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_publish_topic_type_mismatch5)
+
+    def _test_get_shadow_failure_publish_topic_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_publish_topic(options)))
 
     def test_get_shadow_failure_publish_topic_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
-            protocol_client, lambda options: _type_mismatch_publish_topic(options)))
+        test_retry_wrapper(self._test_get_shadow_failure_publish_topic_type_mismatch311)
 
-    def test_get_shadow_failure_correlation_token_type_mismatch5(self):
+    def _test_get_shadow_failure_correlation_token_type_mismatch5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_correlation_token(options)))
 
-    def test_get_shadow_failure_correlation_token_type_mismatch311(self):
+    def test_get_shadow_failure_correlation_token_type_mismatch5(self):
+        test_retry_wrapper(self._test_get_shadow_failure_correlation_token_type_mismatch5)
+
+    def _test_get_shadow_failure_correlation_token_type_mismatch311(self):
         self._do_mqtt311_test(lambda protocol_client: self._do_get_shadow_failure_test(
             protocol_client, lambda options: _type_mismatch_correlation_token(options)))
+
+    def test_get_shadow_failure_correlation_token_type_mismatch311(self):
+        test_retry_wrapper(self._test_get_shadow_failure_correlation_token_type_mismatch311)
 
     # ==============================================================
     #             streaming operation SUCCESS TEST CASES
     # ==============================================================
 
-    def test_streaming_operation_success5(self):
+    def _test_streaming_operation_success5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_stream_success_test(protocol_client))
 
-    def test_streaming_operation_success311(self):
+    def test_streaming_operation_success5(self):
+        test_retry_wrapper(self._test_streaming_operation_success5)
+
+    def _test_streaming_operation_success311(self):
         self._do_mqtt311_test(lambda protocol_client: self._do_stream_success_test(protocol_client))
+
+    def test_streaming_operation_success311(self):
+        test_retry_wrapper(self._test_streaming_operation_success311)
 
     # ==============================================================
     #             create_stream FAILURE TEST CASES
     # ==============================================================
-    def test_create_stream_failure_subscription_topic_filter_none5(self):
+    def _test_create_stream_failure_subscription_topic_filter_none5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_create_stream_failure_test(
+            protocol_client, lambda options: _subscription_topic_filter_none(options)))
+
+    def test_create_stream_failure_subscription_topic_filter_none5(self):
+        test_retry_wrapper(self._test_create_stream_failure_subscription_topic_filter_none5)
+
+    def _test_create_stream_failure_subscription_topic_filter_none311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
             protocol_client, lambda options: _subscription_topic_filter_none(options)))
 
     def test_create_stream_failure_subscription_topic_filter_none311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
-            protocol_client, lambda options: _subscription_topic_filter_none(options)))
+        test_retry_wrapper(self._test_create_stream_failure_subscription_topic_filter_none311)
+
+    def _test_create_stream_failure_subscription_topic_filter_type_mismatch5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_create_stream_failure_test(
+            protocol_client, lambda options: _type_mismatch_stream_subscription_topic_filter(options)))
 
     def test_create_stream_failure_subscription_topic_filter_type_mismatch5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_create_stream_failure_test(
+        test_retry_wrapper(self._test_create_stream_failure_subscription_topic_filter_type_mismatch5)
+
+    def _test_create_stream_failure_subscription_topic_filter_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
             protocol_client, lambda options: _type_mismatch_stream_subscription_topic_filter(options)))
 
     def test_create_stream_failure_subscription_topic_filter_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
-            protocol_client, lambda options: _type_mismatch_stream_subscription_topic_filter(options)))
+        test_retry_wrapper(self._test_create_stream_failure_subscription_topic_filter_type_mismatch311)
+
+    def _test_create_stream_failure_subscription_status_listener_type_mismatch5(self):
+        self._do_mqtt5_test(lambda protocol_client: self._do_create_stream_failure_test(
+            protocol_client, lambda options: _type_mismatch_subscription_status_listener(options)))
 
     def test_create_stream_failure_subscription_status_listener_type_mismatch5(self):
-        self._do_mqtt5_test(lambda protocol_client: self._do_create_stream_failure_test(
+        test_retry_wrapper(self._test_create_stream_failure_subscription_status_listener_type_mismatch5)
+
+    def _test_create_stream_failure_subscription_status_listener_type_mismatch311(self):
+        self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
             protocol_client, lambda options: _type_mismatch_subscription_status_listener(options)))
 
     def test_create_stream_failure_subscription_status_listener_type_mismatch311(self):
-        self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
-            protocol_client, lambda options: _type_mismatch_subscription_status_listener(options)))
+        test_retry_wrapper(self._test_create_stream_failure_subscription_status_listener_type_mismatch311)
 
-    def test_create_stream_failure_incoming_publish_listener_type_mismatch5(self):
+    def _test_create_stream_failure_incoming_publish_listener_type_mismatch5(self):
         self._do_mqtt5_test(lambda protocol_client: self._do_create_stream_failure_test(
             protocol_client, lambda options: _type_mismatch_incoming_publish_listener(options)))
 
-    def test_create_stream_failure_incoming_publish_listener_type_mismatch311(self):
+    def test_create_stream_failure_incoming_publish_listener_type_mismatch5(self):
+        test_retry_wrapper(self._test_create_stream_failure_incoming_publish_listener_type_mismatch5)
+
+    def _test_create_stream_failure_incoming_publish_listener_type_mismatch311(self):
         self._do_mqtt311_test(lambda protocol_client: self._do_create_stream_failure_test(
             protocol_client, lambda options: _type_mismatch_incoming_publish_listener(options)))
+
+    def test_create_stream_failure_incoming_publish_listener_type_mismatch311(self):
+        test_retry_wrapper(self._test_create_stream_failure_incoming_publish_listener_type_mismatch311)
 
 
 if __name__ == 'main':

--- a/test/test_mqtt_request_response.py
+++ b/test/test_mqtt_request_response.py
@@ -44,7 +44,10 @@ class MqttRequestResponse5TestCallbacks():
 
     def on_lifecycle_connection_success(self, lifecycle_connection_success: mqtt5.LifecycleConnectSuccessData):
         if self.future_connection_success:
-            self.future_connection_success.set_result(lifecycle_connection_success)
+            if self.future_connection_success.done():
+                pass
+            else:
+                self.future_connection_success.set_result(lifecycle_connection_success)
 
     def on_lifecycle_connection_failure(self, lifecycle_connection_failure: mqtt5.LifecycleConnectFailureData):
         if self.future_connection_success:


### PR DESCRIPTION
* Adds retry wrapper around all MQTT tests that require connectivity.  Socket and TLS negotiation timeouts are retried.
* Fixes a few tests that appear to be using the wrong helper function (will correlation data)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
