### PR TITLE
noCertificateRevocation option binding

### DIFF
--- a/awscrt/io.py
+++ b/awscrt/io.py
@@ -309,6 +309,12 @@ class TlsContextOptions:
             System defaults are used by default.
         cipher_pref (TlsCipherPref): The TLS Cipher Preference to use. System defaults are used by default.
         verify_peer (bool): Whether to validate the peer's x.509 certificate.
+        no_certificate_revocation (bool): Set to true to disable certificate revocation checking during TLS negotiation.
+            On Windows (SChannel), this prevents the TLS handshake from making outbound network calls
+            to CRL/OCSP revocation endpoints, which can block for minutes when the endpoints are unreachable
+            (e.g., in private subnets without internet access).
+            On Linux (s2n), this disables validation of OCSP stapled responses provided by the server.
+            On Apple platforms, this is a no-op as revocation checking is not enabled by default.
         alpn_list (Optional[List[str]]): If set, names to use in Application Layer
             Protocol Negotiation (ALPN). ALPN is not supported on all systems,
             see :meth:`is_alpn_available()`. This can be customized per connection,
@@ -325,6 +331,7 @@ class TlsContextOptions:
         'pkcs12_filepath',
         'pkcs12_password',
         'verify_peer',
+        'no_certificate_revocation',
         '_pkcs11_lib',
         '_pkcs11_user_pin',
         '_pkcs11_slot_id',
@@ -343,6 +350,7 @@ class TlsContextOptions:
         self.min_tls_ver = TlsVersion.DEFAULT
         self.cipher_pref = TlsCipherPref.DEFAULT
         self.verify_peer = True
+        self.no_certificate_revocation = False
 
     @staticmethod
     def create_client_with_mtls_from_path(cert_filepath, pk_filepath):
@@ -627,6 +635,7 @@ class ClientTlsContext(NativeResource):
             options.pkcs12_filepath,
             options.pkcs12_password,
             options.verify_peer,
+            options.no_certificate_revocation,
             options._pkcs11_lib,
             options._pkcs11_user_pin,
             options._pkcs11_slot_id,

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ def determine_generator_args(cmake_version=None, windows_sdk_version=None):
             # This technique may not work with customized VS install paths.
             # An alternative would be to utilize private python calls:
             # (distutils._msvccompiler._find_vc2017() and _find_vc2015()).
-            if '\\Microsoft Visual Studio\\2026' in compiler.cc:
+            if '\\Microsoft Visual Studio\\18' in compiler.cc:
                 vs_version = 18
                 vs_year = 2026
             elif '\\Microsoft Visual Studio\\2022' in compiler.cc:
@@ -189,23 +189,6 @@ def determine_generator_args(cmake_version=None, windows_sdk_version=None):
             elif '\\Microsoft Visual Studio 14.0' in compiler.cc:
                 vs_version = 14
                 vs_year = 2015
