### PR TITLE
Update deprecated OpenBSD CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
       fail-fast: false
       matrix:
         # OpenBSD only supports the two most recent releases
-        version: ['7.4', '7.5']
+        version: ['7.8', '7.9']
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
@@ -396,7 +396,7 @@ jobs:
         with:
           submodules: true
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: openbsd
           version: ${{ matrix.version }}
@@ -424,7 +424,7 @@ jobs:
           submodules: true
 
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
-        uses: cross-platform-actions/action@v0.23.0
+        uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: freebsd
           version: '14.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
           shell: bash
           environment_variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
           run: |
-            sudo pkg_add awscli py3-pip py3-urllib3
+            sudo pkg_add awscli%v2 py3-pip py3-urllib3
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
             ./builder build -p ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
*Issue #, if available:*
OpenBSD 7.4 and 7.5 are deprecated, 7.4 packages were removed from mirrors.

*Description of changes:*
- Use two latest OpenBSD versions: 7.8 and 7.9
- Update cross-platform-actions/action to v1.3.0 (both OpenBSD and FreeBSD jobs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
