### PR TITLE
adding tls_cipher Pref

### DIFF
--- a/awscrt/aws_iot_metrics.py
+++ b/awscrt/aws_iot_metrics.py
@@ -207,14 +207,16 @@ def _minimum_tls_version_metrics_value(version):
 def _tls_cipher_preference_metrics_value(pref):
     """Map TlsCipherPref to its single-character metrics value.
 
-    Mapping: PQ_TLSv1_0_2021_05->A, PQ_DEFAULT->B, TLSv1_2_2025_07->C.
-    Returns None for DEFAULT.
+    Mapping: PQ_TLSv1_0_2021_05->F, PQ_DEFAULT->H, TLSv1_2_2025_07->I.
+    Letters A-E, G, J, K are reserved for cipher preferences exposed by
+    other language SDKs but not by Python.
+    Returns None for DEFAULT or any unrecognized value.
     """
     from awscrt.io import TlsCipherPref
     mapping = {
-        TlsCipherPref.PQ_TLSv1_0_2021_05: "A",
-        TlsCipherPref.PQ_DEFAULT: "B",
-        TlsCipherPref.TLSv1_2_2025_07: "C",
+        TlsCipherPref.PQ_TLSv1_0_2021_05: "F",
+        TlsCipherPref.PQ_DEFAULT: "H",
+        TlsCipherPref.TLSv1_2_2025_07: "I",
     }
     return mapping.get(pref)
 

--- a/test/test_aws_iot_metrics.py
+++ b/test/test_aws_iot_metrics.py
@@ -113,7 +113,7 @@ class TestOptionsWithMultipleNonDefaultFeaturesEncoding(NativeResourceTest):
         self.assertIn("H/A", result)  # HTTP proxy (no TLS on proxy)
         self.assertIn("K/D", result)  # TLSv1_2
         if cipher_pref.is_supported():
-            self.assertIn("J/B", result)  # PQ_DEFAULT
+            self.assertIn("J/H", result)  # PQ_DEFAULT
 
     def test_alternate_values(self):
         """MQTT5 with alternate non-default values."""
@@ -155,7 +155,7 @@ class TestOptionsWithMultipleNonDefaultFeaturesEncoding(NativeResourceTest):
         self.assertIn("H/B", result)  # HTTPS proxy
         self.assertIn("K/E", result)  # TLSv1_3
         if cipher_pref.is_supported():
-            self.assertIn("J/A", result)  # PQ_TLSv1_0_2021_05
+            self.assertIn("J/F", result)  # PQ_TLSv1_0_2021_05
 
     def test_mqtt3_with_proxy_and_tls(self):
         """MQTT3 with HTTPS proxy and TLS context."""
@@ -178,7 +178,7 @@ class TestOptionsWithMultipleNonDefaultFeaturesEncoding(NativeResourceTest):
         self.assertIn("H/B", result)  # HTTPS
         self.assertIn("K/D", result)  # TLSv1_2
         if cipher_pref.is_supported():
-            self.assertIn("J/C", result)  # TLSv1_2_2025_07
+            self.assertIn("J/I", result)  # TLSv1_2_2025_07
 
 
 class TestMergeFeatureLists(NativeResourceTest):


### PR DESCRIPTION
*Description of changes:*
- Making Tls_cipher_preference encoding consistent across all SDKs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