-            else:
-                # Fallback: use vswhere.exe when distutils can't detect the VS version
-                # (e.g. Python 3.8 distutils doesn't know about VS2026)
-                import subprocess
-                vswhere = os.path.join(
-                    os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
-                    'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
-                if os.path.exists(vswhere):
-                    result = subprocess.run(
-                        [vswhere, '-latest', '-property', 'installationVersion'],
-                        capture_output=True, text=True)
-                    if result.returncode == 0 and result.stdout.strip():
-                        major = int(result.stdout.strip().split('.')[0])
-                        # VS major version -> marketing year mapping
-                        major_to_year = {14: 2015, 15: 2017, 16: 2019, 17: 2022, 18: 2026}
-                        vs_version = major
-                        vs_year = major_to_year.get(major, 2022 + (major - 17) * 3)
             assert (vs_version and vs_year)
         except Exception:
             raise RuntimeError('No supported version of MSVC compiler could be found!')

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,23 @@ def determine_generator_args(cmake_version=None, windows_sdk_version=None):
             elif '\\Microsoft Visual Studio 14.0' in compiler.cc:
                 vs_version = 14
                 vs_year = 2015
+            else:
+                # Fallback: use vswhere.exe when distutils can't detect the VS version
+                # (e.g. Python 3.8 distutils doesn't know about VS2026)
+                import subprocess
+                vswhere = os.path.join(
+                    os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
+                    'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+                if os.path.exists(vswhere):
+                    result = subprocess.run(
+                        [vswhere, '-latest', '-property', 'installationVersion'],
+                        capture_output=True, text=True)
+                    if result.returncode == 0 and result.stdout.strip():
+                        major = int(result.stdout.strip().split('.')[0])
+                        # VS major version -> marketing year mapping
+                        major_to_year = {14: 2015, 15: 2017, 16: 2019, 17: 2022, 18: 2026}
+                        vs_version = major
+                        vs_year = major_to_year.get(major, 2022 + (major - 17) * 3)
             assert (vs_version and vs_year)
         except Exception:
             raise RuntimeError('No supported version of MSVC compiler could be found!')

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,10 @@ def determine_generator_args(cmake_version=None, windows_sdk_version=None):
             # This technique may not work with customized VS install paths.
             # An alternative would be to utilize private python calls:
             # (distutils._msvccompiler._find_vc2017() and _find_vc2015()).
-            if '\\Microsoft Visual Studio\\2022' in compiler.cc:
+            if '\\Microsoft Visual Studio\\2026' in compiler.cc:
+                vs_version = 18
+                vs_year = 2026
+            elif '\\Microsoft Visual Studio\\2022' in compiler.cc:
                 vs_version = 17
                 vs_year = 2022
             elif '\\Microsoft Visual Studio\\2019' in compiler.cc:

--- a/source/io.c
+++ b/source/io.c
@@ -426,8 +426,8 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
     Py_ssize_t private_key_buffer_len;
     const char *pkcs12_filepath;
     const char *pkcs12_password;
-    int verify_peer; /* p - boolean predicate */
-    int no_certificate_revocation; /* p - boolean predicate */
+    int verify_peer;
+    int no_certificate_revocation;
     PyObject *py_pkcs11_lib;
     const char *pkcs11_user_pin;
     Py_ssize_t pkcs11_user_pin_len;

--- a/source/io.c
+++ b/source/io.c
@@ -427,6 +427,7 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
     const char *pkcs12_filepath;
     const char *pkcs12_password;
     int verify_peer; /* p - boolean predicate */
+    int no_certificate_revocation; /* p - boolean predicate */
     PyObject *py_pkcs11_lib;
     const char *pkcs11_user_pin;
     Py_ssize_t pkcs11_user_pin_len;
@@ -443,7 +444,7 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "iizz#zz#z#zzpOz#Oz#z#z#z#z",
+            "iizz#zz#z#zzppOz#Oz#z#z#z#z",
             /* i */ &min_tls_version,
             /* i */ &cipher_pref,
             /* z */ &ca_dirpath,
@@ -457,6 +458,7 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
             /* z */ &pkcs12_filepath,
             /* z */ &pkcs12_password,
             /* p */ &verify_peer,
+            /* p */ &no_certificate_revocation,
             /* O */ &py_pkcs11_lib,
             /* z */ &pkcs11_user_pin,
             /* # */ &pkcs11_user_pin_len,
@@ -560,6 +562,8 @@ PyObject *aws_py_client_tls_ctx_new(PyObject *self, PyObject *args) {
     }
 
     ctx_options.verify_peer = (bool)verify_peer;
+    ctx_options.no_certificate_revocation = (bool)no_certificate_revocation;
+
     struct aws_tls_ctx *tls_ctx = aws_tls_client_ctx_new(allocator, &ctx_options);
     if (!tls_ctx) {
         PyErr_SetAwsLastError();


### PR DESCRIPTION
Bind the tls option to disable certificate revocation checks.

update setup.py to check for MSVS 2026 in the new directory format MS is using. i.e. version number `18` instead of  year `2026`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
