### PR TITLE
Drop python 3.8 and 3.13t in manylinux2014

### DIFF
--- a/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
@@ -19,6 +19,7 @@ auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp311*.whl
 /opt/python/cp313-cp313/bin/python -m build
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp313*.whl
 
+# The free-threaded build does not currently support the Limited C API or the stable ABI. Built them separately
 /opt/python/cp314-cp314t/bin/python -m build
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp314t*.whl
 

--- a/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-aarch64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp38-cp38/bin/python -m build
-auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp38*.whl
-
 /opt/python/cp39-cp39/bin/python -m build
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp39*.whl
 
@@ -22,9 +19,6 @@ auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp311*.whl
 /opt/python/cp313-cp313/bin/python -m build
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp313*.whl
 
-# The free-threaded build does not currently support the Limited C API or the stable ABI. Built them separately
-/opt/python/cp313-cp313t/bin/python -m build
-auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp313t*.whl
 /opt/python/cp314-cp314t/bin/python -m build
 auditwheel repair --plat manylinux2014_aarch64 dist/awscrt-*cp314t*.whl
 

--- a/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
+++ b/continuous-delivery/build-wheels-manylinux2014-x86_64.sh
@@ -4,9 +4,6 @@ set -ex
 
 /opt/python/cp39-cp39/bin/python ./continuous-delivery/update-version.py
 
-/opt/python/cp38-cp38/bin/python -m build
-auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp38*.whl
-
 /opt/python/cp39-cp39/bin/python -m build
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp39*.whl
 
@@ -23,8 +20,6 @@ auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp311*.whl
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp313*.whl
 
 # The free-threaded build does not currently support the Limited C API or the stable ABI. Built them separately
-/opt/python/cp313-cp313t/bin/python -m build
-auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp313t*.whl
 /opt/python/cp314-cp314t/bin/python -m build
 auditwheel repair --plat manylinux2014_x86_64 dist/awscrt-*cp314t*.whl
 


### PR DESCRIPTION
*Issue #, if available:*

CD pipeline is failing on trying to use python 3.8 in manylinux2014.

*Description of changes:*


CPython 3.8 and 3.13t was dropped in manylinux2014, see https://github.com/pypa/manylinux/issues/1882
Remove these version in our CD scripts.

Python 3.8 still remains the minimum supported version through manylinux1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
