### PR TITLE
Min or higher Windows SDK Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,32 @@ jobs:
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "${{ steps.python38.outputs.python-path }}"
 
+  windows-latest:
+    # try latest version to see if it works with a later version of Windows SDK
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x64]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    steps:
+      - uses: actions/setup-python@v5
+        id: python38
+        with:
+          python-version: '3.8.10'
+          architecture: ${{ matrix.arch }}
+      - uses: ilammy/setup-nasm@v1
+      - name: configure AWS credentials (containers)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        run: |
+          python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --python "${{ steps.python38.outputs.python-path }}"
+
   macos:
     runs-on: macos-14 # latest
     permissions:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ FREE_THREADED_BUILD = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
 # TLS_PARAMETERS. These are required to build Windows Binaries with TLS 1.3 support.
 WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT = "10.0.17763.0"
 
+# Regex to match a Windows SDK version directory name in the format of major.minor.build.revision
+SDK_VERSION_RE = re.compile(r'^(\d+)\.(\d+)\.(\d+)\.(\d+)$')
+
 
 def parse_version(version_string):
     return tuple(int(x) for x in version_string.split("."))
@@ -123,8 +126,8 @@ def get_windows_sdk_versions():
         if os.path.exists(sdk_path):
             try:
                 for entry in os.listdir(sdk_path):
-                    # SDK version directories look like "10.0.17763.0"
-                    if entry.startswith('10.0.') and os.path.isdir(os.path.join(sdk_path, entry)):
+                    # SDK version directories look like "major.minor.build.revision" (e.g. "10.0.17763.0")
+                    if SDK_VERSION_RE.match(entry) and os.path.isdir(os.path.join(sdk_path, entry)):
                         if entry not in sdk_versions:
                             sdk_versions.append(entry)
             except OSError:

--- a/setup.py
+++ b/setup.py
@@ -144,20 +144,19 @@ def get_best_windows_sdk_version():
     Returns the latest installed SDK version that is >= WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT.
     Raises RuntimeError if no suitable SDK is found.
     """
-    min_version = parse_version(WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT)
     installed_versions = get_windows_sdk_versions()
 
-    for version in installed_versions:
-        if parse_version(version) >= min_version:
+    if installed_versions:
+        # We only need to check against the newest available version.
+        if parse_version(installed_versions[0]) >= parse_version(WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT):
+            version = installed_versions[0]
             print(f"Found Windows SDK {version} (>= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} required for TLS 1.3)")
             return version
-
-    # No suitable SDK found
-    if installed_versions:
-        raise RuntimeError(
-            f"No Windows SDK >= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} found. "
-            f"Installed versions: {', '.join(installed_versions)}. "
-            f"Please install Windows SDK {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} or later for TLS 1.3 support.")
+        else:
+            raise RuntimeError(
+                f"No Windows SDK >= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} found. "
+                f"Installed versions: {', '.join(installed_versions)}. "
+                f"Please install Windows SDK {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} or later for TLS 1.3 support.")
     else:
         raise RuntimeError(
             f"No Windows SDK found. "

--- a/setup.py
+++ b/setup.py
@@ -89,18 +89,32 @@ def determine_cross_compile_args():
 
 
 def get_windows_sdk_versions():
-    """Return a list of installed Windows SDK versions, sorted from newest to oldest."""
+    """Return a list of installed Windows SDK versions, sorted from newest to oldest.
+
+    Uses the Windows registry to find the SDK installation path.
+    """
     if sys.platform != 'win32':
         return []
 
+    import winreg
+
     sdk_versions = []
-    # Windows SDK is typically installed in these locations
-    sdk_paths = [
-        os.path.join(os.environ.get('ProgramFiles(x86)', 'C:\\Program Files (x86)'),
-                     'Windows Kits', '10', 'Include'),
-        os.path.join(os.environ.get('ProgramFiles', 'C:\\Program Files'),
-                     'Windows Kits', '10', 'Include'),
-    ]
+    sdk_paths = []
+
+    # Try to get SDK path from registry
+    try:
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                            r"SOFTWARE\Microsoft\Windows Kits\Installed Roots") as key:
+            sdk_root = winreg.QueryValueEx(key, "KitsRoot10")[0]
+            sdk_paths.append(os.path.join(sdk_root, "Include"))
+    except (OSError, FileNotFoundError):
+        # Registry key not found, fall back to common installation paths
+        sdk_paths = [
+            os.path.join(os.environ.get('ProgramFiles(x86)', 'C:\\Program Files (x86)'),
+                         'Windows Kits', '10', 'Include'),
+            os.path.join(os.environ.get('ProgramFiles', 'C:\\Program Files'),
+                         'Windows Kits', '10', 'Include'),
+        ]
 
     for sdk_path in sdk_paths:
         if os.path.exists(sdk_path):
@@ -122,7 +136,7 @@ def get_best_windows_sdk_version():
     """Return the best Windows SDK version to use for TLS 1.3 support.
 
     Returns the latest installed SDK version that is >= WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT.
