### PR TITLE
Checks if futures are done in AIOHttpClientStreamUnified to avoid race condition

### DIFF
--- a/awscrt/aio/http.py
+++ b/awscrt/aio/http.py
@@ -295,7 +295,8 @@ class AIOHttpClientStreamUnified(HttpClientStreamBase):
         """Process body chunk on the correct event loop thread."""
         if self._chunk_futures:
             future = self._chunk_futures.popleft()
-            future.set_result(chunk)
+            if not future.done():
+                future.set_result(chunk)
         else:
             self._received_chunks.append(chunk)
 
@@ -309,7 +310,8 @@ class AIOHttpClientStreamUnified(HttpClientStreamBase):
         # Resolve all pending chunk futures with an empty string to indicate end of stream
         while self._chunk_futures:
             future = self._chunk_futures.popleft()
-            future.set_result("")
+            if not future.done():
+                future.set_result("")
 
     async def _set_request_body_generator(self, body_iterator: AsyncIterator[bytes]):
         ...


### PR DESCRIPTION

*Issue #, if available:*
In Python libraries like https://github.com/awslabs/aws-sdk-python/tree/develop/clients/aws-sdk-transcribe-streaming and https://github.com/awslabs/amazon-transcribe-streaming-sdk where awscrt is used, a few people, me included notice an issue where futures that are already done (cancelled) are being set so an InvalidStateError is raised.
Examples: https://github.com/awslabs/amazon-transcribe-streaming-sdk/issues/61 and https://github.com/awslabs/aws-sdk-python/issues/13

*Description of changes:*
Just checking if future is not done before setting the result.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
