### PR TITLE
Add aio package __init__.py and fix __all__ export

### DIFF
--- a/awscrt/__init__.py
+++ b/awscrt/__init__.py
@@ -4,10 +4,10 @@
 from weakref import WeakSet
 
 __all__ = [
+    'aio',
     'auth',
     'crypto',
     'http',
-    'aio.http',
     'io',
     'mqtt',
     'mqtt5',

--- a/awscrt/aio/__init__.py
+++ b/awscrt/aio/__init__.py
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+__all__ = ['http']


### PR DESCRIPTION
## Summary

The `aio` module was added in https://github.com/awslabs/aws-crt-python/pull/658. This PR resolves the two following problems that exist after this PR:

1. There was no `__init__.py` file included under the `aio` module. As a result, `setuptools.find_packages` doesn't recognize it as a module and it doesn't get included when building the source and binary distributions for the `awscrt`.
2. `from awscrt import *` is now broken since `aio.http` is included in the `__all__` list in the top-level `__init__.py` file. This PR changes the list entry from `aio.http` to `aio`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