-    If no suitable SDK is found, returns the minimum required version (build may fail if not installed).
+    Raises RuntimeError if no suitable SDK is found.
     """
     min_version = parse_version(WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT)
     installed_versions = get_windows_sdk_versions()
@@ -132,11 +146,16 @@ def get_best_windows_sdk_version():
             print(f"Found Windows SDK {version} (>= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} required for TLS 1.3)")
             return version
 
-    # No suitable SDK found, return minimum required version
-    # CMake will fail if this version is not installed
-    print(f"Warning: No Windows SDK >= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} found. "
-          f"Using minimum required version. Build may fail if SDK is not installed.")
-    return WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT
+    # No suitable SDK found
+    if installed_versions:
+        raise RuntimeError(
+            f"No Windows SDK >= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} found. "
+            f"Installed versions: {', '.join(installed_versions)}. "
+            f"Please install Windows SDK {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} or later for TLS 1.3 support.")
+    else:
+        raise RuntimeError(
+            f"No Windows SDK found. "
+            f"Please install Windows SDK {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} or later for TLS 1.3 support.")
 
 
 def determine_generator_args(cmake_version=None, windows_sdk_version=None):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ MACOS_DEPLOYMENT_TARGET_MIN = "10.15"
 
 # This is the minimum version of the Windows SDK needed for schannel.h with SCH_CREDENTIALS and
 # TLS_PARAMETERS. These are required to build Windows Binaries with TLS 1.3 support.
-WINDOWS_SDK_VERSION_TLS1_3_SUPPORT = "10.0.17763.0"
+WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT = "10.0.17763.0"
 
 
 def parse_version(version_string):
@@ -86,6 +86,57 @@ def determine_cross_compile_args():
     if (host_arch == 'AMD64' or host_arch == 'x86_64') and is_32bit() and sys.platform != 'win32':
         return ['-DCMAKE_C_FLAGS=-m32']
     return []
+
+
+def get_windows_sdk_versions():
+    """Return a list of installed Windows SDK versions, sorted from newest to oldest."""
+    if sys.platform != 'win32':
+        return []
+
+    sdk_versions = []
+    # Windows SDK is typically installed in these locations
+    sdk_paths = [
+        os.path.join(os.environ.get('ProgramFiles(x86)', 'C:\\Program Files (x86)'),
+                     'Windows Kits', '10', 'Include'),
+        os.path.join(os.environ.get('ProgramFiles', 'C:\\Program Files'),
+                     'Windows Kits', '10', 'Include'),
+    ]
+
+    for sdk_path in sdk_paths:
+        if os.path.exists(sdk_path):
+            try:
+                for entry in os.listdir(sdk_path):
+                    # SDK version directories look like "10.0.17763.0"
+                    if entry.startswith('10.0.') and os.path.isdir(os.path.join(sdk_path, entry)):
+                        if entry not in sdk_versions:
+                            sdk_versions.append(entry)
+            except OSError:
+                continue
+
+    # Sort versions from newest to oldest
+    sdk_versions.sort(key=parse_version, reverse=True)
+    return sdk_versions
+
+
+def get_best_windows_sdk_version():
+    """Return the best Windows SDK version to use for TLS 1.3 support.
+
+    Returns the latest installed SDK version that is >= WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT.
+    If no suitable SDK is found, returns the minimum required version (build may fail if not installed).
+    """
+    min_version = parse_version(WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT)
+    installed_versions = get_windows_sdk_versions()
+
+    for version in installed_versions:
+        if parse_version(version) >= min_version:
+            print(f"Found Windows SDK {version} (>= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} required for TLS 1.3)")
+            return version
+
+    # No suitable SDK found, return minimum required version
+    # CMake will fail if this version is not installed
+    print(f"Warning: No Windows SDK >= {WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT} found. "
+          f"Using minimum required version. Build may fail if SDK is not installed.")
+    return WINDOWS_SDK_MIN_VERSION_TLS1_3_SUPPORT
 
 
 def determine_generator_args(cmake_version=None, windows_sdk_version=None):
@@ -272,7 +323,7 @@ class awscrt_build_ext(setuptools.command.build_ext.build_ext):
         if sys.platform == 'win32':
             windows_sdk_version = os.getenv('AWS_CRT_WINDOWS_SDK_VERSION')
             if windows_sdk_version is None:
-                windows_sdk_version = WINDOWS_SDK_VERSION_TLS1_3_SUPPORT
+                windows_sdk_version = get_best_windows_sdk_version()
 
             cmake_version = get_cmake_version()
 


### PR DESCRIPTION
setup.py will now try to find the min or higher version of Windows SDK and allow a later version than min to be used. If no versions are found it will fall back on the minimum version we require to allow TLS 1.3. This will allow later versions of Windows SDK to be used without needing to explicitly use `AWS_CRT_WINDOWS_SDK_VERSION` to use a different version than 10.0.17763.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
