### PR TITLE
Fix NASM failure against aws-lc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
         with:
-          version: '2.16.03'
+          version: '3.02rc7'
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -301,7 +301,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
         with:
-          version: '2.16.03'
+          version: '3.02rc7'
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
           python-version: '3.8.10'
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
+        with:
+          version: '2.16.03'
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -298,6 +300,8 @@ jobs:
           python-version: '3.8.10'
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
+        with:
+          version: '2.16.03'
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
         with:
-          version: '3.02rc7'
+          version: '3.02rc8'
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -301,7 +301,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: ilammy/setup-nasm@v1
         with:
-          version: '3.02rc7'
+          version: '3.02rc8'
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
*Issue #, if available:*
nasm's Codeview debug-info backend (output/codeview.c) panics when it's asked to emit debug tables (-g flag, which the failing CI command uses) for an object with no code section — which is exactly what [aesni-xts-avx512.asm](https://github.com/aws/aws-lc/blob/main/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm) produces on win64 when MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX is defined.

This issue was observed since https://github.com/aws/aws-lc/pull/3319 which optimizes avx512 out when OPENSSL_SMALL is set (which we do by default).

*Description of changes:*
Bumped to the oldest version that actually fixes this issue. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
