### PR TITLE
Fix Test Memleak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,3 @@ jobs:
       # note: using "@main" because "@${{env.BUILDER_VERSION}}" doesn't work
       # https://github.com/actions/runner/issues/480
       uses: awslabs/aws-crt-builder/.github/actions/check-submodules@main
-
-      #kick
-      


### PR DESCRIPTION
The `test_retry_wrapper` was skipping the `tearDown` part of a `unittest.TestCase` of a failed test and spinning up the failing test again immediately which could potentially succeed faster than the previous attempt had time to cleanup after it threw an exception. This could cause the retried test to fail its memory check despite the test itself being successful.

We add a `check_for_leaks` before running a retry which gives the previous failed test the normal TIMEOUT period to clean up its resources before moving onto the next attempt.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
