### PR TITLE
Support s2n-tls on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.92
+  BUILDER_VERSION: v0.9.93
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-python
@@ -50,13 +50,11 @@ jobs:
           - x64
           - x86
         python:
-          - cp38-cp38
           - cp39-cp39
           - cp310-cp310
           - cp311-cp311
           - cp312-cp312
           - cp313-cp313
-          - cp313-cp313t
           - cp314-cp314
           - cp314-cp314t
     permissions:
@@ -78,13 +76,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - cp38-cp38
           - cp39-cp39
           - cp310-cp310
           - cp311-cp311
           - cp312-cp312
           - cp313-cp313
-          - cp313-cp313t
           - cp314-cp314
           - cp314-cp314t
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,42 @@ jobs:
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}
 
+  macos-s2n:
+    runs-on: macos-14 # latest
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    steps:
+      - name: configure AWS credentials (containers)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        run: |
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }}
+
+  macos-x64-s2n:
+    runs-on: macos-14-large # latest
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    steps:
+      - name: configure AWS credentials (containers)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        run: |
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }}
+
   openbsd:
     runs-on: ubuntu-24.04 # latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For an example, see `test.test_s3.py.S3RequestTest.test_fork_workaround` .
 
 ## macOS TLS Configuration
 
-By default on macOS, aws-crt-cpp uses Apple Secure Transport for TLS. This provides FIPS-compliant cryptography
+By default on macOS, aws-crt-python uses Apple Secure Transport for TLS. This provides FIPS-compliant cryptography
 and integration with the macOS Keychain (e.g. PKCS#12 credentials), but is limited to TLS 1.2.
 
 To enable TLS 1.3 on macOS, set the environment variable:
@@ -75,7 +75,7 @@ the environment variable selects which one is used.
 
 ### Keychain Behavior
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v0.8.10, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v0.6.2, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
 
 ```
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain. Using key from Keychain instead of the one provided.
@@ -135,7 +135,7 @@ You can enable the crash handler by setting the environment variable `AWS_CRT_CR
 
 aws-crt-python does not use OpenSSL for TLS.
 On Windows, the OS's default TLS library (Schannel) is used.
-On Apple (macOS), both Secure Transport and s2n-tls are compiled in; the backend is selected at runtime (see [macOS TLS Backend](#macos-tls-backend) below).
+On Apple (macOS), both Secure Transport and s2n-tls are compiled in; the backend is selected at runtime (see [macOS TLS Configuration](#macos-tls-configuration) below).
 On other Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
 But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,33 @@ If you **must** use fork with aws-crt-python, you may be able to avoid hangs and
 
 For an example, see `test.test_s3.py.S3RequestTest.test_fork_workaround` .
 
-## Mac-Only TLS Behavior
+## macOS TLS Configuration
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically. Beginning in v0.6.2, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+By default on macOS, aws-crt-cpp uses Apple Secure Transport for TLS. This provides FIPS-compliant cryptography
+and integration with the macOS Keychain (e.g. PKCS#12 credentials), but is limited to TLS 1.2.
+
+To enable TLS 1.3 on macOS, set the environment variable:
+
+```
+export AWS_CRT_USE_NON_FIPS_TLS_13=1
+```
+
+This switches the TLS backend from Apple Secure Transport to [s2n-tls](https://github.com/aws/s2n-tls) with
+[aws-lc](https://github.com/aws/aws-lc) as the underlying libcrypto. The tradeoffs are:
+
+| | Secure Transport (default) | s2n-tls (`AWS_CRT_USE_NON_FIPS_TLS_13=1`) |
+|---|---|---|
+| TLS versions | Up to TLS 1.2 | Up to TLS 1.3 |
+| FIPS compliance | Yes | No |
+| macOS Keychain integration | Yes (PKCS#12, system certs) | No |
+
+This variable is checked at runtime and only affects macOS. It has no effect on Linux (which always uses s2n-tls)
+or Windows (which always uses Schannel). Both TLS backends are compiled into the binary when building on macOS;
+the environment variable selects which one is used.
+
+### Keychain Behavior
+
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v0.8.10, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
 
 ```
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain. Using key from Keychain instead of the one provided.
@@ -110,8 +134,9 @@ You can enable the crash handler by setting the environment variable `AWS_CRT_CR
 ### OpenSSL and LibCrypto
 
 aws-crt-python does not use OpenSSL for TLS.
-On Apple and Windows devices, the OS's default TLS library is used.
-On Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
+On Windows, the OS's default TLS library (Schannel) is used.
+On Apple (macOS), both Secure Transport and s2n-tls are compiled in; the backend is selected at runtime (see [macOS TLS Backend](#macos-tls-backend) below).
+On other Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
 But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
 
 To simplify installation, aws-crt-python has its own copy of libcrypto.

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -73,6 +73,9 @@ if (UNIX OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
 
 endif()
 
+# Build s2n-tls on all Unix platforms (Linux, BSD, macOS).
+# On macOS (Darwin), both Secure Transport and s2n are built; the TLS backend
+# is selected at runtime via the AWS_CRT_USE_NON_FIPS_TLS_13 environment variable.
 if(UNIX)
     # prebuild s2n-tls.
     aws_prebuild_dependency(
@@ -81,6 +84,10 @@ if(UNIX)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
+            # On Intel Macs, Homebrew installs to /usr/local, which is in the default
+            # system header search path. Without this flag, s2n picks up Homebrew's OpenSSL
+            # headers instead of the bundled aws-lc headers. Not needed on ARM where Homebrew
+            # uses /opt/homebrew (not in default search paths), but harmless to set everywhere.
             -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
     )
 endif()

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -32,9 +32,10 @@ option(AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE "Set this if you want to 
 string(REPLACE "-g" "-g1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-g" "-g1" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
-# On Unix we use S2N for TLS and AWS-LC crypto.
-# (On Windows and Apple we use the default OS libraries)
-if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
+# On Linux and BSD, we use S2N for TLS and AWS-LC crypto.
+# On Windows, we use the default OS libraries.
+# On Apple, we use the default OS libraries by default, but support S2N usage.
+if (UNIX OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
     option(USE_OPENSSL "Set this if you want to use your system's OpenSSL compatible libcrypto" OFF)
     include(AwsPrebuildDependency)
 
@@ -48,7 +49,7 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
             -DCMAKE_BUILD_TYPE=RelWithDebInfo  # Use the same build type as the rest of the project
         )
 
-        if (APPLE OR WIN32)
+        if (WIN32)
             # Libcrypto implementations typically have several chunky pregenerated tables that add a lot
             # to artifact size. We dont really need them for ed25519 case on win/mac, so favor
             # smaller binary over perf here.
@@ -72,7 +73,7 @@ if ((UNIX AND NOT APPLE) OR AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
 
 endif()
 
-if(UNIX AND NOT APPLE)
+if(UNIX)
     # prebuild s2n-tls.
     aws_prebuild_dependency(
         DEPENDENCY_NAME S2N
@@ -80,6 +81,7 @@ if(UNIX AND NOT APPLE)
         CMAKE_ARGUMENTS
             -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
             -DBUILD_TESTING=OFF
+            -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
     )
 endif()
 

--- a/setup.py
+++ b/setup.py
@@ -593,6 +593,17 @@ def awscrt_ext():
             if not is_macos_universal2():
                 if sys.platform == 'darwin':
                     extra_link_args += ['-Wl,-fatal_warnings']
+                    # xcode 15 introduced a new linker that generates a warning
+                    # when it sees duplicate libs or rpath during bundling.
+                    # pyenv installed from homebrew put duplicate rpath entries
+                    # into sysconfig, and setuptools happily passes them along
+                    # to xcode, resulting in a warning
+                    # (which is fatal in this branch).
+                    # ex. https://github.com/pyenv/pyenv/issues/2890
+                    # lets revert back to old linker on xcode >= 15 until one of
+                    # the involved parties fixes the issue.
+                    if get_xcode_major_version() >= 15:
+                        extra_link_args += ['-Wl,-ld_classic']
                 elif 'bsd' in sys.platform:
                     extra_link_args += ['-Wl,-fatal-warnings']
                 else:

--- a/setup.py
+++ b/setup.py
@@ -301,7 +301,7 @@ if using_libcrypto():
     # aws-lc produces libcrypto.a
     AWS_LIBS.append(AwsLib('aws-lc', libname='crypto'))
 
-if sys.platform != 'darwin' and sys.platform != 'win32':
+if sys.platform != 'win32':
     AWS_LIBS.append(AwsLib('s2n'))
 
 AWS_LIBS.append(AwsLib('aws-c-common'))
@@ -593,17 +593,6 @@ def awscrt_ext():
             if not is_macos_universal2():
                 if sys.platform == 'darwin':
                     extra_link_args += ['-Wl,-fatal_warnings']
-                    # xcode 15 introduced a new linker that generates a warning
-                    # when it sees duplicate libs or rpath during bundling.
-                    # pyenv installed from homebrew put duplicate rpath entries
-                    # into sysconfig, and setuptools happily passes them along
-                    # to xcode, resulting in a warning
-                    # (which is fatal in this branch).
-                    # ex. https://github.com/pyenv/pyenv/issues/2890
-                    # lets revert back to old linker on xcode >= 15 until one of
-                    # the involved parties fixes the issue.
-                    if get_xcode_major_version() >= 15:
-                        extra_link_args += ['-Wl,-ld_classic']
                 elif 'bsd' in sys.platform:
                     extra_link_args += ['-Wl,-fatal-warnings']
                 else:

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -5,6 +5,7 @@ from concurrent.futures import Future
 from awscrt import mqtt5, io, http, exceptions
 from test import test_retry_wrapper, NativeResourceTest
 import os
+import sys
 import unittest
 import uuid
 import time
@@ -302,6 +303,38 @@ class Mqtt5ClientTest(NativeResourceTest):
 
     def test_direct_connect_mutual_tls(self):
         test_retry_wrapper(self._test_direct_connect_mutual_tls)
+
+    def _test_direct_connect_mutual_tls13(self):
+        input_host_name = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_TLS13_HOST")
+        input_cert = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
+        input_key = _get_env_variable("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
+
+        client_options = mqtt5.ClientOptions(
+            host_name=input_host_name,
+            port=8883
+        )
+        tls_ctx_options = io.TlsContextOptions.create_client_with_mtls_from_path(
+            input_cert,
+            input_key
+        )
+        client_options.tls_ctx = io.ClientTlsContext(tls_ctx_options)
+
+        callbacks = Mqtt5TestCallbacks()
+        client = self._create_client(client_options=client_options, callbacks=callbacks)
+        client.start()
+
+        # On macOS with Secure Transport (the default), TLS 1.3 is not supported,
+        # so the connection to a TLS-1.3-only host must fail.
+        if sys.platform == 'darwin' and not os.environ.get('AWS_CRT_USE_NON_FIPS_TLS_13'):
+            callbacks.future_connection_failure.result(TIMEOUT)
+        else:
+            callbacks.future_connection_success.result(TIMEOUT)
+
+        client.stop()
+        callbacks.future_stopped.result(TIMEOUT)
+
+    def test_direct_connect_mutual_tls13(self):
+        test_retry_wrapper(self._test_direct_connect_mutual_tls13)
 
     def _test_direct_connect_http_proxy_tls(self):
         input_host_name = _get_env_variable("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST")

--- a/test/test_mqtt5_credentials.py
+++ b/test/test_mqtt5_credentials.py
@@ -130,6 +130,8 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    # When AWS_CRT_USE_NON_FIPS_TLS_13 is set, the TLS backend on macOS switches from
+    # Secure Transport to s2n-tls, which doesn't support PKCS#12.
     @unittest.skipIf(os.environ.get('AWS_CRT_USE_NON_FIPS_TLS_13'), "PKCS12 not supported with non-FIPS TLS 1.3")
     def test_mqtt5_cred_pkcs12(self):
         test_retry_wrapper(self._test_mqtt5_cred_pkcs12)

--- a/test/test_mqtt5_credentials.py
+++ b/test/test_mqtt5_credentials.py
@@ -130,6 +130,7 @@ class MqttConnectionTest(NativeResourceTest):
         client.stop()
         callbacks.future_stopped.result(TIMEOUT)
 
+    @unittest.skipIf(os.environ.get('AWS_CRT_USE_NON_FIPS_TLS_13'), "PKCS12 not supported with non-FIPS TLS 1.3")
     def test_mqtt5_cred_pkcs12(self):
         test_retry_wrapper(self._test_mqtt5_cred_pkcs12)
 

--- a/test/test_mqtt_credentials.py
+++ b/test/test_mqtt_credentials.py
@@ -46,6 +46,7 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
+    @unittest.skipIf(os.environ.get('AWS_CRT_USE_NON_FIPS_TLS_13'), "PKCS12 not supported with non-FIPS TLS 1.3")
     def test_mqtt311_cred_pkcs12(self):
         test_retry_wrapper(self._test_mqtt311_cred_pkcs12)
 

--- a/test/test_mqtt_credentials.py
+++ b/test/test_mqtt_credentials.py
@@ -46,6 +46,8 @@ class MqttConnectionTest(NativeResourceTest):
         connection.connect().result(TIMEOUT)
         connection.disconnect().result(TIMEOUT)
 
+    # When AWS_CRT_USE_NON_FIPS_TLS_13 is set, the TLS backend on macOS switches from
+    # Secure Transport to s2n-tls, which doesn't support PKCS#12.
     @unittest.skipIf(os.environ.get('AWS_CRT_USE_NON_FIPS_TLS_13'), "PKCS12 not supported with non-FIPS TLS 1.3")
     def test_mqtt311_cred_pkcs12(self):
         test_retry_wrapper(self._test_mqtt311_cred_pkcs12)


### PR DESCRIPTION
Add support for s2n-tls as a TLS backend on macOS.
Apple Secure Transport remains the default for FIPS compliance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
